### PR TITLE
chore: update catalog publish import locations

### DIFF
--- a/server/methods.js
+++ b/server/methods.js
@@ -14,8 +14,8 @@ import { Products, ProductSearch, Tags, Packages, Jobs, Orders, OrderSearch, Cat
 import { Media } from "/imports/plugins/core/files/server";
 import { Logger } from "/server/api";
 import { productTemplate, variantTemplate, optionTemplate, orderTemplate } from "./dataset";
-import { publishProductsToCatalog, publishProductToCatalog } from "/imports/plugins/core/catalog/server/methods/catalog";
-
+import collections from "/imports/collections/rawCollections";
+import publishProductToCatalogById from "/imports/plugins/core/catalog/server/no-meteor/utils/publishProductToCatalogById";
 
 const methods = {};
 
@@ -43,7 +43,7 @@ function loadSmallProducts() {
     product.updatedAt = new Date();
     Products.insert(product, {}, { publish: true });
     if (product.type === "simple" && product.isVisible) {
-      publishProductToCatalog(product._id);
+      publishProductToCatalogById(product._id, collections);
     }
   });
   turnOnRevisions();
@@ -261,7 +261,6 @@ function attachProductImages(from = "random") {
     }
   }
   Logger.info("loaded product images");
-  // publishProductsToCatalog(imagesAdded);
 }
 
 /**


### PR DESCRIPTION
This is for a change that we'll be merging into release-1.12.0. Use this branch with the `refactor-4196-aldeed-catalog-schema-changes` branch of reaction until it's merged.

Note: I think the best approach eventually will be to use the GraphQL publishProducts mutation to do this rather than importing anything directly. This will allow us to make a CLI for this that doesn't run within a Reaction Meteor environment. Waiting on that approach until after @Akarshit's branch is merged.