### PR TITLE
Fix search hooks and use images from URL's

### DIFF
--- a/client/components/devtools.js
+++ b/client/components/devtools.js
@@ -25,6 +25,16 @@ class DevTools extends Component {
     });
   }
 
+  handleImagesFromWebClick = () => {
+    Meteor.call("devtools/loaddata/images", "web", (error) => {
+      if (error) {
+        Alerts.toast(`Error loading images ${error.reason}`, "error");
+      } else {
+        Alerts.toast("Images loaded successfully", "success");
+      }
+    });
+  }
+
   handleSeedDataClick = () => {
     Meteor.call("devtools/loaddata/small/products", (error) => {
       if (error) {
@@ -102,7 +112,7 @@ class DevTools extends Component {
         </SettingsCard>
 
         <SettingsCard
-          title={"Small shop data"}
+          title={"Small shop data (10 products, 100 orders"}
           expanded={true}
           showSwitch={false}
         >
@@ -127,6 +137,15 @@ class DevTools extends Component {
             primary={true}
             label={"Load Images"}
             onClick={this.handleImagesClick}
+          />
+
+          <br />
+          <br />
+          <Button
+            bezelStyle={"solid"}
+            primary={true}
+            label={"Load Puppy Images"}
+            onClick={this.handleImagesFromWebClick}
           />
         </SettingsCard>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -217,6 +217,11 @@
       "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
       "dev": true
     },
+    "capture-stack-trace": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
+      "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0="
+    },
     "chalk": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
@@ -337,6 +342,14 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
+    "create-error-class": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
+      "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
+      "requires": {
+        "capture-stack-trace": "1.0.0"
+      }
+    },
     "cross-spawn": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
@@ -402,6 +415,11 @@
       "requires": {
         "esutils": "2.0.2"
       }
+    },
+    "duplexer3": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
     },
     "emoji-regex": {
       "version": "6.5.1",
@@ -673,6 +691,11 @@
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
+    "eventemitter3": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz",
+      "integrity": "sha1-HIaZHYFq0eUEdQ5zh0Ik7PO+xQg="
+    },
     "external-editor": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.1.0.tgz",
@@ -782,6 +805,11 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
+    "get-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+    },
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
@@ -814,6 +842,24 @@
         "object-assign": "4.1.1",
         "pify": "2.3.0",
         "pinkie-promise": "2.0.1"
+      }
+    },
+    "got": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+      "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
+      "requires": {
+        "create-error-class": "3.0.2",
+        "duplexer3": "0.1.4",
+        "get-stream": "3.0.0",
+        "is-redirect": "1.0.0",
+        "is-retry-allowed": "1.1.0",
+        "is-stream": "1.1.0",
+        "lowercase-keys": "1.0.0",
+        "safe-buffer": "5.1.1",
+        "timed-out": "4.0.1",
+        "unzip-response": "2.0.1",
+        "url-parse-lax": "1.0.0"
       }
     },
     "graceful-fs": {
@@ -971,6 +1017,11 @@
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
       "dev": true
     },
+    "is-redirect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
+      "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
+    },
     "is-regex": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
@@ -986,11 +1037,15 @@
       "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
       "dev": true
     },
+    "is-retry-allowed": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
+      "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ="
+    },
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-      "dev": true
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
     "is-symbol": {
       "version": "1.0.1",
@@ -1122,6 +1177,11 @@
       "requires": {
         "js-tokens": "3.0.2"
       }
+    },
+    "lowercase-keys": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
+      "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY="
     },
     "lru-cache": {
       "version": "4.1.1",
@@ -1364,6 +1424,11 @@
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
+    "prepend-http": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
+    },
     "process-nextick-args": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
@@ -1401,6 +1466,16 @@
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "dev": true
+    },
+    "random-puppy": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/random-puppy/-/random-puppy-1.1.0.tgz",
+      "integrity": "sha1-GtqjTA83bVArWdb9gifqYaRUmTs=",
+      "requires": {
+        "eventemitter3": "1.2.0",
+        "got": "6.7.1",
+        "unique-random-array": "1.0.0"
+      }
     },
     "read-pkg": {
       "version": "2.0.0",
@@ -1520,8 +1595,7 @@
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-      "dev": true
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
     },
     "semver": {
       "version": "5.5.0",
@@ -1672,6 +1746,11 @@
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
+    "timed-out": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+      "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
+    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -1701,6 +1780,32 @@
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
       "integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g==",
       "dev": true
+    },
+    "unique-random": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unique-random/-/unique-random-1.0.0.tgz",
+      "integrity": "sha1-zj4iTIJCzTOg53sNcYDXfmti0MQ="
+    },
+    "unique-random-array": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unique-random-array/-/unique-random-array-1.0.0.tgz",
+      "integrity": "sha1-QrNyHFeTiNi2Z8k8Lb3j1dgakTY=",
+      "requires": {
+        "unique-random": "1.0.0"
+      }
+    },
+    "unzip-response": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
+      "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c="
+    },
+    "url-parse-lax": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+      "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+      "requires": {
+        "prepend-http": "1.0.4"
+      }
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   },
   "dependencies": {
     "buffer-stream-reader": "^0.1.1",
-    "jpeg-js": "^0.3.3"
+    "jpeg-js": "^0.3.3",
+    "random-puppy": "^1.1.0"
   },
   "scripts": {
     "lint": "eslint ."

--- a/sample-data/data/small/Products.json
+++ b/sample-data/data/small/Products.json
@@ -28,9 +28,15 @@
 			"weight": 1
 		}
 	},
