### PR TITLE
(fix): compatibilty with v1.13.0 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,12 @@
     "presets": [
       "env",
       "react",
-      "stage-2"
+      [
+        "@babel/preset-stage-2",
+        {
+          "decoratorsLegacy": true
+        }
+      ]
     ]
   },
   "devDependencies": {


### PR DESCRIPTION
Fix compatibility issue with the babel version used in reaction v1.13.0. See https://github.com/babel/babel/issues/7786