-  "hashtags": [
-    "hZdSevCBP8dDc66Ba"
-  ]
+	"hashtags": [
+		"hZdSevCBP8dDc66Ba"
+	],
+	"createdAt": {
+		"$date": "2018-03-16T06:55:07.123Z"
+	},
+	"updatedAt": {
+		"$date": "2018-03-16T06:55:07.123Z"
+	}
 },
 {
 	"_id": "PH8xNGE8pRHdPo8Qc",
@@ -58,6 +64,12 @@
 	"originCountry": "US",
 	"workflow": {
 		"status": "new"
+	},
+	"createdAt": {
+		"$date": "2018-03-16T06:55:07.132Z"
+	},
+	"updatedAt": {
+		"$date": "2018-03-16T06:55:07.132Z"
 	}
 },
 {
@@ -87,6 +99,12 @@
 	"originCountry": "US",
 	"workflow": {
 		"status": "new"
+	},
+	"createdAt": {
+		"$date": "2018-03-16T06:55:07.148Z"
+	},
+	"updatedAt": {
+		"$date": "2018-03-16T06:55:07.148Z"
 	}
 },
 {
@@ -116,6 +134,12 @@
 	"originCountry": "US",
 	"workflow": {
 		"status": "new"
+	},
+	"createdAt": {
+		"$date": "2018-03-16T06:55:07.168Z"
+	},
+	"updatedAt": {
+		"$date": "2018-03-16T06:55:07.168Z"
 	}
 },
 {
@@ -148,9 +172,15 @@
 			"weight": 1
 		}
 	},
-  "hashtags": [
-    "hZdSevCBP8dDc66Ba"
-  ]
+	"hashtags": [
+		"hZdSevCBP8dDc66Ba"
+	],
+	"createdAt": {
+		"$date": "2018-03-16T06:55:07.184Z"
+	},
+	"updatedAt": {
+		"$date": "2018-03-16T06:55:07.184Z"
+	}
 },
 {
 	"_id": "oWNyqhaeyw9eKdZKv",
@@ -178,6 +208,12 @@
 	"originCountry": "US",
 	"workflow": {
 		"status": "new"
+	},
+	"createdAt": {
+		"$date": "2018-03-16T06:55:07.193Z"
+	},
+	"updatedAt": {
+		"$date": "2018-03-16T06:55:07.193Z"
 	}
 },
 {
@@ -205,9 +241,15 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-  "hashtags": [
-    "hZdSevCBP8dDc66Ba"
-  ]
+	"hashtags": [
+		"hZdSevCBP8dDc66Ba"
+	],
+	"createdAt": {
+		"$date": "2018-03-16T06:55:07.206Z"
+	},
+	"updatedAt": {
+		"$date": "2018-03-16T06:55:07.206Z"
+	}
 },
 {
 	"_id": "zhXWhcsisSexE9bg8",
@@ -235,6 +277,12 @@
 	"originCountry": "US",
 	"workflow": {
 		"status": "new"
+	},
+	"createdAt": {
+		"$date": "2018-03-16T06:55:07.215Z"
+	},
+	"updatedAt": {
+		"$date": "2018-03-16T06:55:07.215Z"
 	}
 },
 {
@@ -262,9 +310,15 @@
 	"vendor": "Bookworks",
 	"description": "Need to make a quick note? Got a once-in-a-lifetime idea? Write it down in one of these great little notebooks",
 	"isBackorder": true,
-  "hashtags": [
-    "hZdSevCBP8dDc66Ba"
-  ]
+	"hashtags": [
+		"hZdSevCBP8dDc66Ba"
+	],
+	"createdAt": {
+		"$date": "2018-03-16T06:55:07.225Z"
+	},
+	"updatedAt": {
+		"$date": "2018-03-16T06:55:07.225Z"
+	}
 },
 {
 	"_id": "ddzkNjFJ3MjfkzvMg",
@@ -292,6 +346,12 @@
 	"originCountry": "US",
 	"workflow": {
 		"status": "new"
+	},
+	"createdAt": {
+		"$date": "2018-03-16T06:55:07.231Z"
+	},
+	"updatedAt": {
+		"$date": "2018-03-16T06:55:07.231Z"
 	}
 },
 {
@@ -321,7 +381,13 @@
 	"isBackorder": true,
 	"hashtags": [
 		"dhqmJjXWotCNkTzxg"
-	]
+	],
+	"createdAt": {
+		"$date": "2018-03-16T06:55:07.240Z"
+	},
+	"updatedAt": {
+		"$date": "2018-03-16T06:55:07.240Z"
+	}
 },
 {
 	"_id": "78zu2u3in4rNrWtKt",
@@ -349,6 +415,12 @@
 	"originCountry": "US",
 	"workflow": {
 		"status": "new"
+	},
+	"createdAt": {
+		"$date": "2018-03-16T06:55:07.247Z"
+	},
+	"updatedAt": {
+		"$date": "2018-03-16T06:55:07.247Z"
 	}
 },
 {
@@ -378,6 +450,12 @@
 	"originCountry": "US",
 	"workflow": {
 		"status": "new"
+	},
+	"createdAt": {
+		"$date": "2018-03-16T06:55:07.255Z"
+	},
+	"updatedAt": {
+		"$date": "2018-03-16T06:55:07.255Z"
 	}
 },
 {
@@ -407,6 +485,12 @@
 	"originCountry": "US",
 	"workflow": {
 		"status": "new"
+	},
+	"createdAt": {
+		"$date": "2018-03-16T06:55:07.261Z"
+	},
+	"updatedAt": {
+		"$date": "2018-03-16T06:55:07.261Z"
 	}
 },
 {
@@ -436,6 +520,12 @@
 	"originCountry": "US",
 	"workflow": {
 		"status": "new"
+	},
+	"createdAt": {
+		"$date": "2018-03-16T06:55:07.270Z"
+	},
+	"updatedAt": {
+		"$date": "2018-03-16T06:55:07.270Z"
 	}
 },
 {
@@ -465,6 +555,12 @@
 	"originCountry": "US",
 	"workflow": {
 		"status": "new"
+	},
+	"createdAt": {
+		"$date": "2018-03-16T06:55:07.281Z"
+	},
+	"updatedAt": {
+		"$date": "2018-03-16T06:55:07.281Z"
 	}
 },
 {
@@ -492,9 +588,15 @@
 	"description": "Get your Reaction together and show it to the world. 100% cotton fabric and double-stitching make this a shirt that will last for years to come",
 	"isBackorder": true,
 	"handle": "reaction-mens-shirt",
-  "hashtags": [
-    "dhqmJjXWotCNkTzxg"
-  ]
+	"hashtags": [
+		"dhqmJjXWotCNkTzxg"
+	],
+	"createdAt": {
+		"$date": "2018-03-16T06:55:07.299Z"
+	},
+	"updatedAt": {
+		"$date": "2018-03-16T06:55:07.299Z"
+	}
 },
 {
 	"_id": "cxYA8s8qdi8qnYSNw",
@@ -522,6 +624,12 @@
 	"originCountry": "US",
 	"workflow": {
 		"status": "new"
+	},
+	"createdAt": {
+		"$date": "2018-03-16T06:55:07.305Z"
+	},
+	"updatedAt": {
+		"$date": "2018-03-16T06:55:07.305Z"
 	}
 },
 {
@@ -551,7 +659,13 @@
 	"isVisible": true,
 	"optionTitle": "Small",
 	"width": 1,
-	"title": "SM"
+	"title": "SM",
+	"createdAt": {
+		"$date": "2018-03-16T06:55:07.310Z"
+	},
+	"updatedAt": {
+		"$date": "2018-03-16T06:55:07.310Z"
+	}
 },
 {
 	"_id": "u7BcWyqS9WHc4zDfJ",
@@ -580,7 +694,13 @@
 	"isVisible": true,
 	"optionTitle": "Medium",
 	"width": 2,
-	"title": "M"
+	"title": "M",
+	"createdAt": {
+		"$date": "2018-03-16T06:55:07.318Z"
+	},
+	"updatedAt": {
+		"$date": "2018-03-16T06:55:07.318Z"
+	}
 },
 {
 	"_id": "eJQdg8nQ3g7LJJXWJ",
@@ -609,7 +729,13 @@
 	"isVisible": true,
 	"optionTitle": "Large",
 	"width": 1,
-	"title": "L"
+	"title": "L",
+	"createdAt": {
+		"$date": "2018-03-16T06:55:07.331Z"
+	},
+	"updatedAt": {
+		"$date": "2018-03-16T06:55:07.331Z"
+	}
 },
 {
 	"_id": "RYqHfoqpQBWc53Apo",
@@ -638,7 +764,13 @@
 	"isVisible": true,
 	"optionTitle": "Extra-Large",
 	"width": 1,
-	"title": "XL"
+	"title": "XL",
+	"createdAt": {
+		"$date": "2018-03-16T06:55:07.342Z"
+	},
+	"updatedAt": {
+		"$date": "2018-03-16T06:55:07.342Z"
+	}
 },
 {
 	"_id": "9zxhE27pAvx8vbKr5",
@@ -665,9 +797,15 @@
 	"vendor": "Stickerworks",
 	"description": "Show your pride and affix some Reaction to almost any surface",
 	"isBackorder": true,
-  "hashtags": [
-    "hZdSevCBP8dDc66Ba"
-  ]
+	"hashtags": [
+		"hZdSevCBP8dDc66Ba"
+	],
+	"createdAt": {
+		"$date": "2018-03-16T06:55:07.360Z"
+	},
+	"updatedAt": {
+		"$date": "2018-03-16T06:55:07.360Z"
+	}
 },
 {
 	"_id": "aXsSSpddrPcBWppFK",
@@ -695,6 +833,416 @@
 	"originCountry": "US",
 	"workflow": {
 		"status": "new"
+	},
+	"createdAt": {
+		"$date": "2018-03-16T06:55:07.364Z"
+	},
+	"updatedAt": {
+		"$date": "2018-03-16T06:55:07.364Z"
 	}
+},
+{
+	"_id": "5pe6Y2sxKy5eppGMF",
+	"type": "simple",
+	"isVisible": true,
+	"ancestors": [],
+	"title": "Reaction Hoodie",
+	"originCountry": "US",
+	"requiresShipping": true,
+	"handle": "reaction-hoodie",
+	"isDeleted": false,
+	"shopId": "J8Bhq3uTtdgwZx3rz",
+	"template": "productDetailSimple",
+	"createdAt": {
+		"$date": "2018-03-16T06:56:02.953Z"
+	},
+	"updatedAt": {
+		"$date": "2018-03-16T07:07:37.800Z"
+	},
+	"workflow": {
+		"status": "new"
+	},
+	"price": {
+		"range": "35",
+		"min": 35,
+		"max": 35
+	},
+	"vendor": "Hanes",
+	"description": "Whether DJ'ing your EDM set or hacking into the NSA this stylish hoodie will keep your tiny fragile body warm",
+	"pageTitle": "Keep yourself warm while still representing your favorite open-source ecommerce platform",
+	"hashtags": [
+		"dhqmJjXWotCNkTzxg"
+	]
+},
+{
+	"_id": "TsKXj4hugyJxuWQaR",
+	"type": "variant",
+	"ancestors": [
+		"5pe6Y2sxKy5eppGMF"
+	],
+	"price": 0,
+	"inventoryQuantity": 0,
+	"isDeleted": false,
+	"compareAtPrice": 0,
+	"weight": 0,
+	"length": 0,
+	"width": 0,
+	"height": 0,
+	"inventoryManagement": true,
+	"inventoryPolicy": false,
+	"lowInventoryWarningThreshold": 0,
+	"isVisible": true,
+	"shopId": "J8Bhq3uTtdgwZx3rz",
+	"taxable": true,
+	"taxCode": "0000",
+	"title": "Black",
+	"optionTitle": "Untitled Option",
+	"workflow": {
+		"status": "new"
+	},
+	"originCountry": "US"
+},
+{
+	"_id": "47SvKpw4Y2u9tQkqg",
+	"ancestors": [
+		"5pe6Y2sxKy5eppGMF",
+		"TsKXj4hugyJxuWQaR"
+	],
+	"type": "variant",
+	"title": "S",
+	"price": 35,
+	"inventoryQuantity": 100,
+	"isDeleted": false,
+	"compareAtPrice": 55,
+	"weight": 4,
+	"length": 23,
+	"width": 19,
+	"height": 3,
+	"inventoryManagement": true,
+	"inventoryPolicy": false,
+	"lowInventoryWarningThreshold": 0,
+	"isVisible": true,
+	"shopId": "J8Bhq3uTtdgwZx3rz",
+	"taxable": true,
+	"taxCode": "0000",
+	"optionTitle": "Small",
+	"workflow": {
+		"status": "new"
+	},
+	"originCountry": "US"
+},
+{
+	"_id": "RTgxXqqHD69C5sGaZ",
+	"ancestors": [
+		"5pe6Y2sxKy5eppGMF",
+		"TsKXj4hugyJxuWQaR"
+	],
+	"type": "variant",
+	"title": "M",
+	"price": 35,
+	"inventoryQuantity": 100,
+	"isDeleted": false,
+	"compareAtPrice": 55,
+	"weight": 4,
+	"length": 23,
+	"width": 19,
+	"height": 3,
+	"inventoryManagement": true,
+	"inventoryPolicy": false,
+	"lowInventoryWarningThreshold": 0,
+	"isVisible": true,
+	"shopId": "J8Bhq3uTtdgwZx3rz",
+	"taxable": true,
+	"taxCode": "0000",
+	"optionTitle": "Medium",
+	"workflow": {
+		"status": "new"
+	},
+	"originCountry": "US"
+},
+{
+	"_id": "LZ7mWgohWDxDCxqbg",
+	"ancestors": [
+		"5pe6Y2sxKy5eppGMF",
+		"TsKXj4hugyJxuWQaR"
+	],
+	"type": "variant",
+	"title": "L",
+	"price": 35,
+	"inventoryQuantity": 100,
+	"isDeleted": false,
+	"compareAtPrice": 55,
+	"weight": 4,
+	"length": 23,
+	"width": 19,
+	"height": 3,
+	"inventoryManagement": true,
+	"inventoryPolicy": false,
+	"lowInventoryWarningThreshold": 0,
+	"isVisible": true,
+	"shopId": "J8Bhq3uTtdgwZx3rz",
+	"taxable": true,
+	"taxCode": "0000",
+	"optionTitle": "Large",
+	"workflow": {
+		"status": "new"
+	},
+	"originCountry": "US"
+},
+{
+	"_id": "fs6MdddZgQLEXFqLR",
+	"ancestors": [
+		"5pe6Y2sxKy5eppGMF",
+		"TsKXj4hugyJxuWQaR"
+	],
+	"type": "variant",
+	"title": "XL",
+	"price": 35,
+	"inventoryQuantity": 100,
+	"isDeleted": false,
+	"compareAtPrice": 55,
+	"weight": 4,
+	"length": 23,
+	"width": 19,
+	"height": 3,
+	"inventoryManagement": true,
+	"inventoryPolicy": false,
+	"lowInventoryWarningThreshold": 0,
+	"isVisible": true,
+	"shopId": "J8Bhq3uTtdgwZx3rz",
+	"taxable": true,
+	"taxCode": "0000",
+	"optionTitle": "X-Large",
+	"workflow": {
+		"status": "new"
+	},
+	"originCountry": "US"
+},
+{
+	"_id": "Ks3fNppgpv4G8R4gt",
+	"type": "simple",
+	"isVisible": true,
+	"ancestors": [],
+	"title": "Reaction Camp Shirt",
+	"originCountry": "US",
+	"requiresShipping": true,
+	"isDeleted": false,
+	"shopId": "J8Bhq3uTtdgwZx3rz",
+	"template": "productDetailSimple",
+	"workflow": {
+		"status": "new"
+	},
+	"price": {
+		"range": "40 - 45",
+		"min": 40,
+		"max": 45
+	},
+	"vendor": "Hanes",
+	"description": "This camp shirt is a classy, clean alternative to T-shirts or Polos. Represent Reaction at camp or on the road",
+	"pageTitle": "Stylish but casual",
+	"hashtags": [
+		"dhqmJjXWotCNkTzxg"
+	],
+	"handle": "reaction-camp-shirt",
+	"createdAt": {
+		"$date": "2018-03-16T07:10:27.905Z"
+	},
+	"updatedAt": {
+		"$date": "2018-03-16T07:24:13.917Z"
+	}
+},
+{
+	"_id": "wxAThpm5Cv5j6ozjY",
+	"type": "variant",
+	"ancestors": [
+		"Ks3fNppgpv4G8R4gt"
+	],
+	"price": 0,
+	"inventoryQuantity": 0,
+	"isDeleted": false,
+	"compareAtPrice": 0,
+	"weight": 0,
+	"length": 0,
+	"width": 0,
+	"height": 0,
+	"inventoryManagement": true,
+	"inventoryPolicy": false,
+	"lowInventoryWarningThreshold": 0,
+	"isVisible": true,
+	"shopId": "J8Bhq3uTtdgwZx3rz",
+	"taxable": true,
+	"taxCode": "0000",
+	"title": "Black",
+	"optionTitle": "Untitled Option",
+	"workflow": {
+		"status": "new"
+	},
+	"originCountry": "US"
+},
+{
+	"_id": "b9GkPWqBNkxhArTPJ",
+	"ancestors": [
+		"Ks3fNppgpv4G8R4gt",
+		"wxAThpm5Cv5j6ozjY"
+	],
+	"type": "variant",
+	"title": "S",
+	"price": 40,
+	"inventoryQuantity": 100,
+	"isDeleted": false,
+	"compareAtPrice": 55,
+	"weight": 4,
+	"length": 23,
+	"width": 19,
+	"height": 3,
+	"inventoryManagement": true,
+	"inventoryPolicy": false,
+	"lowInventoryWarningThreshold": 0,
+	"isVisible": true,
+	"shopId": "J8Bhq3uTtdgwZx3rz",
+	"taxable": true,
+	"taxCode": "0000",
+	"optionTitle": "Small",
+	"workflow": {
+		"status": "new"
+	},
+	"originCountry": "US"
+},
+{
+	"_id": "x8sJGkbYxg2iRYMFM",
+	"ancestors": [
+		"Ks3fNppgpv4G8R4gt",
+		"wxAThpm5Cv5j6ozjY"
+	],
+	"type": "variant",
+	"title": "M",
+	"price": 40,
+	"inventoryQuantity": 100,
+	"isDeleted": false,
+	"compareAtPrice": 55,
+	"weight": 4,
+	"length": 23,
+	"width": 19,
+	"height": 3,
+	"inventoryManagement": true,
+	"inventoryPolicy": false,
+	"lowInventoryWarningThreshold": 0,
+	"isVisible": true,
+	"shopId": "J8Bhq3uTtdgwZx3rz",
+	"taxable": true,
+	"taxCode": "0000",
+	"optionTitle": "Medium",
+	"workflow": {
+		"status": "new"
+	},
+	"originCountry": "US"
+},
+{
+	"_id": "X6uN3h6ASh37PpF7b",
+	"ancestors": [
+		"Ks3fNppgpv4G8R4gt",
+		"wxAThpm5Cv5j6ozjY"
+	],
+	"type": "variant",
+	"title": "L",
+	"price": 45,
+	"inventoryQuantity": 100,
+	"isDeleted": false,
+	"compareAtPrice": 55,
+	"weight": 4,
+	"length": 23,
+	"width": 19,
+	"height": 3,
+	"inventoryManagement": true,
+	"inventoryPolicy": false,
+	"lowInventoryWarningThreshold": 0,
+	"isVisible": true,
+	"shopId": "J8Bhq3uTtdgwZx3rz",
+	"taxable": true,
+	"taxCode": "0000",
+	"optionTitle": "Large",
+	"workflow": {
+		"status": "new"
+	},
+	"originCountry": "US"
+},
+{
+	"_id": "ZqEeYurYBa6N9cWpL",
+	"ancestors": [
+		"Ks3fNppgpv4G8R4gt",
+		"wxAThpm5Cv5j6ozjY"
+	],
+	"type": "variant",
+	"title": "XL",
+	"price": 45,
+	"inventoryQuantity": 100,
+	"isDeleted": false,
+	"compareAtPrice": 55,
+	"weight": 4,
+	"length": 23,
+	"width": 19,
+	"height": 3,
+	"inventoryManagement": true,
+	"inventoryPolicy": false,
+	"lowInventoryWarningThreshold": 0,
+	"isVisible": true,
+	"shopId": "J8Bhq3uTtdgwZx3rz",
+	"taxable": true,
+	"taxCode": "0000",
+	"optionTitle": "X-Large",
+	"workflow": {
+		"status": "new"
+	},
+	"originCountry": "US"
+},
+{
+	"_id": "2dQcGbDozDki2w6uy",
+	"type": "simple",
+	"isVisible": false,
+	"ancestors": [],
+	"title": "",
+	"originCountry": "US",
+	"requiresShipping": true,
+	"handle": "2dQcGbDozDki2w6uy",
+	"isDeleted": false,
+	"shopId": "J8Bhq3uTtdgwZx3rz",
+	"template": "productDetailSimple",
+	"createdAt": {
+		"$date": "2018-03-16T07:27:20.640Z"
+	},
+	"updatedAt": {
+		"$date": "2018-03-16T07:27:20.640Z"
+	},
+	"workflow": {
+		"status": "new"
+	}
+},
+{
+	"_id": "cMaH6N63myRozQgDz",
+	"type": "variant",
+	"ancestors": [
+		"2dQcGbDozDki2w6uy"
+	],
+	"price": 0,
+	"inventoryQuantity": 0,
+	"isDeleted": false,
+	"compareAtPrice": 0,
+	"weight": 0,
+	"length": 0,
+	"width": 0,
+	"height": 0,
+	"inventoryManagement": true,
+	"inventoryPolicy": false,
+	"lowInventoryWarningThreshold": 0,
+	"isVisible": false,
+	"shopId": "J8Bhq3uTtdgwZx3rz",
+	"taxable": true,
+	"taxCode": "0000",
+	"title": "",
+	"optionTitle": "Untitled Option",
+	"workflow": {
+		"status": "new"
+	},
+	"originCountry": "US"
 }]
 

--- a/sample-data/data/small/Products.json
+++ b/sample-data/data/small/Products.json
@@ -30,13 +30,7 @@
 	},
 	"hashtags": [
 		"hZdSevCBP8dDc66Ba"
-	],
-	"createdAt": {
-		"$date": "2018-03-16T06:55:07.123Z"
-	},
-	"updatedAt": {
-		"$date": "2018-03-16T06:55:07.123Z"
-	}
+	]
 },
 {
 	"_id": "PH8xNGE8pRHdPo8Qc",
@@ -64,12 +58,6 @@
 	"originCountry": "US",
 	"workflow": {
 		"status": "new"
-	},
-	"createdAt": {
-		"$date": "2018-03-16T06:55:07.132Z"
-	},
-	"updatedAt": {
-		"$date": "2018-03-16T06:55:07.132Z"
 	}
 },
 {
@@ -99,12 +87,6 @@
 	"originCountry": "US",
 	"workflow": {
 		"status": "new"
-	},
-	"createdAt": {
-		"$date": "2018-03-16T06:55:07.148Z"
-	},
-	"updatedAt": {
-		"$date": "2018-03-16T06:55:07.148Z"
 	}
 },
 {
@@ -134,12 +116,6 @@
 	"originCountry": "US",
 	"workflow": {
 		"status": "new"
-	},
-	"createdAt": {
-		"$date": "2018-03-16T06:55:07.168Z"
-	},
-	"updatedAt": {
-		"$date": "2018-03-16T06:55:07.168Z"
 	}
 },
 {
@@ -174,13 +150,7 @@
 	},
 	"hashtags": [
 		"hZdSevCBP8dDc66Ba"
-	],
-	"createdAt": {
-		"$date": "2018-03-16T06:55:07.184Z"
-	},
-	"updatedAt": {
-		"$date": "2018-03-16T06:55:07.184Z"
-	}
+	]
 },
 {
 	"_id": "oWNyqhaeyw9eKdZKv",
@@ -208,12 +178,6 @@
 	"originCountry": "US",
 	"workflow": {
 		"status": "new"
-	},
-	"createdAt": {
-		"$date": "2018-03-16T06:55:07.193Z"
-	},
-	"updatedAt": {
-		"$date": "2018-03-16T06:55:07.193Z"
 	}
 },
 {
@@ -243,13 +207,7 @@
 	"isBackorder": false,
 	"hashtags": [
 		"hZdSevCBP8dDc66Ba"
-	],
-	"createdAt": {
-		"$date": "2018-03-16T06:55:07.206Z"
-	},
-	"updatedAt": {
-		"$date": "2018-03-16T06:55:07.206Z"
-	}
+	]
 },
 {
 	"_id": "zhXWhcsisSexE9bg8",
@@ -277,12 +235,6 @@
 	"originCountry": "US",
 	"workflow": {
 		"status": "new"
-	},
-	"createdAt": {
-		"$date": "2018-03-16T06:55:07.215Z"
-	},
-	"updatedAt": {
-		"$date": "2018-03-16T06:55:07.215Z"
 	}
 },
 {
@@ -312,13 +264,7 @@
 	"isBackorder": true,
 	"hashtags": [
 		"hZdSevCBP8dDc66Ba"
-	],
-	"createdAt": {
-		"$date": "2018-03-16T06:55:07.225Z"
-	},
-	"updatedAt": {
-		"$date": "2018-03-16T06:55:07.225Z"
-	}
+	]
 },
 {
 	"_id": "ddzkNjFJ3MjfkzvMg",
@@ -346,12 +292,6 @@
 	"originCountry": "US",
 	"workflow": {
 		"status": "new"
-	},
-	"createdAt": {
-		"$date": "2018-03-16T06:55:07.231Z"
-	},
-	"updatedAt": {
-		"$date": "2018-03-16T06:55:07.231Z"
 	}
 },
 {
@@ -381,13 +321,7 @@
 	"isBackorder": true,
 	"hashtags": [
 		"dhqmJjXWotCNkTzxg"
-	],
-	"createdAt": {
-		"$date": "2018-03-16T06:55:07.240Z"
-	},
-	"updatedAt": {
-		"$date": "2018-03-16T06:55:07.240Z"
-	}
+	]
 },
 {
 	"_id": "78zu2u3in4rNrWtKt",
@@ -415,12 +349,6 @@
 	"originCountry": "US",
 	"workflow": {
 		"status": "new"
-	},
-	"createdAt": {
-		"$date": "2018-03-16T06:55:07.247Z"
-	},
-	"updatedAt": {
-		"$date": "2018-03-16T06:55:07.247Z"
 	}
 },
 {
@@ -450,12 +378,6 @@
 	"originCountry": "US",
 	"workflow": {
 		"status": "new"
-	},
-	"createdAt": {
-		"$date": "2018-03-16T06:55:07.255Z"
-	},
-	"updatedAt": {
-		"$date": "2018-03-16T06:55:07.255Z"
 	}
 },
 {
@@ -485,12 +407,6 @@
 	"originCountry": "US",
 	"workflow": {
 		"status": "new"
-	},
-	"createdAt": {
-		"$date": "2018-03-16T06:55:07.261Z"
-	},
-	"updatedAt": {
-		"$date": "2018-03-16T06:55:07.261Z"
 	}
 },
 {
@@ -520,12 +436,6 @@
 	"originCountry": "US",
 	"workflow": {
 		"status": "new"
-	},
-	"createdAt": {
-		"$date": "2018-03-16T06:55:07.270Z"
-	},
-	"updatedAt": {
-		"$date": "2018-03-16T06:55:07.270Z"
 	}
 },
 {
@@ -555,12 +465,6 @@
 	"originCountry": "US",
 	"workflow": {
 		"status": "new"
-	},
-	"createdAt": {
-		"$date": "2018-03-16T06:55:07.281Z"
-	},
-	"updatedAt": {
-		"$date": "2018-03-16T06:55:07.281Z"
 	}
 },
 {
@@ -590,13 +494,7 @@
 	"handle": "reaction-mens-shirt",
 	"hashtags": [
 		"dhqmJjXWotCNkTzxg"
-	],
-	"createdAt": {
-		"$date": "2018-03-16T06:55:07.299Z"
-	},
-	"updatedAt": {
-		"$date": "2018-03-16T06:55:07.299Z"
-	}
+	]
 },
 {
 	"_id": "cxYA8s8qdi8qnYSNw",
@@ -624,12 +522,6 @@
 	"originCountry": "US",
 	"workflow": {
 		"status": "new"
-	},
-	"createdAt": {
-		"$date": "2018-03-16T06:55:07.305Z"
-	},
-	"updatedAt": {
-		"$date": "2018-03-16T06:55:07.305Z"
 	}
 },
 {
@@ -659,13 +551,7 @@
 	"isVisible": true,
 	"optionTitle": "Small",
 	"width": 1,
-	"title": "SM",
-	"createdAt": {
-		"$date": "2018-03-16T06:55:07.310Z"
-	},
-	"updatedAt": {
-		"$date": "2018-03-16T06:55:07.310Z"
-	}
+	"title": "SM"
 },
 {
 	"_id": "u7BcWyqS9WHc4zDfJ",
@@ -694,13 +580,7 @@
 	"isVisible": true,
 	"optionTitle": "Medium",
 	"width": 2,
-	"title": "M",
-	"createdAt": {
-		"$date": "2018-03-16T06:55:07.318Z"
-	},
-	"updatedAt": {
-		"$date": "2018-03-16T06:55:07.318Z"
-	}
+	"title": "M"
 },
 {
 	"_id": "eJQdg8nQ3g7LJJXWJ",
@@ -729,13 +609,7 @@
 	"isVisible": true,
 	"optionTitle": "Large",
 	"width": 1,
-	"title": "L",
-	"createdAt": {
-		"$date": "2018-03-16T06:55:07.331Z"
-	},
-	"updatedAt": {
-		"$date": "2018-03-16T06:55:07.331Z"
-	}
+	"title": "L"
 },
 {
 	"_id": "RYqHfoqpQBWc53Apo",
@@ -764,13 +638,7 @@
 	"isVisible": true,
 	"optionTitle": "Extra-Large",
 	"width": 1,
-	"title": "XL",
-	"createdAt": {
-		"$date": "2018-03-16T06:55:07.342Z"
-	},
-	"updatedAt": {
-		"$date": "2018-03-16T06:55:07.342Z"
-	}
+	"title": "XL"
 },
 {
 	"_id": "9zxhE27pAvx8vbKr5",
@@ -799,13 +667,7 @@
 	"isBackorder": true,
 	"hashtags": [
 		"hZdSevCBP8dDc66Ba"
-	],
-	"createdAt": {
-		"$date": "2018-03-16T06:55:07.360Z"
-	},
-	"updatedAt": {
-		"$date": "2018-03-16T06:55:07.360Z"
-	}
+	]
 },
 {
 	"_id": "aXsSSpddrPcBWppFK",
@@ -833,12 +695,6 @@
 	"originCountry": "US",
 	"workflow": {
 		"status": "new"
-	},
-	"createdAt": {
-		"$date": "2018-03-16T06:55:07.364Z"
-	},
-	"updatedAt": {
-		"$date": "2018-03-16T06:55:07.364Z"
 	}
 },
 {
@@ -853,12 +709,6 @@
 	"isDeleted": false,
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"template": "productDetailSimple",
-	"createdAt": {
-		"$date": "2018-03-16T06:56:02.953Z"
-	},
-	"updatedAt": {
-		"$date": "2018-03-16T07:07:37.800Z"
-	},
 	"workflow": {
 		"status": "new"
 	},
@@ -1043,13 +893,7 @@
 	"hashtags": [
 		"dhqmJjXWotCNkTzxg"
 	],
-	"handle": "reaction-camp-shirt",
-	"createdAt": {
-		"$date": "2018-03-16T07:10:27.905Z"
-	},
-	"updatedAt": {
-		"$date": "2018-03-16T07:24:13.917Z"
-	}
+	"handle": "reaction-camp-shirt"
 },
 {
 	"_id": "wxAThpm5Cv5j6ozjY",
@@ -1190,56 +1034,6 @@
 	"taxable": true,
 	"taxCode": "0000",
 	"optionTitle": "X-Large",
-	"workflow": {
-		"status": "new"
-	},
-	"originCountry": "US"
-},
-{
-	"_id": "2dQcGbDozDki2w6uy",
-	"type": "simple",
-	"isVisible": false,
-	"ancestors": [],
-	"title": "",
-	"originCountry": "US",
-	"requiresShipping": true,
-	"handle": "2dQcGbDozDki2w6uy",
-	"isDeleted": false,
-	"shopId": "J8Bhq3uTtdgwZx3rz",
-	"template": "productDetailSimple",
-	"createdAt": {
-		"$date": "2018-03-16T07:27:20.640Z"
-	},
-	"updatedAt": {
-		"$date": "2018-03-16T07:27:20.640Z"
-	},
-	"workflow": {
-		"status": "new"
-	}
-},
-{
-	"_id": "cMaH6N63myRozQgDz",
-	"type": "variant",
-	"ancestors": [
-		"2dQcGbDozDki2w6uy"
-	],
-	"price": 0,
-	"inventoryQuantity": 0,
-	"isDeleted": false,
-	"compareAtPrice": 0,
-	"weight": 0,
-	"length": 0,
-	"width": 0,
-	"height": 0,
-	"inventoryManagement": true,
-	"inventoryPolicy": false,
-	"lowInventoryWarningThreshold": 0,
-	"isVisible": false,
-	"shopId": "J8Bhq3uTtdgwZx3rz",
-	"taxable": true,
-	"taxCode": "0000",
-	"title": "",
-	"optionTitle": "Untitled Option",
 	"workflow": {
 		"status": "new"
 	},

--- a/server/methods.js
+++ b/server/methods.js
@@ -172,9 +172,7 @@ function createProductImage(product) {
 
 async function createProductImageFromUrl(product) {
   const url = Promise.await(randomPuppy());
-  console.log("url", url);
   const fileRecord = await FileRecord.fromUrl(url, { fetch });
-  console.log("fileRecord", fileRecord);
   const topVariant = getTopVariant(product._id);
   const { shopId } = product;
   fileRecord.metadata = {

--- a/server/methods.js
+++ b/server/methods.js
@@ -492,7 +492,7 @@ function kickoffOrderSearchRebuild() {
 methods.resetData = function () {
   // delete existing data
   Tags.remove({});
-  Products.direct.remove({});
+  Products.remove({});
   Catalog.remove({});
   ProductSearch.remove({});
   OrderSearch.remove({});

--- a/server/methods.js
+++ b/server/methods.js
@@ -10,12 +10,12 @@ import { FileRecord } from "@reactioncommerce/file-collections";
 import { Meteor } from "meteor/meteor";
 import { Random } from "meteor/random";
 import { Job } from "/imports/plugins/core/job-collection/lib";
-import { Products, ProductSearch, Tags, Packages, Jobs, Orders, Catalog } from "/lib/collections";
+import { Products, ProductSearch, Tags, Packages, Jobs, Orders, OrderSearch, Catalog, MediaRecords } from "/lib/collections";
 import { Media } from "/imports/plugins/core/files/server";
-
 import { Logger } from "/server/api";
 import { productTemplate, variantTemplate, optionTemplate, orderTemplate } from "./dataset";
-import { publishProductToCatalog } from "/imports/plugins/core/catalog/server/methods/catalog";
+import { publishProductsToCatalog, publishProductToCatalog } from "/imports/plugins/core/catalog/server/methods/catalog";
+
 
 const methods = {};
 
@@ -41,7 +41,6 @@ function loadSmallProducts() {
   products.forEach((product) => {
     product.createdAt = new Date();
     product.updatedAt = new Date();
-    console.log("product.type", product.type);
     Products.insert(product, {}, { publish: true });
     if (product.type === "simple" && product.isVisible) {
       publishProductToCatalog(product._id);
@@ -79,6 +78,16 @@ function getTopVariant(productId) {
     "ancestors.1": { $exists: false }
   });
   return topVariant;
+}
+
+/**
+ * @method getPrimaryProduct
+ * @summary determine the top-level product for assigning product images
+ * @param {object} variant - the variant to find the parent for
+ */
+function getPrimaryProduct(variant) {
+  const parent = Products.findOne({ _id: { $in: variant.ancestors  }, type: "simple" } );
+  return parent;
 }
 
 /**
@@ -152,8 +161,49 @@ function createProductImage(product) {
     });
     fileRecord.attachData(image.data);
 
-    const topVariant = getTopVariant(product._id);
     const { shopId } = product;
+    if (product.type === "simple") {
+      const topVariant = getTopVariant(product._id);
+      fileRecord.metadata = {
+        productId: product._id,
+        variantId: topVariant._id,
+        toGrid: 1,
+        shopId,
+        priority: 0,
+        workflow: "published"
+      };
+    } else {
+      const parent = getPrimaryProduct(product);
+      fileRecord.metadata = {
+        productId: parent._id,
+        variantId: product._id,
+        toGrid: 1,
+        shopId,
+        priority: 0,
+        workflow: "published"
+      };
+    }
+
+    Promise.await(Media.insert(fileRecord));
+    Promise.await(storeFromAttachedBuffer(fileRecord));
+
+    Logger.info(`Wrote image for ${product.title}`);
+  });
+}
+
+/**
+ * @method createProductImageFromUrl
+ * @summary Pull a puppy image from the internet and attach it to a product
+ * @param {object} product - the product to attach an image to
+ * @returns {object} fileObj - the file object that's been created
+ */
+async function createProductImageFromUrl(product) {
+  console.log("adding image to ", product.title);
+  const url = await randomPuppy();
+  const fileRecord = await FileRecord.fromUrl(url, { fetch });
+  const { shopId } = product;
+  const topVariant = getTopVariant(product._id);
+  if (product.type === "simple") {
     fileRecord.metadata = {
       productId: product._id,
       variantId: topVariant._id,
@@ -162,28 +212,20 @@ function createProductImage(product) {
       priority: 0,
       workflow: "published"
     };
+  } else {
+    const parent = getPrimaryProduct(product);
+    fileRecord.metadata = {
+      productId: parent._id,
+      variantId: product._id,
+      toGrid: 1,
+      shopId,
+      priority: 0,
+      workflow: "published"
+    };
+  }
 
-    Promise.await(Media.insert(fileRecord));
-    Promise.await(storeFromAttachedBuffer(fileRecord));
+  Media.insert(fileRecord);
 
-    Logger.info(`Wrote image for ${product._id}`);
-  });
-}
-
-async function createProductImageFromUrl(product) {
-  const url = Promise.await(randomPuppy());
-  const fileRecord = await FileRecord.fromUrl(url, { fetch });
-  const topVariant = getTopVariant(product._id);
-  const { shopId } = product;
-  fileRecord.metadata = {
-    productId: product._id,
-    variantId: topVariant._id,
-    toGrid: 1,
-    shopId,
-    priority: 0,
-    workflow: "published"
-  };
-  return Media.insert(fileRecord);
 }
 
 /**
@@ -191,17 +233,26 @@ async function createProductImageFromUrl(product) {
  * @summary Generate an image and attach it to every product
  * @returns {undefined}
  */
-function attachProductImages() {
+function attachProductImages(from = "random") {
   Logger.info("Started loading product images");
-  const products = Products.find({type: "simple"}).fetch();
+  const products = Products.find({}).fetch();
+  const productIds = products.map(({ _id }) => _id);
+  const media = MediaRecords.find({ "metadata.productId": { $in: productIds } }).fetch();
+  const productIdsWithMedia = _.uniq(media.map((doc) => doc.metadata.productId));
+  let imagesAdded = [];
   for (const product of products) {
-    if (!Promise.await(Media.findOne({"metadata.productId": product._id}))) {
-      // createProductImage(product);
-      Promise.await(createProductImageFromUrl(product));
-      publishProductToCatalog(product._id);
+    // include top level products and options but not top-level variants
+    if (!productIdsWithMedia.includes(product._id && product.ancestors.length > 1)) {
+      if (from === "web") {
+        Promise.await(createProductImageFromUrl(product));
+      } else {
+        Promise.await(createProductImage(product));
+      }
+      imagesAdded.push(product._id);
     }
   }
   Logger.info("loaded product images");
+  // publishProductsToCatalog(imagesAdded);
 }
 
 /**
@@ -444,6 +495,7 @@ methods.resetData = function () {
   Products.direct.remove({});
   Catalog.remove({});
   ProductSearch.remove({});
+  OrderSearch.remove({});
   Orders.remove({});
   resetMedia();
 };
@@ -472,8 +524,9 @@ methods.loadSmallOrders = function () {
  * @summary Generate random images and attach them to all products
  * @returns {undefined}
  */
-methods.loadImages = function () {
-  attachProductImages();
+methods.loadImages = function (from) {
+  check(from, String);
+  attachProductImages(from);
 };
 
 /**

--- a/server/methods.js
+++ b/server/methods.js
@@ -40,9 +40,12 @@ function loadSmallProducts() {
     product.createdAt = new Date();
     product.updatedAt = new Date();
     Products.insert(product, {}, { publish: true });
-    publishProductToCatalog(product._id);
+    if (product.type === "simple" && product.isVisible) {
+      publishProductToCatalog(product._id);
+    }
   });
   turnOnRevisions();
+  kickoffProductSearchRebuild();
   Logger.info("Products loaded");
 }
 


### PR DESCRIPTION
We now need to trigger rebuild of the product search manually now because `Hooks` are gone. Also building images from a URL so we get a real image instead of a noise image.