### PR TITLE
Compatibility with Reaction 2.0

### DIFF
--- a/client/components/devtools.js
+++ b/client/components/devtools.js
@@ -168,7 +168,7 @@ class DevTools extends Component {
           <Button
             bezelStyle={"solid"}
             primary={true}
-            label={"Load Produts and Tags"}
+            label={"Load Products and Tags"}
             onClick={this.handleMediumDataClick}
           />
           <br />
@@ -198,7 +198,7 @@ class DevTools extends Component {
           <Button
             bezelStyle={"solid"}
             primary={true}
-            label={"Load Produts and Tags"}
+            label={"Load Products and Tags"}
             onClick={this.handleLargeDataClick}
           />
           <br />

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
       "requires": {
-        "acorn": "3.3.0"
+        "acorn": "^3.0.4"
       },
       "dependencies": {
         "acorn": {
@@ -39,10 +39,10 @@
       "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "dev": true,
       "requires": {
-        "co": "4.6.0",
-        "fast-deep-equal": "1.0.0",
-        "fast-json-stable-stringify": "2.0.0",
-        "json-schema-traverse": "0.3.1"
+        "co": "^4.6.0",
+        "fast-deep-equal": "^1.0.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.3.0"
       }
     },
     "ajv-keywords": {
@@ -75,7 +75,7 @@
       "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
       "dev": true,
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       }
     },
     "aria-query": {
@@ -85,7 +85,7 @@
       "dev": true,
       "requires": {
         "ast-types-flow": "0.0.7",
-        "commander": "2.14.1"
+        "commander": "^2.11.0"
       }
     },
     "array-includes": {
@@ -94,8 +94,8 @@
       "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.10.0"
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.7.0"
       }
     },
     "array-union": {
@@ -104,7 +104,7 @@
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
-        "array-uniq": "1.0.3"
+        "array-uniq": "^1.0.1"
       }
     },
     "array-uniq": {
@@ -146,9 +146,9 @@
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "esutils": "2.0.2",
-        "js-tokens": "3.0.2"
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
       },
       "dependencies": {
         "chalk": {
@@ -157,11 +157,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "strip-ansi": {
@@ -170,7 +170,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         }
       }
@@ -187,7 +187,7 @@
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -208,7 +208,7 @@
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
       "dev": true,
       "requires": {
-        "callsites": "0.2.0"
+        "callsites": "^0.2.0"
       }
     },
     "callsites": {
@@ -228,9 +228,9 @@
       "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
       "dev": true,
       "requires": {
-        "ansi-styles": "3.2.0",
-        "escape-string-regexp": "1.0.5",
-        "supports-color": "5.2.0"
+        "ansi-styles": "^3.2.0",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.2.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -239,7 +239,7 @@
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "supports-color": {
@@ -248,7 +248,7 @@
           "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -271,7 +271,7 @@
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
       "dev": true,
       "requires": {
-        "restore-cursor": "2.0.0"
+        "restore-cursor": "^2.0.0"
       }
     },
     "cli-width": {
@@ -292,7 +292,7 @@
       "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
       "dev": true,
       "requires": {
-        "color-name": "1.1.3"
+        "color-name": "^1.1.1"
       }
     },
     "color-name": {
@@ -319,9 +319,9 @@
       "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.4",
-        "typedarray": "0.0.6"
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
       }
     },
     "contains-path": {
@@ -347,7 +347,7 @@
       "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
       "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
       "requires": {
-        "capture-stack-trace": "1.0.0"
+        "capture-stack-trace": "^1.0.0"
       }
     },
     "cross-spawn": {
@@ -356,9 +356,9 @@
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "dev": true,
       "requires": {
-        "lru-cache": "4.1.1",
-        "shebang-command": "1.2.0",
-        "which": "1.3.0"
+        "lru-cache": "^4.0.1",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
       }
     },
     "damerau-levenshtein": {
@@ -388,8 +388,8 @@
       "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
       "dev": true,
       "requires": {
-        "foreach": "2.0.5",
-        "object-keys": "1.0.11"
+        "foreach": "^2.0.5",
+        "object-keys": "^1.0.8"
       }
     },
     "del": {
@@ -398,13 +398,13 @@
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
       "dev": true,
       "requires": {
-        "globby": "5.0.0",
-        "is-path-cwd": "1.0.0",
-        "is-path-in-cwd": "1.0.0",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "rimraf": "2.6.2"
+        "globby": "^5.0.0",
+        "is-path-cwd": "^1.0.0",
+        "is-path-in-cwd": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "rimraf": "^2.2.8"
       }
     },
     "doctrine": {
@@ -413,7 +413,7 @@
       "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
       "dev": true,
       "requires": {
-        "esutils": "2.0.2"
+        "esutils": "^2.0.2"
       }
     },
     "duplexer3": {
@@ -433,7 +433,7 @@
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
       "dev": true,
       "requires": {
-        "iconv-lite": "0.4.19"
+        "iconv-lite": "~0.4.13"
       }
     },
     "error-ex": {
@@ -442,7 +442,7 @@
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
       "dev": true,
       "requires": {
-        "is-arrayish": "0.2.1"
+        "is-arrayish": "^0.2.1"
       }
     },
     "es-abstract": {
@@ -451,11 +451,11 @@
       "integrity": "sha512-/uh/DhdqIOSkAWifU+8nG78vlQxdLckUdI/sPgy0VhuXi2qJ7T8czBmqIYtLQVpCIFYafChnsRsB5pyb1JdmCQ==",
       "dev": true,
       "requires": {
-        "es-to-primitive": "1.1.1",
-        "function-bind": "1.1.1",
-        "has": "1.0.1",
-        "is-callable": "1.1.3",
-        "is-regex": "1.0.4"
+        "es-to-primitive": "^1.1.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.1",
+        "is-callable": "^1.1.3",
+        "is-regex": "^1.0.4"
       }
     },
     "es-to-primitive": {
@@ -464,9 +464,9 @@
       "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
       "dev": true,
       "requires": {
-        "is-callable": "1.1.3",
-        "is-date-object": "1.0.1",
-        "is-symbol": "1.0.1"
+        "is-callable": "^1.1.1",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.1"
       }
     },
     "escape-string-regexp": {
@@ -481,43 +481,43 @@
       "integrity": "sha512-AyxBUCANU/o/xC0ijGMKavo5Ls3oK6xykiOITlMdjFjrKOsqLrA7Nf5cnrDgcKrHzBirclAZt63XO7YZlVUPwA==",
       "dev": true,
       "requires": {
-        "ajv": "5.5.2",
-        "babel-code-frame": "6.26.0",
-        "chalk": "2.3.1",
-        "concat-stream": "1.6.0",
-        "cross-spawn": "5.1.0",
-        "debug": "3.1.0",
-        "doctrine": "2.1.0",
-        "eslint-scope": "3.7.1",
-        "eslint-visitor-keys": "1.0.0",
-        "espree": "3.5.3",
-        "esquery": "1.0.0",
-        "esutils": "2.0.2",
-        "file-entry-cache": "2.0.0",
-        "functional-red-black-tree": "1.0.1",
-        "glob": "7.1.2",
-        "globals": "11.3.0",
-        "ignore": "3.3.7",
-        "imurmurhash": "0.1.4",
-        "inquirer": "3.3.0",
-        "is-resolvable": "1.1.0",
-        "js-yaml": "3.10.0",
-        "json-stable-stringify-without-jsonify": "1.0.1",
-        "levn": "0.3.0",
-        "lodash": "4.17.5",
-        "minimatch": "3.0.4",
-        "mkdirp": "0.5.1",
-        "natural-compare": "1.4.0",
-        "optionator": "0.8.2",
-        "path-is-inside": "1.0.2",
-        "pluralize": "7.0.0",
-        "progress": "2.0.0",
-        "require-uncached": "1.0.3",
-        "semver": "5.5.0",
-        "strip-ansi": "4.0.0",
-        "strip-json-comments": "2.0.1",
-        "table": "4.0.2",
-        "text-table": "0.2.0"
+        "ajv": "^5.3.0",
+        "babel-code-frame": "^6.22.0",
+        "chalk": "^2.1.0",
+        "concat-stream": "^1.6.0",
+        "cross-spawn": "^5.1.0",
+        "debug": "^3.1.0",
+        "doctrine": "^2.1.0",
+        "eslint-scope": "^3.7.1",
+        "eslint-visitor-keys": "^1.0.0",
+        "espree": "^3.5.2",
+        "esquery": "^1.0.0",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^2.0.0",
+        "functional-red-black-tree": "^1.0.1",
+        "glob": "^7.1.2",
+        "globals": "^11.0.1",
+        "ignore": "^3.3.3",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^3.0.6",
+        "is-resolvable": "^1.0.0",
+        "js-yaml": "^3.9.1",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.3.0",
+        "lodash": "^4.17.4",
+        "minimatch": "^3.0.2",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.2",
+        "path-is-inside": "^1.0.2",
+        "pluralize": "^7.0.0",
+        "progress": "^2.0.0",
+        "require-uncached": "^1.0.3",
+        "semver": "^5.3.0",
+        "strip-ansi": "^4.0.0",
+        "strip-json-comments": "~2.0.1",
+        "table": "^4.0.1",
+        "text-table": "~0.2.0"
       }
     },
     "eslint-import-resolver-node": {
@@ -526,8 +526,8 @@
       "integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
       "dev": true,
       "requires": {
-        "debug": "2.6.9",
-        "resolve": "1.5.0"
+        "debug": "^2.6.9",
+        "resolve": "^1.5.0"
       },
       "dependencies": {
         "debug": {
@@ -547,8 +547,8 @@
       "integrity": "sha512-jDI/X5l/6D1rRD/3T43q8Qgbls2nq5km5KSqiwlyUbGo5+04fXhMKdCPhjwbqAa6HXWaMxj8Q4hQDIh7IadJQw==",
       "dev": true,
       "requires": {
-        "debug": "2.6.9",
-        "pkg-dir": "1.0.0"
+        "debug": "^2.6.8",
+        "pkg-dir": "^1.0.0"
       },
       "dependencies": {
         "debug": {
@@ -568,16 +568,16 @@
       "integrity": "sha512-Rf7dfKJxZ16QuTgVv1OYNxkZcsu/hULFnC+e+w0Gzi6jMC3guQoWQgxYxc54IDRinlb6/0v5z/PxxIKmVctN+g==",
       "dev": true,
       "requires": {
-        "builtin-modules": "1.1.1",
-        "contains-path": "0.1.0",
-        "debug": "2.6.9",
+        "builtin-modules": "^1.1.1",
+        "contains-path": "^0.1.0",
+        "debug": "^2.6.8",
         "doctrine": "1.5.0",
-        "eslint-import-resolver-node": "0.3.2",
-        "eslint-module-utils": "2.1.1",
-        "has": "1.0.1",
-        "lodash.cond": "4.5.2",
-        "minimatch": "3.0.4",
-        "read-pkg-up": "2.0.0"
+        "eslint-import-resolver-node": "^0.3.1",
+        "eslint-module-utils": "^2.1.1",
+        "has": "^1.0.1",
+        "lodash.cond": "^4.3.0",
+        "minimatch": "^3.0.3",
+        "read-pkg-up": "^2.0.0"
       },
       "dependencies": {
         "debug": {
@@ -595,8 +595,8 @@
           "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
           "dev": true,
           "requires": {
-            "esutils": "2.0.2",
-            "isarray": "1.0.0"
+            "esutils": "^2.0.2",
+            "isarray": "^1.0.0"
           }
         }
       }
@@ -607,13 +607,13 @@
       "integrity": "sha1-VFg9GuRCSDFi4EDhPMMYZUZRAOU=",
       "dev": true,
       "requires": {
-        "aria-query": "0.7.1",
-        "array-includes": "3.0.3",
+        "aria-query": "^0.7.0",
+        "array-includes": "^3.0.3",
         "ast-types-flow": "0.0.7",
-        "axobject-query": "0.1.0",
-        "damerau-levenshtein": "1.0.4",
-        "emoji-regex": "6.5.1",
-        "jsx-ast-utils": "2.0.1"
+        "axobject-query": "^0.1.0",
+        "damerau-levenshtein": "^1.0.0",
+        "emoji-regex": "^6.1.0",
+        "jsx-ast-utils": "^2.0.0"
       }
     },
     "eslint-plugin-react": {
@@ -622,10 +622,10 @@
       "integrity": "sha512-30aMOHWX/DOaaLJVBHz6RMvYM2qy5GH63+y2PLFdIrYe4YLtODFmT3N1YA7ZqUnaBweVbedr4K4cqxOlWAPjIw==",
       "dev": true,
       "requires": {
-        "doctrine": "2.1.0",
-        "has": "1.0.1",
-        "jsx-ast-utils": "2.0.1",
-        "prop-types": "15.6.0"
+        "doctrine": "^2.0.2",
+        "has": "^1.0.1",
+        "jsx-ast-utils": "^2.0.1",
+        "prop-types": "^15.6.0"
       }
     },
     "eslint-scope": {
@@ -634,8 +634,8 @@
       "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
       "dev": true,
       "requires": {
-        "esrecurse": "4.2.0",
-        "estraverse": "4.2.0"
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
       }
     },
     "eslint-visitor-keys": {
@@ -650,8 +650,8 @@
       "integrity": "sha512-Zy3tAJDORxQZLl2baguiRU1syPERAIg0L+JB2MWorORgTu/CplzvxS9WWA7Xh4+Q+eOQihNs/1o1Xep8cvCxWQ==",
       "dev": true,
       "requires": {
-        "acorn": "5.4.1",
-        "acorn-jsx": "3.0.1"
+        "acorn": "^5.4.0",
+        "acorn-jsx": "^3.0.0"
       }
     },
     "esprima": {
@@ -666,7 +666,7 @@
       "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
       "dev": true,
       "requires": {
-        "estraverse": "4.2.0"
+        "estraverse": "^4.0.0"
       }
     },
     "esrecurse": {
@@ -675,8 +675,8 @@
       "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
       "dev": true,
       "requires": {
-        "estraverse": "4.2.0",
-        "object-assign": "4.1.1"
+        "estraverse": "^4.1.0",
+        "object-assign": "^4.0.1"
       }
     },
     "estraverse": {
@@ -702,9 +702,9 @@
       "integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
       "dev": true,
       "requires": {
-        "chardet": "0.4.2",
-        "iconv-lite": "0.4.19",
-        "tmp": "0.0.33"
+        "chardet": "^0.4.0",
+        "iconv-lite": "^0.4.17",
+        "tmp": "^0.0.33"
       }
     },
     "fast-deep-equal": {
@@ -731,13 +731,13 @@
       "integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
       "dev": true,
       "requires": {
-        "core-js": "1.2.7",
-        "isomorphic-fetch": "2.2.1",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1",
-        "promise": "7.3.1",
-        "setimmediate": "1.0.5",
-        "ua-parser-js": "0.7.17"
+        "core-js": "^1.0.0",
+        "isomorphic-fetch": "^2.1.1",
+        "loose-envify": "^1.0.0",
+        "object-assign": "^4.1.0",
+        "promise": "^7.1.1",
+        "setimmediate": "^1.0.5",
+        "ua-parser-js": "^0.7.9"
       }
     },
     "figures": {
@@ -746,7 +746,7 @@
       "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "1.0.5"
+        "escape-string-regexp": "^1.0.5"
       }
     },
     "file-entry-cache": {
@@ -755,8 +755,8 @@
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
       "dev": true,
       "requires": {
-        "flat-cache": "1.3.0",
-        "object-assign": "4.1.1"
+        "flat-cache": "^1.2.1",
+        "object-assign": "^4.0.1"
       }
     },
     "find-up": {
@@ -765,8 +765,8 @@
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
       "dev": true,
       "requires": {
-        "path-exists": "2.1.0",
-        "pinkie-promise": "2.0.1"
+        "path-exists": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "flat-cache": {
@@ -775,10 +775,10 @@
       "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
       "dev": true,
       "requires": {
-        "circular-json": "0.3.3",
-        "del": "2.2.2",
-        "graceful-fs": "4.1.11",
-        "write": "0.2.1"
+        "circular-json": "^0.3.1",
+        "del": "^2.0.2",
+        "graceful-fs": "^4.1.2",
+        "write": "^0.2.1"
       }
     },
     "foreach": {
@@ -816,12 +816,12 @@
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "globals": {
@@ -836,12 +836,12 @@
       "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
       "dev": true,
       "requires": {
-        "array-union": "1.0.2",
-        "arrify": "1.0.1",
-        "glob": "7.1.2",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
+        "array-union": "^1.0.1",
+        "arrify": "^1.0.0",
+        "glob": "^7.0.3",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "got": {
@@ -849,17 +849,17 @@
       "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
       "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
       "requires": {
-        "create-error-class": "3.0.2",
-        "duplexer3": "0.1.4",
-        "get-stream": "3.0.0",
-        "is-redirect": "1.0.0",
-        "is-retry-allowed": "1.1.0",
-        "is-stream": "1.1.0",
-        "lowercase-keys": "1.0.0",
-        "safe-buffer": "5.1.1",
-        "timed-out": "4.0.1",
-        "unzip-response": "2.0.1",
-        "url-parse-lax": "1.0.0"
+        "create-error-class": "^3.0.0",
+        "duplexer3": "^0.1.4",
+        "get-stream": "^3.0.0",
+        "is-redirect": "^1.0.0",
+        "is-retry-allowed": "^1.0.0",
+        "is-stream": "^1.0.0",
+        "lowercase-keys": "^1.0.0",
+        "safe-buffer": "^5.0.1",
+        "timed-out": "^4.0.0",
+        "unzip-response": "^2.0.1",
+        "url-parse-lax": "^1.0.0"
       }
     },
     "graceful-fs": {
@@ -874,7 +874,7 @@
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
       "dev": true,
       "requires": {
-        "function-bind": "1.1.1"
+        "function-bind": "^1.0.2"
       }
     },
     "has-ansi": {
@@ -883,7 +883,7 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "has-flag": {
@@ -922,8 +922,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -938,20 +938,20 @@
       "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "3.0.0",
-        "chalk": "2.3.1",
-        "cli-cursor": "2.1.0",
-        "cli-width": "2.2.0",
-        "external-editor": "2.1.0",
-        "figures": "2.0.0",
-        "lodash": "4.17.5",
+        "ansi-escapes": "^3.0.0",
+        "chalk": "^2.0.0",
+        "cli-cursor": "^2.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^2.0.4",
+        "figures": "^2.0.0",
+        "lodash": "^4.3.0",
         "mute-stream": "0.0.7",
-        "run-async": "2.3.0",
-        "rx-lite": "4.0.8",
-        "rx-lite-aggregates": "4.0.8",
-        "string-width": "2.1.1",
-        "strip-ansi": "4.0.0",
-        "through": "2.3.8"
+        "run-async": "^2.2.0",
+        "rx-lite": "^4.0.8",
+        "rx-lite-aggregates": "^4.0.8",
+        "string-width": "^2.1.0",
+        "strip-ansi": "^4.0.0",
+        "through": "^2.3.6"
       }
     },
     "is-arrayish": {
@@ -966,7 +966,7 @@
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
-        "builtin-modules": "1.1.1"
+        "builtin-modules": "^1.0.0"
       }
     },
     "is-callable": {
@@ -999,7 +999,7 @@
       "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
       "dev": true,
       "requires": {
-        "is-path-inside": "1.0.1"
+        "is-path-inside": "^1.0.0"
       }
     },
     "is-path-inside": {
@@ -1008,7 +1008,7 @@
       "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "dev": true,
       "requires": {
-        "path-is-inside": "1.0.2"
+        "path-is-inside": "^1.0.1"
       }
     },
     "is-promise": {
@@ -1028,7 +1028,7 @@
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "dev": true,
       "requires": {
-        "has": "1.0.1"
+        "has": "^1.0.1"
       }
     },
     "is-resolvable": {
@@ -1071,8 +1071,8 @@
       "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
       "dev": true,
       "requires": {
-        "node-fetch": "1.7.3",
-        "whatwg-fetch": "2.0.3"
+        "node-fetch": "^1.0.1",
+        "whatwg-fetch": ">=0.10.0"
       }
     },
     "jpeg-js": {
@@ -1092,8 +1092,8 @@
       "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
       "dev": true,
       "requires": {
-        "argparse": "1.0.9",
-        "esprima": "4.0.0"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       }
     },
     "json-schema-traverse": {
@@ -1114,7 +1114,7 @@
       "integrity": "sha1-6AGxs5mF4g//yHtA43SAgOLcrH8=",
       "dev": true,
       "requires": {
-        "array-includes": "3.0.3"
+        "array-includes": "^3.0.3"
       }
     },
     "levn": {
@@ -1123,8 +1123,8 @@
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2"
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
       }
     },
     "load-json-file": {
@@ -1133,10 +1133,10 @@
       "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "parse-json": "2.2.0",
-        "pify": "2.3.0",
-        "strip-bom": "3.0.0"
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "strip-bom": "^3.0.0"
       }
     },
     "locate-path": {
@@ -1145,8 +1145,8 @@
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "dev": true,
       "requires": {
-        "p-locate": "2.0.0",
-        "path-exists": "3.0.0"
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
       },
       "dependencies": {
         "path-exists": {
@@ -1175,7 +1175,7 @@
       "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
       "dev": true,
       "requires": {
-        "js-tokens": "3.0.2"
+        "js-tokens": "^3.0.0"
       }
     },
     "lowercase-keys": {
@@ -1189,8 +1189,8 @@
       "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
       "dev": true,
       "requires": {
-        "pseudomap": "1.0.2",
-        "yallist": "2.1.2"
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
       }
     },
     "mimic-fn": {
@@ -1205,7 +1205,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -1247,8 +1247,8 @@
       "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
       "dev": true,
       "requires": {
-        "encoding": "0.1.12",
-        "is-stream": "1.1.0"
+        "encoding": "^0.1.11",
+        "is-stream": "^1.0.1"
       }
     },
     "normalize-package-data": {
@@ -1257,10 +1257,10 @@
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "2.5.0",
-        "is-builtin-module": "1.0.0",
-        "semver": "5.5.0",
-        "validate-npm-package-license": "3.0.1"
+        "hosted-git-info": "^2.1.4",
+        "is-builtin-module": "^1.0.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
       }
     },
     "object-assign": {
@@ -1281,7 +1281,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "onetime": {
@@ -1290,7 +1290,7 @@
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
       "dev": true,
       "requires": {
-        "mimic-fn": "1.2.0"
+        "mimic-fn": "^1.0.0"
       }
     },
     "optionator": {
@@ -1299,12 +1299,12 @@
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
-        "deep-is": "0.1.3",
-        "fast-levenshtein": "2.0.6",
-        "levn": "0.3.0",
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2",
-        "wordwrap": "1.0.0"
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
       }
     },
     "os-tmpdir": {
@@ -1319,7 +1319,7 @@
       "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
       "dev": true,
       "requires": {
-        "p-try": "1.0.0"
+        "p-try": "^1.0.0"
       }
     },
     "p-locate": {
@@ -1328,7 +1328,7 @@
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "dev": true,
       "requires": {
-        "p-limit": "1.2.0"
+        "p-limit": "^1.1.0"
       }
     },
     "p-try": {
@@ -1343,7 +1343,7 @@
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
-        "error-ex": "1.3.1"
+        "error-ex": "^1.2.0"
       }
     },
     "path-exists": {
@@ -1352,7 +1352,7 @@
       "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
       "dev": true,
       "requires": {
-        "pinkie-promise": "2.0.1"
+        "pinkie-promise": "^2.0.0"
       }
     },
     "path-is-absolute": {
@@ -1379,7 +1379,7 @@
       "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
       "dev": true,
       "requires": {
-        "pify": "2.3.0"
+        "pify": "^2.0.0"
       }
     },
     "pify": {
@@ -1400,7 +1400,7 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "2.0.4"
+        "pinkie": "^2.0.0"
       }
     },
     "pkg-dir": {
@@ -1409,7 +1409,7 @@
       "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
       "dev": true,
       "requires": {
-        "find-up": "1.1.2"
+        "find-up": "^1.0.0"
       }
     },
     "pluralize": {
@@ -1447,7 +1447,7 @@
       "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
       "dev": true,
       "requires": {
-        "asap": "2.0.6"
+        "asap": "~2.0.3"
       }
     },
     "prop-types": {
@@ -1456,9 +1456,9 @@
       "integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
       "dev": true,
       "requires": {
-        "fbjs": "0.8.16",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1"
+        "fbjs": "^0.8.16",
+        "loose-envify": "^1.3.1",
+        "object-assign": "^4.1.1"
       }
     },
     "pseudomap": {
@@ -1472,9 +1472,9 @@
       "resolved": "https://registry.npmjs.org/random-puppy/-/random-puppy-1.1.0.tgz",
       "integrity": "sha1-GtqjTA83bVArWdb9gifqYaRUmTs=",
       "requires": {
-        "eventemitter3": "1.2.0",
-        "got": "6.7.1",
-        "unique-random-array": "1.0.0"
+        "eventemitter3": "^1.2.0",
+        "got": "^6.3.0",
+        "unique-random-array": "^1.0.0"
       }
     },
     "read-pkg": {
@@ -1483,9 +1483,9 @@
       "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
       "dev": true,
       "requires": {
-        "load-json-file": "2.0.0",
-        "normalize-package-data": "2.4.0",
-        "path-type": "2.0.0"
+        "load-json-file": "^2.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^2.0.0"
       }
     },
     "read-pkg-up": {
@@ -1494,8 +1494,8 @@
       "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
       "dev": true,
       "requires": {
-        "find-up": "2.1.0",
-        "read-pkg": "2.0.0"
+        "find-up": "^2.0.0",
+        "read-pkg": "^2.0.0"
       },
       "dependencies": {
         "find-up": {
@@ -1504,7 +1504,7 @@
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
-            "locate-path": "2.0.0"
+            "locate-path": "^2.0.0"
           }
         }
       }
@@ -1515,13 +1515,13 @@
       "integrity": "sha512-vuYxeWYM+fde14+rajzqgeohAI7YoJcHE7kXDAc4Nk0EbuKnJfqtY9YtRkLo/tqkuF7MsBQRhPnPeyjYITp3ZQ==",
       "dev": true,
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "2.0.0",
-        "safe-buffer": "5.1.1",
-        "string_decoder": "1.0.3",
-        "util-deprecate": "1.0.2"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.0.3",
+        "util-deprecate": "~1.0.1"
       }
     },
     "require-uncached": {
@@ -1530,8 +1530,8 @@
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
       "requires": {
-        "caller-path": "0.1.0",
-        "resolve-from": "1.0.1"
+        "caller-path": "^0.1.0",
+        "resolve-from": "^1.0.0"
       }
     },
     "resolve": {
@@ -1540,7 +1540,7 @@
       "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
       "dev": true,
       "requires": {
-        "path-parse": "1.0.5"
+        "path-parse": "^1.0.5"
       }
     },
     "resolve-from": {
@@ -1555,8 +1555,8 @@
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
       "dev": true,
       "requires": {
-        "onetime": "2.0.1",
-        "signal-exit": "3.0.2"
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
       }
     },
     "rimraf": {
@@ -1565,7 +1565,7 @@
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "dev": true,
       "requires": {
-        "glob": "7.1.2"
+        "glob": "^7.0.5"
       }
     },
     "run-async": {
@@ -1574,7 +1574,7 @@
       "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
       "dev": true,
       "requires": {
-        "is-promise": "2.1.0"
+        "is-promise": "^2.1.0"
       }
     },
     "rx-lite": {
@@ -1589,7 +1589,7 @@
       "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
       "dev": true,
       "requires": {
-        "rx-lite": "4.0.8"
+        "rx-lite": "*"
       }
     },
     "safe-buffer": {
@@ -1615,7 +1615,7 @@
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
-        "shebang-regex": "1.0.0"
+        "shebang-regex": "^1.0.0"
       }
     },
     "shebang-regex": {
@@ -1636,7 +1636,7 @@
       "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "2.0.0"
+        "is-fullwidth-code-point": "^2.0.0"
       }
     },
     "spdx-correct": {
@@ -1645,7 +1645,7 @@
       "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
       "dev": true,
       "requires": {
-        "spdx-license-ids": "1.2.2"
+        "spdx-license-ids": "^1.0.2"
       }
     },
     "spdx-expression-parse": {
@@ -1672,8 +1672,8 @@
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "2.0.0",
-        "strip-ansi": "4.0.0"
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
       }
     },
     "string_decoder": {
@@ -1682,7 +1682,7 @@
       "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "~5.1.0"
       }
     },
     "strip-ansi": {
@@ -1691,7 +1691,7 @@
       "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "3.0.0"
+        "ansi-regex": "^3.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -1726,12 +1726,12 @@
       "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
       "dev": true,
       "requires": {
-        "ajv": "5.5.2",
-        "ajv-keywords": "2.1.1",
-        "chalk": "2.3.1",
-        "lodash": "4.17.5",
+        "ajv": "^5.2.3",
+        "ajv-keywords": "^2.1.0",
+        "chalk": "^2.1.0",
+        "lodash": "^4.17.4",
         "slice-ansi": "1.0.0",
-        "string-width": "2.1.1"
+        "string-width": "^2.1.1"
       }
     },
     "text-table": {
@@ -1757,7 +1757,7 @@
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "dev": true,
       "requires": {
-        "os-tmpdir": "1.0.2"
+        "os-tmpdir": "~1.0.2"
       }
     },
     "type-check": {
@@ -1766,7 +1766,7 @@
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2"
+        "prelude-ls": "~1.1.2"
       }
     },
     "typedarray": {
@@ -1791,7 +1791,7 @@
       "resolved": "https://registry.npmjs.org/unique-random-array/-/unique-random-array-1.0.0.tgz",
       "integrity": "sha1-QrNyHFeTiNi2Z8k8Lb3j1dgakTY=",
       "requires": {
-        "unique-random": "1.0.0"
+        "unique-random": "^1.0.0"
       }
     },
     "unzip-response": {
@@ -1804,7 +1804,7 @@
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
       "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
       "requires": {
-        "prepend-http": "1.0.4"
+        "prepend-http": "^1.0.1"
       }
     },
     "util-deprecate": {
@@ -1819,8 +1819,8 @@
       "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
       "dev": true,
       "requires": {
-        "spdx-correct": "1.0.2",
-        "spdx-expression-parse": "1.0.4"
+        "spdx-correct": "~1.0.0",
+        "spdx-expression-parse": "~1.0.0"
       }
     },
     "whatwg-fetch": {
@@ -1835,7 +1835,7 @@
       "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
       "dev": true,
       "requires": {
-        "isexe": "2.0.0"
+        "isexe": "^2.0.0"
       }
     },
     "wordwrap": {
@@ -1856,7 +1856,7 @@
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
       "dev": true,
       "requires": {
-        "mkdirp": "0.5.1"
+        "mkdirp": "^0.5.1"
       }
     },
     "yallist": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1073,6 +1073,18 @@
       "requires": {
         "node-fetch": "^1.0.1",
         "whatwg-fetch": ">=0.10.0"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+          "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+          "dev": true,
+          "requires": {
+            "encoding": "^0.1.11",
+            "is-stream": "^1.0.1"
+          }
+        }
       }
     },
     "jpeg-js": {
@@ -1242,14 +1254,9 @@
       "dev": true
     },
     "node-fetch": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-      "dev": true,
-      "requires": {
-        "encoding": "^0.1.11",
-        "is-stream": "^1.0.1"
-      }
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.3.0.tgz",
+      "integrity": "sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA=="
     },
     "normalize-package-data": {
       "version": "2.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,15 +5,15 @@
   "requires": true,
   "dependencies": {
     "@reactioncommerce/eslint-config": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@reactioncommerce/eslint-config/-/eslint-config-1.0.1.tgz",
-      "integrity": "sha512-Lpq/k4UzyUDyXeysZT+o+VMNi8BUTVoM+IfdvYL+7mpNiGYhj3BCprapOZget1t7V11TIxbxSL2wTXvRFP5JaQ==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@reactioncommerce/eslint-config/-/eslint-config-1.9.0.tgz",
+      "integrity": "sha512-pLkrZNEEoL1MSQCYn+jeGmEZHDFuyrrEEAtF+uq206Sddw+hiwQ4s9vEWNs4mP60mnKmHo03QfQ8XtQik6tRcA==",
       "dev": true
     },
     "acorn": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.4.1.tgz",
-      "integrity": "sha512-XLmq3H/BVvW6/GbxKryGxWORz1ebilSsUDlyC27bXhWGWAZWkGwS6FLHjOlwFXNFoWFQEO/Df4u0YYd0K3BQgQ==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+      "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
       "dev": true
     },
     "acorn-jsx": {
@@ -52,9 +52,9 @@
       "dev": true
     },
     "ansi-escapes": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
-      "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+      "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
       "dev": true
     },
     "ansi-regex": {
@@ -70,18 +70,18 @@
       "dev": true
     },
     "argparse": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-      "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
       }
     },
     "aria-query": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-0.7.1.tgz",
-      "integrity": "sha1-Jsu1r/ZBRLCoJb4YRuCxbPoAsR4=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-3.0.0.tgz",
+      "integrity": "sha1-ZbP8wcoRVajJrmTW7uKX8V1RM8w=",
       "dev": true,
       "requires": {
         "ast-types-flow": "0.0.7",
@@ -98,33 +98,6 @@
         "es-abstract": "^1.7.0"
       }
     },
-    "array-union": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-      "dev": true,
-      "requires": {
-        "array-uniq": "^1.0.1"
-      }
-    },
-    "array-uniq": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
-      "dev": true
-    },
-    "arrify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-      "dev": true
-    },
-    "asap": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
-      "dev": true
-    },
     "ast-types-flow": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
@@ -132,9 +105,9 @@
       "dev": true
     },
     "axobject-query": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-0.1.0.tgz",
-      "integrity": "sha1-YvWdvFnJ+SQnWco0mWDnov48NsA=",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.0.2.tgz",
+      "integrity": "sha512-MCeek8ZH7hKyO1rWUbKNQBbl4l2eY0ntk7OGi+q0RlafrCnfPxC06WZA+uebCfmYp4mNU9jRBP1AhGyf8+W3ww==",
       "dev": true,
       "requires": {
         "ast-types-flow": "0.0.7"
@@ -191,16 +164,16 @@
         "concat-map": "0.0.1"
       }
     },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
+    },
     "buffer-stream-reader": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/buffer-stream-reader/-/buffer-stream-reader-0.1.1.tgz",
       "integrity": "sha1-yov5NjHe7di4+MO7RJkcwwlR4lk="
-    },
-    "builtin-modules": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
-      "dev": true
     },
     "caller-path": {
       "version": "0.1.0",
@@ -218,34 +191,34 @@
       "dev": true
     },
     "capture-stack-trace": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
-      "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz",
+      "integrity": "sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw=="
     },
     "chalk": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
-      "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "dev": true,
       "requires": {
-        "ansi-styles": "^3.2.0",
+        "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.2.0"
+        "supports-color": "^5.3.0"
       },
       "dependencies": {
         "ansi-styles": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
           }
         },
         "supports-color": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
-          "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
@@ -287,12 +260,12 @@
       "dev": true
     },
     "color-convert": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
-      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
       "dev": true,
       "requires": {
-        "color-name": "^1.1.1"
+        "color-name": "1.1.3"
       }
     },
     "color-name": {
@@ -302,9 +275,9 @@
       "dev": true
     },
     "commander": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.14.1.tgz",
-      "integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw==",
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
+      "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
       "dev": true
     },
     "concat-map": {
@@ -314,11 +287,12 @@
       "dev": true
     },
     "concat-stream": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-      "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "dev": true,
       "requires": {
+        "buffer-from": "^1.0.0",
         "inherits": "^2.0.3",
         "readable-stream": "^2.2.2",
         "typedarray": "^0.0.6"
@@ -328,12 +302,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
       "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
-      "dev": true
-    },
-    "core-js": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-      "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
       "dev": true
     },
     "core-util-is": {
@@ -368,12 +336,12 @@
       "dev": true
     },
     "debug": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+      "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
       "dev": true,
       "requires": {
-        "ms": "2.0.0"
+        "ms": "^2.1.1"
       }
     },
     "deep-is": {
@@ -383,28 +351,12 @@
       "dev": true
     },
     "define-properties": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
-      "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
       "dev": true,
       "requires": {
-        "foreach": "^2.0.5",
-        "object-keys": "^1.0.8"
-      }
-    },
-    "del": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
-      "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
-      "dev": true,
-      "requires": {
-        "globby": "^5.0.0",
-        "is-path-cwd": "^1.0.0",
-        "is-path-in-cwd": "^1.0.0",
-        "object-assign": "^4.0.1",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0",
-        "rimraf": "^2.2.8"
+        "object-keys": "^1.0.12"
       }
     },
     "doctrine": {
@@ -422,51 +374,43 @@
       "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
     },
     "emoji-regex": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-6.5.1.tgz",
-      "integrity": "sha512-PAHp6TxrCy7MGMFidro8uikr+zlJJKJ/Q6mm2ExZ7HwkyR9lSVFfE3kt36qcwa24BQL7y0G9axycGjK1A/0uNQ==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
       "dev": true
     },
-    "encoding": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-      "dev": true,
-      "requires": {
-        "iconv-lite": "~0.4.13"
-      }
-    },
     "error-ex": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
-      "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
       }
     },
     "es-abstract": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.10.0.tgz",
-      "integrity": "sha512-/uh/DhdqIOSkAWifU+8nG78vlQxdLckUdI/sPgy0VhuXi2qJ7T8czBmqIYtLQVpCIFYafChnsRsB5pyb1JdmCQ==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
+      "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
       "dev": true,
       "requires": {
-        "es-to-primitive": "^1.1.1",
+        "es-to-primitive": "^1.2.0",
         "function-bind": "^1.1.1",
-        "has": "^1.0.1",
-        "is-callable": "^1.1.3",
-        "is-regex": "^1.0.4"
+        "has": "^1.0.3",
+        "is-callable": "^1.1.4",
+        "is-regex": "^1.0.4",
+        "object-keys": "^1.0.12"
       }
     },
     "es-to-primitive": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
-      "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+      "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
       "dev": true,
       "requires": {
-        "is-callable": "^1.1.1",
+        "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
-        "is-symbol": "^1.0.1"
+        "is-symbol": "^1.0.2"
       }
     },
     "escape-string-regexp": {
@@ -476,9 +420,9 @@
       "dev": true
     },
     "eslint": {
-      "version": "4.17.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.17.0.tgz",
-      "integrity": "sha512-AyxBUCANU/o/xC0ijGMKavo5Ls3oK6xykiOITlMdjFjrKOsqLrA7Nf5cnrDgcKrHzBirclAZt63XO7YZlVUPwA==",
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
+      "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
       "dev": true,
       "requires": {
         "ajv": "^5.3.0",
@@ -490,7 +434,7 @@
         "doctrine": "^2.1.0",
         "eslint-scope": "^3.7.1",
         "eslint-visitor-keys": "^1.0.0",
-        "espree": "^3.5.2",
+        "espree": "^3.5.4",
         "esquery": "^1.0.0",
         "esutils": "^2.0.2",
         "file-entry-cache": "^2.0.0",
@@ -512,11 +456,12 @@
         "path-is-inside": "^1.0.2",
         "pluralize": "^7.0.0",
         "progress": "^2.0.0",
+        "regexpp": "^1.0.1",
         "require-uncached": "^1.0.3",
         "semver": "^5.3.0",
         "strip-ansi": "^4.0.0",
         "strip-json-comments": "~2.0.1",
-        "table": "^4.0.1",
+        "table": "4.0.2",
         "text-table": "~0.2.0"
       }
     },
@@ -538,17 +483,23 @@
           "requires": {
             "ms": "2.0.0"
           }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
         }
       }
     },
     "eslint-module-utils": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.1.1.tgz",
-      "integrity": "sha512-jDI/X5l/6D1rRD/3T43q8Qgbls2nq5km5KSqiwlyUbGo5+04fXhMKdCPhjwbqAa6HXWaMxj8Q4hQDIh7IadJQw==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.3.0.tgz",
+      "integrity": "sha512-lmDJgeOOjk8hObTysjqH7wyMi+nsHwwvfBykwfhjR1LNdd7C2uFJBvx4OpWYpXOw4df1yE1cDEVd1yLHitk34w==",
       "dev": true,
       "requires": {
         "debug": "^2.6.8",
-        "pkg-dir": "^1.0.0"
+        "pkg-dir": "^2.0.0"
       },
       "dependencies": {
         "debug": {
@@ -559,25 +510,31 @@
           "requires": {
             "ms": "2.0.0"
           }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
         }
       }
     },
     "eslint-plugin-import": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.8.0.tgz",
-      "integrity": "sha512-Rf7dfKJxZ16QuTgVv1OYNxkZcsu/hULFnC+e+w0Gzi6jMC3guQoWQgxYxc54IDRinlb6/0v5z/PxxIKmVctN+g==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.16.0.tgz",
+      "integrity": "sha512-z6oqWlf1x5GkHIFgrSvtmudnqM6Q60KM4KvpWi5ubonMjycLjndvd5+8VAZIsTlHC03djdgJuyKG6XO577px6A==",
       "dev": true,
       "requires": {
-        "builtin-modules": "^1.1.1",
         "contains-path": "^0.1.0",
-        "debug": "^2.6.8",
+        "debug": "^2.6.9",
         "doctrine": "1.5.0",
-        "eslint-import-resolver-node": "^0.3.1",
-        "eslint-module-utils": "^2.1.1",
-        "has": "^1.0.1",
-        "lodash.cond": "^4.3.0",
-        "minimatch": "^3.0.3",
-        "read-pkg-up": "^2.0.0"
+        "eslint-import-resolver-node": "^0.3.2",
+        "eslint-module-utils": "^2.3.0",
+        "has": "^1.0.3",
+        "lodash": "^4.17.11",
+        "minimatch": "^3.0.4",
+        "read-pkg-up": "^2.0.0",
+        "resolve": "^1.9.0"
       },
       "dependencies": {
         "debug": {
@@ -598,40 +555,50 @@
             "esutils": "^2.0.2",
             "isarray": "^1.0.0"
           }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
         }
       }
     },
     "eslint-plugin-jsx-a11y": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.0.3.tgz",
-      "integrity": "sha1-VFg9GuRCSDFi4EDhPMMYZUZRAOU=",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.2.1.tgz",
+      "integrity": "sha512-cjN2ObWrRz0TTw7vEcGQrx+YltMvZoOEx4hWU8eEERDnBIU00OTq7Vr+jA7DFKxiwLNv4tTh5Pq2GUNEa8b6+w==",
       "dev": true,
       "requires": {
-        "aria-query": "^0.7.0",
+        "aria-query": "^3.0.0",
         "array-includes": "^3.0.3",
-        "ast-types-flow": "0.0.7",
-        "axobject-query": "^0.1.0",
-        "damerau-levenshtein": "^1.0.0",
-        "emoji-regex": "^6.1.0",
-        "jsx-ast-utils": "^2.0.0"
+        "ast-types-flow": "^0.0.7",
+        "axobject-query": "^2.0.2",
+        "damerau-levenshtein": "^1.0.4",
+        "emoji-regex": "^7.0.2",
+        "has": "^1.0.3",
+        "jsx-ast-utils": "^2.0.1"
       }
     },
     "eslint-plugin-react": {
-      "version": "7.6.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.6.1.tgz",
-      "integrity": "sha512-30aMOHWX/DOaaLJVBHz6RMvYM2qy5GH63+y2PLFdIrYe4YLtODFmT3N1YA7ZqUnaBweVbedr4K4cqxOlWAPjIw==",
+      "version": "7.12.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.12.4.tgz",
+      "integrity": "sha512-1puHJkXJY+oS1t467MjbqjvX53uQ05HXwjqDgdbGBqf5j9eeydI54G3KwiJmWciQ0HTBacIKw2jgwSBSH3yfgQ==",
       "dev": true,
       "requires": {
-        "doctrine": "^2.0.2",
-        "has": "^1.0.1",
+        "array-includes": "^3.0.3",
+        "doctrine": "^2.1.0",
+        "has": "^1.0.3",
         "jsx-ast-utils": "^2.0.1",
-        "prop-types": "^15.6.0"
+        "object.fromentries": "^2.0.0",
+        "prop-types": "^15.6.2",
+        "resolve": "^1.9.0"
       }
     },
     "eslint-scope": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
-      "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.3.tgz",
+      "integrity": "sha512-W+B0SvF4gamyCTmUc+uITPY0989iXVfKvhwtmJocTaYoc/3khEHmEmvfY/Gn9HA9VV75jrQECsHizkNw1b68FA==",
       "dev": true,
       "requires": {
         "esrecurse": "^4.1.0",
@@ -645,38 +612,37 @@
       "dev": true
     },
     "espree": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.3.tgz",
-      "integrity": "sha512-Zy3tAJDORxQZLl2baguiRU1syPERAIg0L+JB2MWorORgTu/CplzvxS9WWA7Xh4+Q+eOQihNs/1o1Xep8cvCxWQ==",
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+      "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
       "dev": true,
       "requires": {
-        "acorn": "^5.4.0",
+        "acorn": "^5.5.0",
         "acorn-jsx": "^3.0.0"
       }
     },
     "esprima": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true
     },
     "esquery": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
-      "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
+      "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
       "dev": true,
       "requires": {
         "estraverse": "^4.0.0"
       }
     },
     "esrecurse": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
-      "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
       "dev": true,
       "requires": {
-        "estraverse": "^4.1.0",
-        "object-assign": "^4.0.1"
+        "estraverse": "^4.1.0"
       }
     },
     "estraverse": {
@@ -697,9 +663,9 @@
       "integrity": "sha1-HIaZHYFq0eUEdQ5zh0Ik7PO+xQg="
     },
     "external-editor": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.1.0.tgz",
-      "integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+      "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
       "dev": true,
       "requires": {
         "chardet": "^0.4.0",
@@ -708,9 +674,9 @@
       }
     },
     "fast-deep-equal": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
-      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
       "dev": true
     },
     "fast-json-stable-stringify": {
@@ -724,21 +690,6 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
-    },
-    "fbjs": {
-      "version": "0.8.16",
-      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
-      "integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
-      "dev": true,
-      "requires": {
-        "core-js": "^1.0.0",
-        "isomorphic-fetch": "^2.1.1",
-        "loose-envify": "^1.0.0",
-        "object-assign": "^4.1.0",
-        "promise": "^7.1.1",
-        "setimmediate": "^1.0.5",
-        "ua-parser-js": "^0.7.9"
-      }
     },
     "figures": {
       "version": "2.0.0",
@@ -760,32 +711,25 @@
       }
     },
     "find-up": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
       "dev": true,
       "requires": {
-        "path-exists": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
+        "locate-path": "^2.0.0"
       }
     },
     "flat-cache": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
-      "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.4.tgz",
+      "integrity": "sha512-VwyB3Lkgacfik2vhqR4uv2rvebqmDvFu4jlN/C1RzWoJEo8I7z4Q404oiqYCkq41mni8EzQnm95emU9seckwtg==",
       "dev": true,
       "requires": {
         "circular-json": "^0.3.1",
-        "del": "^2.0.2",
         "graceful-fs": "^4.1.2",
+        "rimraf": "~2.6.2",
         "write": "^0.2.1"
       }
-    },
-    "foreach": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
-      "dev": true
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -811,9 +755,9 @@
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
     },
     "glob": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
@@ -825,24 +769,10 @@
       }
     },
     "globals": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-11.3.0.tgz",
-      "integrity": "sha512-kkpcKNlmQan9Z5ZmgqKH/SMbSmjxQ7QjyNqfXVc8VJcoBV2UEg+sxQD15GQofGRh2hfpwUb70VC31DR7Rq5Hdw==",
+      "version": "11.10.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.10.0.tgz",
+      "integrity": "sha512-0GZF1RiPKU97IHUO5TORo9w1PwrH/NBPl+fS7oMLdaTRiYmYbwK4NWoZWrAdd0/abG9R2BU+OiwyQpTpE6pdfQ==",
       "dev": true
-    },
-    "globby": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
-      "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
-      "dev": true,
-      "requires": {
-        "array-union": "^1.0.1",
-        "arrify": "^1.0.0",
-        "glob": "^7.0.3",
-        "object-assign": "^4.0.1",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
-      }
     },
     "got": {
       "version": "6.7.1",
@@ -863,18 +793,18 @@
       }
     },
     "graceful-fs": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
       "dev": true
     },
     "has": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
-      "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "dev": true,
       "requires": {
-        "function-bind": "^1.0.2"
+        "function-bind": "^1.1.1"
       }
     },
     "has-ansi": {
@@ -892,22 +822,31 @@
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
+    "has-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+      "dev": true
+    },
     "hosted-git-info": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
+      "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
       "dev": true
     },
     "iconv-lite": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
-      "dev": true
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
     },
     "ignore": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
-      "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
+      "version": "3.3.10",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+      "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
       "dev": true
     },
     "imurmurhash": {
@@ -960,19 +899,10 @@
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
-    "is-builtin-module": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-      "dev": true,
-      "requires": {
-        "builtin-modules": "^1.0.0"
-      }
-    },
     "is-callable": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
-      "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
       "dev": true
     },
     "is-date-object": {
@@ -986,30 +916,6 @@
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
       "dev": true
-    },
-    "is-path-cwd": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
-      "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
-      "dev": true
-    },
-    "is-path-in-cwd": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
-      "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
-      "dev": true,
-      "requires": {
-        "is-path-inside": "^1.0.0"
-      }
-    },
-    "is-path-inside": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
-      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
-      "dev": true,
-      "requires": {
-        "path-is-inside": "^1.0.1"
-      }
     },
     "is-promise": {
       "version": "2.1.0",
@@ -1048,10 +954,13 @@
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
     "is-symbol": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
-      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
-      "dev": true
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+      "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.0"
+      }
     },
     "isarray": {
       "version": "1.0.0",
@@ -1065,32 +974,10 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
-    "isomorphic-fetch": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
-      "dev": true,
-      "requires": {
-        "node-fetch": "^1.0.1",
-        "whatwg-fetch": ">=0.10.0"
-      },
-      "dependencies": {
-        "node-fetch": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-          "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-          "dev": true,
-          "requires": {
-            "encoding": "^0.1.11",
-            "is-stream": "^1.0.1"
-          }
-        }
-      }
-    },
     "jpeg-js": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.3.3.tgz",
-      "integrity": "sha512-+As71pgzYX+mVcLHCuvFhfn1QKq7tACj1jXbvkkE43VAy2YUN0KNPQxxb3BBSBpqlJh30DPNNbdUR3jc82sacQ=="
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.3.4.tgz",
+      "integrity": "sha512-6IzjQxvnlT8UlklNmDXIJMWxijULjqGrzgqc0OG7YadZdvm7KPQ1j0ehmQQHckgEWOfgpptzcnWgESovxudpTA=="
     },
     "js-tokens": {
       "version": "3.0.2",
@@ -1099,9 +986,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
-      "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.1.tgz",
+      "integrity": "sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
@@ -1159,46 +1046,32 @@
       "requires": {
         "p-locate": "^2.0.0",
         "path-exists": "^3.0.0"
-      },
-      "dependencies": {
-        "path-exists": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-          "dev": true
-        }
       }
     },
     "lodash": {
-      "version": "4.17.5",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
-      "dev": true
-    },
-    "lodash.cond": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/lodash.cond/-/lodash.cond-4.5.2.tgz",
-      "integrity": "sha1-9HGh2khr5g9quVXRcRVSPdHSVdU=",
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
       "dev": true
     },
     "loose-envify": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "dev": true,
       "requires": {
-        "js-tokens": "^3.0.0"
+        "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
     "lowercase-keys": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
-      "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
     },
     "lru-cache": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
       "dev": true,
       "requires": {
         "pseudomap": "^1.0.2",
@@ -1236,9 +1109,9 @@
       }
     },
     "ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
       "dev": true
     },
     "mute-stream": {
@@ -1259,13 +1132,13 @@
       "integrity": "sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA=="
     },
     "normalize-package-data": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
       "dev": true,
       "requires": {
         "hosted-git-info": "^2.1.4",
-        "is-builtin-module": "^1.0.0",
+        "resolve": "^1.10.0",
         "semver": "2 || 3 || 4 || 5",
         "validate-npm-package-license": "^3.0.1"
       }
@@ -1277,10 +1150,22 @@
       "dev": true
     },
     "object-keys": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
-      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
+      "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==",
       "dev": true
+    },
+    "object.fromentries": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.0.tgz",
+      "integrity": "sha512-9iLiI6H083uiqUuvzyY6qrlmc/Gz8hLQFOcb/Ri/0xXFkSNS3ctV+CbE6yM2+AnkYfOB3dGjdzC0wrMLIhQICA==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.11.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.1"
+      }
     },
     "once": {
       "version": "1.4.0",
@@ -1321,9 +1206,9 @@
       "dev": true
     },
     "p-limit": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
-      "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
       "dev": true,
       "requires": {
         "p-try": "^1.0.0"
@@ -1354,13 +1239,10 @@
       }
     },
     "path-exists": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-      "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-      "dev": true,
-      "requires": {
-        "pinkie-promise": "^2.0.0"
-      }
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "dev": true
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -1375,9 +1257,9 @@
       "dev": true
     },
     "path-parse": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
     },
     "path-type": {
@@ -1395,28 +1277,13 @@
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
       "dev": true
     },
-    "pinkie": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-      "dev": true
-    },
-    "pinkie-promise": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "dev": true,
-      "requires": {
-        "pinkie": "^2.0.0"
-      }
-    },
     "pkg-dir": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
-      "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+      "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
       "dev": true,
       "requires": {
-        "find-up": "^1.0.0"
+        "find-up": "^2.1.0"
       }
     },
     "pluralize": {
@@ -1443,27 +1310,17 @@
       "dev": true
     },
     "progress": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
-      "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
-    "promise": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-      "dev": true,
-      "requires": {
-        "asap": "~2.0.3"
-      }
-    },
     "prop-types": {
-      "version": "15.6.0",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.0.tgz",
-      "integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
+      "version": "15.6.2",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
+      "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
       "dev": true,
       "requires": {
-        "fbjs": "^0.8.16",
         "loose-envify": "^1.3.1",
         "object-assign": "^4.1.1"
       }
@@ -1503,23 +1360,12 @@
       "requires": {
         "find-up": "^2.0.0",
         "read-pkg": "^2.0.0"
-      },
-      "dependencies": {
-        "find-up": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-          "dev": true,
-          "requires": {
-            "locate-path": "^2.0.0"
-          }
-        }
       }
     },
     "readable-stream": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.4.tgz",
-      "integrity": "sha512-vuYxeWYM+fde14+rajzqgeohAI7YoJcHE7kXDAc4Nk0EbuKnJfqtY9YtRkLo/tqkuF7MsBQRhPnPeyjYITp3ZQ==",
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "requires": {
         "core-util-is": "~1.0.0",
@@ -1527,9 +1373,15 @@
         "isarray": "~1.0.0",
         "process-nextick-args": "~2.0.0",
         "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.0.3",
+        "string_decoder": "~1.1.1",
         "util-deprecate": "~1.0.1"
       }
+    },
+    "regexpp": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
+      "integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==",
+      "dev": true
     },
     "require-uncached": {
       "version": "1.0.3",
@@ -1542,12 +1394,12 @@
       }
     },
     "resolve": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
-      "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
+      "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
       "dev": true,
       "requires": {
-        "path-parse": "^1.0.5"
+        "path-parse": "^1.0.6"
       }
     },
     "resolve-from": {
@@ -1567,12 +1419,12 @@
       }
     },
     "rimraf": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
       "dev": true,
       "requires": {
-        "glob": "^7.0.5"
+        "glob": "^7.1.3"
       }
     },
     "run-async": {
@@ -1600,20 +1452,20 @@
       }
     },
     "safe-buffer": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
-    "semver": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
-    "setimmediate": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+    "semver": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
       "dev": true
     },
     "shebang-command": {
@@ -1647,24 +1499,35 @@
       }
     },
     "spdx-correct": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-      "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
+      "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
       "dev": true,
       "requires": {
-        "spdx-license-ids": "^1.0.2"
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
       }
     },
-    "spdx-expression-parse": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-      "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
+    "spdx-exceptions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+      "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
       "dev": true
     },
+    "spdx-expression-parse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "dev": true,
+      "requires": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
     "spdx-license-ids": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-      "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.3.tgz",
+      "integrity": "sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g==",
       "dev": true
     },
     "sprintf-js": {
@@ -1684,9 +1547,9 @@
       }
     },
     "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
@@ -1782,21 +1645,15 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
-    "ua-parser-js": {
-      "version": "0.7.17",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
-      "integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g==",
-      "dev": true
-    },
     "unique-random": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unique-random/-/unique-random-1.0.0.tgz",
       "integrity": "sha1-zj4iTIJCzTOg53sNcYDXfmti0MQ="
     },
     "unique-random-array": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unique-random-array/-/unique-random-array-1.0.0.tgz",
-      "integrity": "sha1-QrNyHFeTiNi2Z8k8Lb3j1dgakTY=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/unique-random-array/-/unique-random-array-1.0.1.tgz",
+      "integrity": "sha512-z9J/SV8CUIhIRROcHe9YUoAT6XthUJt0oUyLGgobiXJprDP9O9dsErNevvSaAv5BkhwFEVPn6nIEOKeNE6Ck1Q==",
       "requires": {
         "unique-random": "^1.0.0"
       }
@@ -1821,25 +1678,19 @@
       "dev": true
     },
     "validate-npm-package-license": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-      "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
       "dev": true,
       "requires": {
-        "spdx-correct": "~1.0.0",
-        "spdx-expression-parse": "~1.0.0"
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
       }
     },
-    "whatwg-fetch": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
-      "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ=",
-      "dev": true
-    },
     "which": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "dev": true,
       "requires": {
         "isexe": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "buffer-stream-reader": "^0.1.1",
     "jpeg-js": "^0.3.3",
+    "node-fetch": "^2.3.0",
     "random-puppy": "^1.1.0"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -25,15 +25,6 @@
   "babel": {
     "plugins": [
       [
-        "lodash",
-        {
-          "id": [
-            "lodash",
-            "recompose"
-          ]
-        }
-      ],
-      [
         "module-resolver",
         {
           "root": [
@@ -43,8 +34,7 @@
             "@reactioncommerce/reaction-collections": "./imports/plugins/core/collections",
             "@reactioncommerce/reaction-components": "./imports/plugins/core/components/lib",
             "@reactioncommerce/reaction-router": "./imports/plugins/core/router/lib",
-            "@reactioncommerce/reaction-ui": "./imports/plugins/core/ui/client/components",
-            "underscore": "lodash"
+            "@reactioncommerce/reaction-ui": "./imports/plugins/core/ui/client/components"
           }
         }
       ]

--- a/register.js
+++ b/register.js
@@ -1,4 +1,4 @@
-import { Reaction } from "/server/api";
+import { Reaction } from "/lib/api";
 
 if (process.env.NODE_ENV === "development") {
   // Register package as ReactionCommerce package

--- a/sample-data/data/medium/Products.json
+++ b/sample-data/data/medium/Products.json
@@ -10,8 +10,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -37,7 +37,7 @@
 	"ancestors": [
 		"aKJFQeJtNmGPmM364"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -74,7 +74,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "66.00",
+	"price": 66.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -103,7 +103,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "545.00",
+	"price": 545.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -132,7 +132,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "68.00",
+	"price": 68.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -161,7 +161,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "612.00",
+	"price": 612.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -194,8 +194,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -221,7 +221,7 @@
 	"ancestors": [
 		"rrXuhyosB32PBy6tK"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -258,7 +258,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "432.00",
+	"price": 432.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -291,8 +291,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -318,7 +318,7 @@
 	"ancestors": [
 		"fegdvsry3akBXJ2zL"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -355,7 +355,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "985.00",
+	"price": 985.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -388,8 +388,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -415,7 +415,7 @@
 	"ancestors": [
 		"8mXcqJTjZHPdLSMDt"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -452,7 +452,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "306.00",
+	"price": 306.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -481,7 +481,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "956.00",
+	"price": 956.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -510,7 +510,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "661.00",
+	"price": 661.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -543,8 +543,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -570,7 +570,7 @@
 	"ancestors": [
 		"uC3BSubYxWnMxE9pw"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -607,7 +607,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "921.00",
+	"price": 921.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -640,8 +640,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -667,7 +667,7 @@
 	"ancestors": [
 		"waZN8YzkqJoWCbDar"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -704,7 +704,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "529.00",
+	"price": 529.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -733,7 +733,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "209.00",
+	"price": 209.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -762,7 +762,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "276.00",
+	"price": 276.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -795,8 +795,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -822,7 +822,7 @@
 	"ancestors": [
 		"jrq2saL3YHn5wWaFG"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -859,7 +859,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "364.00",
+	"price": 364.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -888,7 +888,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "602.00",
+	"price": 602.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -921,8 +921,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -948,7 +948,7 @@
 	"ancestors": [
 		"B5bmhoEvdvTwx48Z4"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -985,7 +985,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "47.00",
+	"price": 47.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -1014,7 +1014,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "422.00",
+	"price": 422.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -1047,8 +1047,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -1074,7 +1074,7 @@
 	"ancestors": [
 		"aELvF7679AL2hWmWG"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -1111,7 +1111,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "281.00",
+	"price": 281.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -1144,8 +1144,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -1171,7 +1171,7 @@
 	"ancestors": [
 		"ppGE5EhZQfNXPnMKk"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -1208,7 +1208,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "932.00",
+	"price": 932.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -1237,7 +1237,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "5.00",
+	"price": 5.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -1270,8 +1270,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -1297,7 +1297,7 @@
 	"ancestors": [
 		"AR2qMo5D4wEJDX9bQ"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -1334,7 +1334,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "981.00",
+	"price": 981.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -1367,8 +1367,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -1394,7 +1394,7 @@
 	"ancestors": [
 		"S9w2QXBXpGsSDEqga"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -1431,7 +1431,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "251.00",
+	"price": 251.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -1464,8 +1464,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -1491,7 +1491,7 @@
 	"ancestors": [
 		"h2mg8udfnXJnWM7ck"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -1528,7 +1528,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "587.00",
+	"price": 587.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -1557,7 +1557,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "926.00",
+	"price": 926.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -1586,7 +1586,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "185.00",
+	"price": 185.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -1619,8 +1619,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -1646,7 +1646,7 @@
 	"ancestors": [
 		"FR8fRRNmkdSbmWKef"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -1683,7 +1683,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "50.00",
+	"price": 50.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -1712,7 +1712,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "902.00",
+	"price": 902.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -1745,8 +1745,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -1772,7 +1772,7 @@
 	"ancestors": [
 		"cRZwuDHSBKLgCjHDZ"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -1809,7 +1809,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "380.00",
+	"price": 380.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -1838,7 +1838,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "386.00",
+	"price": 386.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -1867,7 +1867,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "491.00",
+	"price": 491.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -1896,7 +1896,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "950.00",
+	"price": 950.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -1929,8 +1929,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -1956,7 +1956,7 @@
 	"ancestors": [
 		"G4sbbdESBHJeDxnsN"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -1993,7 +1993,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "122.00",
+	"price": 122.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -2022,7 +2022,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "905.00",
+	"price": 905.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -2051,7 +2051,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "775.00",
+	"price": 775.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -2080,7 +2080,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "989.00",
+	"price": 989.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -2113,8 +2113,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -2140,7 +2140,7 @@
 	"ancestors": [
 		"if7SKfKAzQLaQ9Exd"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -2177,7 +2177,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "976.00",
+	"price": 976.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -2210,8 +2210,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -2237,7 +2237,7 @@
 	"ancestors": [
 		"cGbBRhQbcSNqPPqWS"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -2274,7 +2274,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "379.00",
+	"price": 379.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -2303,7 +2303,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "782.00",
+	"price": 782.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -2332,7 +2332,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "214.00",
+	"price": 214.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -2365,8 +2365,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -2392,7 +2392,7 @@
 	"ancestors": [
 		"j82ytxuYL35XdyEMS"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -2429,7 +2429,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "108.00",
+	"price": 108.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -2458,7 +2458,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "791.00",
+	"price": 791.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -2491,8 +2491,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -2518,7 +2518,7 @@
 	"ancestors": [
 		"JEaBHbzkcTNpFxdGk"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -2555,7 +2555,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "699.00",
+	"price": 699.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -2584,7 +2584,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "36.00",
+	"price": 36.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -2613,7 +2613,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "867.00",
+	"price": 867.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -2642,7 +2642,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "307.00",
+	"price": 307.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -2675,8 +2675,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -2702,7 +2702,7 @@
 	"ancestors": [
 		"q95qurEmFLhevDLhr"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -2739,7 +2739,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "92.00",
+	"price": 92.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -2768,7 +2768,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "594.00",
+	"price": 594.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -2801,8 +2801,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -2828,7 +2828,7 @@
 	"ancestors": [
 		"eHcZu5ZvjQ8ffNmbq"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -2865,7 +2865,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "67.00",
+	"price": 67.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -2894,7 +2894,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "235.00",
+	"price": 235.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -2927,8 +2927,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -2954,7 +2954,7 @@
 	"ancestors": [
 		"SQhgk577GPeTnnSMY"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -2991,7 +2991,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "258.00",
+	"price": 258.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -3020,7 +3020,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "755.00",
+	"price": 755.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -3049,7 +3049,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "803.00",
+	"price": 803.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -3082,8 +3082,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -3109,7 +3109,7 @@
 	"ancestors": [
 		"epNS9pqgbXzsAHPxc"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -3146,7 +3146,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "336.00",
+	"price": 336.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -3175,7 +3175,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "604.00",
+	"price": 604.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -3208,8 +3208,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -3235,7 +3235,7 @@
 	"ancestors": [
 		"zXgPXtHMFdbuofT35"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -3272,7 +3272,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "970.00",
+	"price": 970.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -3301,7 +3301,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "480.00",
+	"price": 480.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -3330,7 +3330,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "43.00",
+	"price": 43.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -3363,8 +3363,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -3390,7 +3390,7 @@
 	"ancestors": [
 		"bwJhPFXyomoqZ3zin"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -3427,7 +3427,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "82.00",
+	"price": 82.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -3456,7 +3456,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "668.00",
+	"price": 668.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -3489,8 +3489,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -3516,7 +3516,7 @@
 	"ancestors": [
 		"5jRj63ZeK7eJxWjrE"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -3553,7 +3553,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "791.00",
+	"price": 791.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -3582,7 +3582,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "817.00",
+	"price": 817.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -3611,7 +3611,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "946.00",
+	"price": 946.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -3640,7 +3640,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "143.00",
+	"price": 143.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -3673,8 +3673,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -3700,7 +3700,7 @@
 	"ancestors": [
 		"FZ5uqG2GuJZ5zfj5K"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -3737,7 +3737,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "101.00",
+	"price": 101.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -3766,7 +3766,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "960.00",
+	"price": 960.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -3799,8 +3799,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -3826,7 +3826,7 @@
 	"ancestors": [
 		"K7ez8e4EBLXFsvfGC"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -3863,7 +3863,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "598.00",
+	"price": 598.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -3892,7 +3892,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "322.00",
+	"price": 322.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -3921,7 +3921,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "535.00",
+	"price": 535.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -3950,7 +3950,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "401.00",
+	"price": 401.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -3983,8 +3983,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -4010,7 +4010,7 @@
 	"ancestors": [
 		"s8we293KPBz3ZqWE8"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -4047,7 +4047,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "258.00",
+	"price": 258.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -4076,7 +4076,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "728.00",
+	"price": 728.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -4105,7 +4105,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "509.00",
+	"price": 509.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -4134,7 +4134,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "523.00",
+	"price": 523.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -4167,8 +4167,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -4194,7 +4194,7 @@
 	"ancestors": [
 		"Nvy5CLdTiCYNYaqLn"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -4231,7 +4231,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "574.00",
+	"price": 574.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -4264,8 +4264,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -4291,7 +4291,7 @@
 	"ancestors": [
 		"bE9P6m64s2DmdJpbf"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -4328,7 +4328,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "497.00",
+	"price": 497.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -4357,7 +4357,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "759.00",
+	"price": 759.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -4386,7 +4386,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "203.00",
+	"price": 203.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -4419,8 +4419,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -4446,7 +4446,7 @@
 	"ancestors": [
 		"mxpQjKGWRzeTL9xHc"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -4483,7 +4483,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "398.00",
+	"price": 398.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -4512,7 +4512,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "755.00",
+	"price": 755.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -4541,7 +4541,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "723.00",
+	"price": 723.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -4574,8 +4574,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -4601,7 +4601,7 @@
 	"ancestors": [
 		"aMtepdd67NcTMQgma"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -4638,7 +4638,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "94.00",
+	"price": 94.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -4667,7 +4667,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "925.00",
+	"price": 925.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -4700,8 +4700,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -4727,7 +4727,7 @@
 	"ancestors": [
 		"pZu35WznN3Pq4od8v"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -4764,7 +4764,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "241.00",
+	"price": 241.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -4797,8 +4797,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -4824,7 +4824,7 @@
 	"ancestors": [
 		"veY5wR6f3gGwAbohz"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -4861,7 +4861,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "932.00",
+	"price": 932.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -4890,7 +4890,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "667.00",
+	"price": 667.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -4919,7 +4919,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "323.00",
+	"price": 323.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -4952,8 +4952,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -4979,7 +4979,7 @@
 	"ancestors": [
 		"DLBcCszHRqvqnsq7p"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -5016,7 +5016,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "67.00",
+	"price": 67.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -5049,8 +5049,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -5076,7 +5076,7 @@
 	"ancestors": [
 		"t6ZB4j8NnJ4GREqnw"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -5113,7 +5113,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "861.00",
+	"price": 861.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -5146,8 +5146,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -5173,7 +5173,7 @@
 	"ancestors": [
 		"pDjs9LaiiohoRtL9f"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -5210,7 +5210,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "833.00",
+	"price": 833.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -5239,7 +5239,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "744.00",
+	"price": 744.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -5272,8 +5272,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -5299,7 +5299,7 @@
 	"ancestors": [
 		"DbMahAxw9jQB5ein8"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -5336,7 +5336,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "809.00",
+	"price": 809.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -5369,8 +5369,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -5396,7 +5396,7 @@
 	"ancestors": [
 		"PwKrfEq5bT373fL2X"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -5433,7 +5433,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "61.00",
+	"price": 61.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -5466,8 +5466,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -5493,7 +5493,7 @@
 	"ancestors": [
 		"g2EgfgYoD4sDD8vtX"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -5530,7 +5530,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "812.00",
+	"price": 812.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -5559,7 +5559,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "758.00",
+	"price": 758.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -5592,8 +5592,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -5619,7 +5619,7 @@
 	"ancestors": [
 		"meXAxHtudtNPsCRJo"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -5656,7 +5656,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "253.00",
+	"price": 253.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -5685,7 +5685,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "905.00",
+	"price": 905.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -5714,7 +5714,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "501.00",
+	"price": 501.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -5743,7 +5743,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "340.00",
+	"price": 340.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -5776,8 +5776,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -5803,7 +5803,7 @@
 	"ancestors": [
 		"CjyJmgnKDPHZiJhHZ"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -5840,7 +5840,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "237.00",
+	"price": 237.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -5869,7 +5869,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "664.00",
+	"price": 664.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -5902,8 +5902,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -5929,7 +5929,7 @@
 	"ancestors": [
 		"gDHqZtCsdfR375JFo"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -5966,7 +5966,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "781.00",
+	"price": 781.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -5995,7 +5995,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "937.00",
+	"price": 937.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -6024,7 +6024,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "352.00",
+	"price": 352.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -6057,8 +6057,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -6084,7 +6084,7 @@
 	"ancestors": [
 		"qHjPoLvQprqzB8zPk"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -6121,7 +6121,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "259.00",
+	"price": 259.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -6150,7 +6150,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "761.00",
+	"price": 761.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -6183,8 +6183,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -6210,7 +6210,7 @@
 	"ancestors": [
 		"5Kihds3BDTmt62bEq"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -6247,7 +6247,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "731.00",
+	"price": 731.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -6276,7 +6276,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "211.00",
+	"price": 211.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -6305,7 +6305,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "764.00",
+	"price": 764.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -6334,7 +6334,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "165.00",
+	"price": 165.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -6367,8 +6367,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -6394,7 +6394,7 @@
 	"ancestors": [
 		"pbPyd3GCsMQXyCMhA"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -6431,7 +6431,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "911.00",
+	"price": 911.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -6460,7 +6460,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "825.00",
+	"price": 825.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -6493,8 +6493,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -6520,7 +6520,7 @@
 	"ancestors": [
 		"3PtuqHD3nP4auRwoX"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -6557,7 +6557,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "576.00",
+	"price": 576.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -6586,7 +6586,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "927.00",
+	"price": 927.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -6619,8 +6619,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -6646,7 +6646,7 @@
 	"ancestors": [
 		"ibGcsnGDj4trwuJnd"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -6683,7 +6683,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "133.00",
+	"price": 133.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -6716,8 +6716,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -6743,7 +6743,7 @@
 	"ancestors": [
 		"rZjGkmJekGE2NJm6i"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -6780,7 +6780,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "957.00",
+	"price": 957.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -6813,8 +6813,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -6840,7 +6840,7 @@
 	"ancestors": [
 		"Mvt2ckTNffWdjoL27"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -6877,7 +6877,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "536.00",
+	"price": 536.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -6910,8 +6910,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -6937,7 +6937,7 @@
 	"ancestors": [
 		"XibbBcgwHEqqkNDSa"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -6974,7 +6974,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "153.00",
+	"price": 153.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -7007,8 +7007,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -7034,7 +7034,7 @@
 	"ancestors": [
 		"345WF5NJwxbRR5L8j"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -7071,7 +7071,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "53.00",
+	"price": 53.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -7100,7 +7100,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "860.00",
+	"price": 860.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -7129,7 +7129,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "516.00",
+	"price": 516.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -7162,8 +7162,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -7189,7 +7189,7 @@
 	"ancestors": [
 		"Ru4Jq9gDirQLepvZD"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -7226,7 +7226,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "924.00",
+	"price": 924.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -7259,8 +7259,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -7286,7 +7286,7 @@
 	"ancestors": [
 		"LLc6jCky8B4MBsgj5"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -7323,7 +7323,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "931.00",
+	"price": 931.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -7352,7 +7352,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "833.00",
+	"price": 833.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -7381,7 +7381,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "723.00",
+	"price": 723.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -7414,8 +7414,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -7441,7 +7441,7 @@
 	"ancestors": [
 		"iCzC9CkfdPogdtHr9"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -7478,7 +7478,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "457.00",
+	"price": 457.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -7511,8 +7511,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -7538,7 +7538,7 @@
 	"ancestors": [
 		"NfwH4wgfzx53wZYW2"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -7575,7 +7575,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "110.00",
+	"price": 110.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -7604,7 +7604,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "367.00",
+	"price": 367.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -7633,7 +7633,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "54.00",
+	"price": 54.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -7662,7 +7662,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "727.00",
+	"price": 727.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -7695,8 +7695,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -7722,7 +7722,7 @@
 	"ancestors": [
 		"a3sTfQo2YxiQFbF5m"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -7759,7 +7759,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "734.00",
+	"price": 734.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -7788,7 +7788,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "470.00",
+	"price": 470.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -7821,8 +7821,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -7848,7 +7848,7 @@
 	"ancestors": [
 		"BZcN4avcg2rqtakAc"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -7885,7 +7885,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "735.00",
+	"price": 735.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -7914,7 +7914,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "431.00",
+	"price": 431.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -7947,8 +7947,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -7974,7 +7974,7 @@
 	"ancestors": [
 		"CeChg8w5xcbAz9XBx"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -8011,7 +8011,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "340.00",
+	"price": 340.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -8040,7 +8040,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "331.00",
+	"price": 331.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -8069,7 +8069,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "1000.00",
+	"price": 1000.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -8098,7 +8098,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "607.00",
+	"price": 607.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -8131,8 +8131,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -8158,7 +8158,7 @@
 	"ancestors": [
 		"CrJgoRqfPZJsED5KE"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -8195,7 +8195,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "483.00",
+	"price": 483.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -8224,7 +8224,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "317.00",
+	"price": 317.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -8253,7 +8253,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "762.00",
+	"price": 762.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -8282,7 +8282,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "903.00",
+	"price": 903.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -8315,8 +8315,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -8342,7 +8342,7 @@
 	"ancestors": [
 		"Z2kcCn2uCwaWBkWPs"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -8379,7 +8379,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "504.00",
+	"price": 504.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -8412,8 +8412,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -8439,7 +8439,7 @@
 	"ancestors": [
 		"dHAbxTRBSBYEnW5wQ"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -8476,7 +8476,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "303.00",
+	"price": 303.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -8505,7 +8505,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "339.00",
+	"price": 339.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -8534,7 +8534,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "139.00",
+	"price": 139.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -8563,7 +8563,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "779.00",
+	"price": 779.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -8596,8 +8596,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -8623,7 +8623,7 @@
 	"ancestors": [
 		"qN6MEdwzu9a2JzupD"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -8660,7 +8660,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "725.00",
+	"price": 725.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -8689,7 +8689,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "113.00",
+	"price": 113.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -8718,7 +8718,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "91.00",
+	"price": 91.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -8751,8 +8751,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -8778,7 +8778,7 @@
 	"ancestors": [
 		"ExhbxMzhARMtjJToz"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -8815,7 +8815,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "768.00",
+	"price": 768.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -8844,7 +8844,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "189.00",
+	"price": 189.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -8877,8 +8877,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -8904,7 +8904,7 @@
 	"ancestors": [
 		"QxGjusx8Le3jb37HA"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -8941,7 +8941,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "58.00",
+	"price": 58.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -8970,7 +8970,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "436.00",
+	"price": 436.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -8999,7 +8999,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "763.00",
+	"price": 763.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -9028,7 +9028,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "904.00",
+	"price": 904.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -9061,8 +9061,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -9088,7 +9088,7 @@
 	"ancestors": [
 		"jcCJxkHgWdaGm5GCH"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -9125,7 +9125,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "466.00",
+	"price": 466.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -9154,7 +9154,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "259.00",
+	"price": 259.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -9187,8 +9187,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -9214,7 +9214,7 @@
 	"ancestors": [
 		"2nbgqDe6R6JZZBCTj"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -9251,7 +9251,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "943.00",
+	"price": 943.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -9284,8 +9284,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -9311,7 +9311,7 @@
 	"ancestors": [
 		"JZqpCGyD3PSMCxrW2"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -9348,7 +9348,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "431.00",
+	"price": 431.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -9377,7 +9377,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "776.00",
+	"price": 776.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -9410,8 +9410,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -9437,7 +9437,7 @@
 	"ancestors": [
 		"WbMPgratHKydHB77t"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -9474,7 +9474,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "849.00",
+	"price": 849.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -9503,7 +9503,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "257.00",
+	"price": 257.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -9532,7 +9532,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "584.00",
+	"price": 584.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -9565,8 +9565,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -9592,7 +9592,7 @@
 	"ancestors": [
 		"7KJAZoxa2Cy3RRmeQ"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -9629,7 +9629,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "866.00",
+	"price": 866.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -9658,7 +9658,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "753.00",
+	"price": 753.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -9691,8 +9691,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -9718,7 +9718,7 @@
 	"ancestors": [
 		"azR5jEY5NsB6rWxHS"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -9755,7 +9755,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "969.00",
+	"price": 969.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -9784,7 +9784,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "226.00",
+	"price": 226.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -9813,7 +9813,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "305.00",
+	"price": 305.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -9846,8 +9846,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -9873,7 +9873,7 @@
 	"ancestors": [
 		"Lt3nnM4MXWHtA7QJb"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -9910,7 +9910,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "495.00",
+	"price": 495.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -9939,7 +9939,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "743.00",
+	"price": 743.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -9972,8 +9972,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -9999,7 +9999,7 @@
 	"ancestors": [
 		"mGYzCqMMjCjZFZyks"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -10036,7 +10036,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "532.00",
+	"price": 532.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -10069,8 +10069,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -10096,7 +10096,7 @@
 	"ancestors": [
 		"tMtC6ATWm5ecGwDkc"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -10133,7 +10133,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "687.00",
+	"price": 687.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -10162,7 +10162,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "995.00",
+	"price": 995.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -10195,8 +10195,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -10222,7 +10222,7 @@
 	"ancestors": [
 		"PtuTwe429XPSCSbHL"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -10259,7 +10259,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "396.00",
+	"price": 396.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -10288,7 +10288,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "299.00",
+	"price": 299.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -10317,7 +10317,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "998.00",
+	"price": 998.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -10346,7 +10346,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "492.00",
+	"price": 492.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -10379,8 +10379,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -10406,7 +10406,7 @@
 	"ancestors": [
 		"8knmfbwFK9N4qDbnK"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -10443,7 +10443,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "931.00",
+	"price": 931.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -10472,7 +10472,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "637.00",
+	"price": 637.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -10501,7 +10501,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "10.00",
+	"price": 10.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -10534,8 +10534,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -10561,7 +10561,7 @@
 	"ancestors": [
 		"7qhtQCtbd8Ka8LbbP"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -10598,7 +10598,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "74.00",
+	"price": 74.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -10627,7 +10627,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "649.00",
+	"price": 649.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -10656,7 +10656,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "60.00",
+	"price": 60.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -10689,8 +10689,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -10716,7 +10716,7 @@
 	"ancestors": [
 		"8g4P8FzkfNwiYLQ8G"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -10753,7 +10753,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "370.00",
+	"price": 370.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -10782,7 +10782,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "358.00",
+	"price": 358.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -10811,7 +10811,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "123.00",
+	"price": 123.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -10840,7 +10840,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "167.00",
+	"price": 167.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -10873,8 +10873,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -10900,7 +10900,7 @@
 	"ancestors": [
 		"uSL5ocsMgSF4Z3ikh"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -10937,7 +10937,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "343.00",
+	"price": 343.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -10966,7 +10966,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "766.00",
+	"price": 766.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -10995,7 +10995,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "407.00",
+	"price": 407.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -11028,8 +11028,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -11055,7 +11055,7 @@
 	"ancestors": [
 		"wvKR7Xu4Qe92QP5ka"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -11092,7 +11092,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "594.00",
+	"price": 594.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -11121,7 +11121,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "3.00",
+	"price": 3.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -11150,7 +11150,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "282.00",
+	"price": 282.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -11183,8 +11183,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -11210,7 +11210,7 @@
 	"ancestors": [
 		"4dEAqwC6amiMW5BMn"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -11247,7 +11247,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "856.00",
+	"price": 856.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -11276,7 +11276,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "130.00",
+	"price": 130.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -11305,7 +11305,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "874.00",
+	"price": 874.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -11334,7 +11334,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "932.00",
+	"price": 932.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -11367,8 +11367,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -11394,7 +11394,7 @@
 	"ancestors": [
 		"Lj32BSPY4aujhHhpg"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -11431,7 +11431,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "135.00",
+	"price": 135.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -11460,7 +11460,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "847.00",
+	"price": 847.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -11489,7 +11489,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "689.00",
+	"price": 689.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -11522,8 +11522,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -11549,7 +11549,7 @@
 	"ancestors": [
 		"bkcumPzmwF8XAq5Z9"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -11586,7 +11586,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "176.00",
+	"price": 176.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -11615,7 +11615,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "879.00",
+	"price": 879.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -11648,8 +11648,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -11675,7 +11675,7 @@
 	"ancestors": [
 		"jZ6i6Hn64w48K2x9Y"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -11712,7 +11712,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "379.00",
+	"price": 379.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -11741,7 +11741,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "933.00",
+	"price": 933.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -11770,7 +11770,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "721.00",
+	"price": 721.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -11803,8 +11803,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -11830,7 +11830,7 @@
 	"ancestors": [
 		"EjuWcru9otrLB94fe"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -11867,7 +11867,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "390.00",
+	"price": 390.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -11896,7 +11896,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "457.00",
+	"price": 457.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -11929,8 +11929,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -11956,7 +11956,7 @@
 	"ancestors": [
 		"TdGjzrADdijjMrans"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -11993,7 +11993,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "101.00",
+	"price": 101.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -12022,7 +12022,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "103.00",
+	"price": 103.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -12055,8 +12055,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -12082,7 +12082,7 @@
 	"ancestors": [
 		"iJsWF9Kw4JkKYx3eo"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -12119,7 +12119,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "554.00",
+	"price": 554.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -12148,7 +12148,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "862.00",
+	"price": 862.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -12177,7 +12177,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "988.00",
+	"price": 988.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -12210,8 +12210,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -12237,7 +12237,7 @@
 	"ancestors": [
 		"YzRx4hRtndMe8AxnQ"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -12274,7 +12274,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "734.00",
+	"price": 734.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -12303,7 +12303,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "58.00",
+	"price": 58.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -12336,8 +12336,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -12363,7 +12363,7 @@
 	"ancestors": [
 		"StbCBGiNPaaiZvTT7"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -12400,7 +12400,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "279.00",
+	"price": 279.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -12429,7 +12429,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "969.00",
+	"price": 969.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -12458,7 +12458,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "715.00",
+	"price": 715.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -12491,8 +12491,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -12518,7 +12518,7 @@
 	"ancestors": [
 		"mdhdxJXneGSwz7n7X"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -12555,7 +12555,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "612.00",
+	"price": 612.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -12584,7 +12584,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "368.00",
+	"price": 368.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -12613,7 +12613,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "13.00",
+	"price": 13.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -12646,8 +12646,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -12673,7 +12673,7 @@
 	"ancestors": [
 		"EavidAPBdb3hGqEkQ"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -12710,7 +12710,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "72.00",
+	"price": 72.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -12743,8 +12743,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -12770,7 +12770,7 @@
 	"ancestors": [
 		"uAzfZkAfLrvwy9nXT"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -12807,7 +12807,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "620.00",
+	"price": 620.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -12840,8 +12840,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -12867,7 +12867,7 @@
 	"ancestors": [
 		"2YujjjTMJDk9eFG2Z"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -12904,7 +12904,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "156.00",
+	"price": 156.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -12933,7 +12933,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "833.00",
+	"price": 833.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -12962,7 +12962,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "422.00",
+	"price": 422.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -12995,8 +12995,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -13022,7 +13022,7 @@
 	"ancestors": [
 		"SpDZLKXgaMbNMJtKj"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -13059,7 +13059,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "63.00",
+	"price": 63.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -13088,7 +13088,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "941.00",
+	"price": 941.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -13117,7 +13117,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "640.00",
+	"price": 640.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -13146,7 +13146,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "290.00",
+	"price": 290.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -13179,8 +13179,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -13206,7 +13206,7 @@
 	"ancestors": [
 		"HNR9DyvQ5HJe7hBEy"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -13243,7 +13243,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "178.00",
+	"price": 178.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -13276,8 +13276,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -13303,7 +13303,7 @@
 	"ancestors": [
 		"8R96EZMte2qrsNXCm"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -13340,7 +13340,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "209.00",
+	"price": 209.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -13373,8 +13373,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -13400,7 +13400,7 @@
 	"ancestors": [
 		"PB6M3Dv4seBWCuDXy"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -13437,7 +13437,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "706.00",
+	"price": 706.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -13466,7 +13466,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "211.00",
+	"price": 211.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -13495,7 +13495,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "343.00",
+	"price": 343.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -13528,8 +13528,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -13555,7 +13555,7 @@
 	"ancestors": [
 		"Y5SYqdo48crHRJzsq"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -13592,7 +13592,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "493.00",
+	"price": 493.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -13621,7 +13621,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "116.00",
+	"price": 116.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -13650,7 +13650,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "960.00",
+	"price": 960.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -13679,7 +13679,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "983.00",
+	"price": 983.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -13712,8 +13712,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -13739,7 +13739,7 @@
 	"ancestors": [
 		"6pi4gaKBuufDnuRge"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -13776,7 +13776,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "607.00",
+	"price": 607.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -13805,7 +13805,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "150.00",
+	"price": 150.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -13834,7 +13834,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "852.00",
+	"price": 852.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -13863,7 +13863,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "438.00",
+	"price": 438.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -13896,8 +13896,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -13923,7 +13923,7 @@
 	"ancestors": [
 		"ztZzbPGSi4iRsN8fb"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -13960,7 +13960,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "1000.00",
+	"price": 1000.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -13989,7 +13989,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "588.00",
+	"price": 588.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -14018,7 +14018,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "634.00",
+	"price": 634.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -14047,7 +14047,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "48.00",
+	"price": 48.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -14080,8 +14080,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -14107,7 +14107,7 @@
 	"ancestors": [
 		"vGQtCb9Am8kyLfvEw"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -14144,7 +14144,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "749.00",
+	"price": 749.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -14173,7 +14173,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "91.00",
+	"price": 91.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -14202,7 +14202,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "549.00",
+	"price": 549.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -14235,8 +14235,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -14262,7 +14262,7 @@
 	"ancestors": [
 		"rYsWiqACdQC9XZnns"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -14299,7 +14299,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "310.00",
+	"price": 310.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -14328,7 +14328,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "659.00",
+	"price": 659.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -14357,7 +14357,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "928.00",
+	"price": 928.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -14390,8 +14390,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -14417,7 +14417,7 @@
 	"ancestors": [
 		"9F7ha8cjXCwZ5PrEz"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -14454,7 +14454,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "965.00",
+	"price": 965.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -14483,7 +14483,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "759.00",
+	"price": 759.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -14512,7 +14512,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "866.00",
+	"price": 866.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -14541,7 +14541,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "998.00",
+	"price": 998.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -14574,8 +14574,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -14601,7 +14601,7 @@
 	"ancestors": [
 		"g9xRXvrZerjYqAQSa"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -14638,7 +14638,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "167.00",
+	"price": 167.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -14667,7 +14667,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "751.00",
+	"price": 751.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -14700,8 +14700,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -14727,7 +14727,7 @@
 	"ancestors": [
 		"cRjheYjeAiCu7Xoh4"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -14764,7 +14764,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "991.00",
+	"price": 991.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -14793,7 +14793,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "258.00",
+	"price": 258.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -14822,7 +14822,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "407.00",
+	"price": 407.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -14851,7 +14851,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "734.00",
+	"price": 734.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -14884,8 +14884,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -14911,7 +14911,7 @@
 	"ancestors": [
 		"uG9EEHfpqEGN8jhph"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -14948,7 +14948,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "409.00",
+	"price": 409.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -14977,7 +14977,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "612.00",
+	"price": 612.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -15006,7 +15006,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "471.00",
+	"price": 471.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -15039,8 +15039,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -15066,7 +15066,7 @@
 	"ancestors": [
 		"yfx6YSQeRyxH3m6m2"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -15103,7 +15103,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "788.00",
+	"price": 788.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -15132,7 +15132,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "218.00",
+	"price": 218.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -15161,7 +15161,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "16.00",
+	"price": 16.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -15194,8 +15194,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -15221,7 +15221,7 @@
 	"ancestors": [
 		"ZjuvfXDBd3JyZLjhX"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -15258,7 +15258,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "250.00",
+	"price": 250.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -15287,7 +15287,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "50.00",
+	"price": 50.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -15316,7 +15316,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "665.00",
+	"price": 665.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -15349,8 +15349,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -15376,7 +15376,7 @@
 	"ancestors": [
 		"rp8Ttf8Muj8LCt2k5"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -15413,7 +15413,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "783.00",
+	"price": 783.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -15442,7 +15442,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "987.00",
+	"price": 987.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -15471,7 +15471,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "489.00",
+	"price": 489.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -15504,8 +15504,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -15531,7 +15531,7 @@
 	"ancestors": [
 		"fSmS5noJsjcP3Qde9"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -15568,7 +15568,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "861.00",
+	"price": 861.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -15597,7 +15597,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "96.00",
+	"price": 96.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -15630,8 +15630,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -15657,7 +15657,7 @@
 	"ancestors": [
 		"twWNyKkTptTdApqch"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -15694,7 +15694,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "429.00",
+	"price": 429.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -15727,8 +15727,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -15754,7 +15754,7 @@
 	"ancestors": [
 		"ewj6EbgpFpYRcpywa"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -15791,7 +15791,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "870.00",
+	"price": 870.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -15820,7 +15820,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "935.00",
+	"price": 935.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -15853,8 +15853,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -15880,7 +15880,7 @@
 	"ancestors": [
 		"Wt9cKF99h9kpYe7W3"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -15917,7 +15917,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "619.00",
+	"price": 619.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -15950,8 +15950,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -15977,7 +15977,7 @@
 	"ancestors": [
 		"bRbfG3mn7NohX5GHH"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -16014,7 +16014,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "636.00",
+	"price": 636.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -16043,7 +16043,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "60.00",
+	"price": 60.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -16076,8 +16076,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -16103,7 +16103,7 @@
 	"ancestors": [
 		"MX2ZLmAnMzTTc4W7F"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -16140,7 +16140,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "858.00",
+	"price": 858.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -16169,7 +16169,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "520.00",
+	"price": 520.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -16198,7 +16198,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "59.00",
+	"price": 59.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -16227,7 +16227,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "746.00",
+	"price": 746.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -16260,8 +16260,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -16287,7 +16287,7 @@
 	"ancestors": [
 		"CQsYYc2Wd4HpwYyY6"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -16324,7 +16324,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "104.00",
+	"price": 104.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -16353,7 +16353,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "431.00",
+	"price": 431.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -16386,8 +16386,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -16413,7 +16413,7 @@
 	"ancestors": [
 		"joCsbThukYi6M5heX"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -16450,7 +16450,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "314.00",
+	"price": 314.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -16479,7 +16479,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "478.00",
+	"price": 478.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -16508,7 +16508,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "850.00",
+	"price": 850.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -16537,7 +16537,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "966.00",
+	"price": 966.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -16570,8 +16570,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -16597,7 +16597,7 @@
 	"ancestors": [
 		"9MJNLpxyKvWewk8ik"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -16634,7 +16634,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "473.00",
+	"price": 473.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -16663,7 +16663,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "713.00",
+	"price": 713.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -16696,8 +16696,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -16723,7 +16723,7 @@
 	"ancestors": [
 		"BzYWmMhRfHXYbNARb"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -16760,7 +16760,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "473.00",
+	"price": 473.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -16789,7 +16789,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "631.00",
+	"price": 631.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -16822,8 +16822,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -16849,7 +16849,7 @@
 	"ancestors": [
 		"5KBtZ8QxgX8AXM3FN"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -16886,7 +16886,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "705.00",
+	"price": 705.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -16915,7 +16915,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "477.00",
+	"price": 477.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -16948,8 +16948,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -16975,7 +16975,7 @@
 	"ancestors": [
 		"aKrh93z8gGSZbgd7D"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -17012,7 +17012,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "414.00",
+	"price": 414.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -17041,7 +17041,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "552.00",
+	"price": 552.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -17070,7 +17070,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "82.00",
+	"price": 82.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -17103,8 +17103,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -17130,7 +17130,7 @@
 	"ancestors": [
 		"vow2LAAsbfbpuzRnA"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -17167,7 +17167,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "789.00",
+	"price": 789.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -17196,7 +17196,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "121.00",
+	"price": 121.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -17229,8 +17229,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -17256,7 +17256,7 @@
 	"ancestors": [
 		"37r2ME3FvJ5729qtS"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -17293,7 +17293,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "415.00",
+	"price": 415.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -17326,8 +17326,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -17353,7 +17353,7 @@
 	"ancestors": [
 		"rkZTbHYTtko9mSMAx"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -17390,7 +17390,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "630.00",
+	"price": 630.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -17419,7 +17419,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "132.00",
+	"price": 132.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -17448,7 +17448,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "883.00",
+	"price": 883.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -17477,7 +17477,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "49.00",
+	"price": 49.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -17510,8 +17510,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -17537,7 +17537,7 @@
 	"ancestors": [
 		"oEfwpwK7N7EngiMiY"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -17574,7 +17574,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "160.00",
+	"price": 160.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -17603,7 +17603,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "685.00",
+	"price": 685.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -17632,7 +17632,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "392.00",
+	"price": 392.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -17665,8 +17665,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -17692,7 +17692,7 @@
 	"ancestors": [
 		"vWCRTERo4nTFpHNcE"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -17729,7 +17729,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "993.00",
+	"price": 993.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -17758,7 +17758,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "749.00",
+	"price": 749.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -17791,8 +17791,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -17818,7 +17818,7 @@
 	"ancestors": [
 		"xHot4mBBDMu9RN89w"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -17855,7 +17855,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "906.00",
+	"price": 906.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -17884,7 +17884,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "616.00",
+	"price": 616.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -17913,7 +17913,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "952.00",
+	"price": 952.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -17946,8 +17946,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -17973,7 +17973,7 @@
 	"ancestors": [
 		"o956pvipwjeqSgr7M"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -18010,7 +18010,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "339.00",
+	"price": 339.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -18039,7 +18039,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "458.00",
+	"price": 458.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -18068,7 +18068,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "334.00",
+	"price": 334.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -18097,7 +18097,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "109.00",
+	"price": 109.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -18130,8 +18130,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -18157,7 +18157,7 @@
 	"ancestors": [
 		"JosckbGax5bu8cTd5"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -18194,7 +18194,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "361.00",
+	"price": 361.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -18227,8 +18227,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -18254,7 +18254,7 @@
 	"ancestors": [
 		"jhq2tGeCtCAuEcLuv"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -18291,7 +18291,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "371.00",
+	"price": 371.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -18320,7 +18320,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "889.00",
+	"price": 889.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -18353,8 +18353,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -18380,7 +18380,7 @@
 	"ancestors": [
 		"tA5vFnnnRNeGYyp2b"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -18417,7 +18417,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "477.00",
+	"price": 477.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -18446,7 +18446,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "469.00",
+	"price": 469.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -18475,7 +18475,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "935.00",
+	"price": 935.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -18504,7 +18504,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "11.00",
+	"price": 11.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -18537,8 +18537,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -18564,7 +18564,7 @@
 	"ancestors": [
 		"kyhir9wjXhm7AfW4c"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -18601,7 +18601,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "173.00",
+	"price": 173.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -18630,7 +18630,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "515.00",
+	"price": 515.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -18663,8 +18663,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -18690,7 +18690,7 @@
 	"ancestors": [
 		"iKFBj7KNxvkEJSaSD"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -18727,7 +18727,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "147.00",
+	"price": 147.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -18756,7 +18756,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "12.00",
+	"price": 12.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -18785,7 +18785,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "459.00",
+	"price": 459.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -18818,8 +18818,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -18845,7 +18845,7 @@
 	"ancestors": [
 		"gbDARXiteeEnhF6Fn"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -18882,7 +18882,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "424.00",
+	"price": 424.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -18915,8 +18915,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -18942,7 +18942,7 @@
 	"ancestors": [
 		"5ghNk9bdvo8qsfitF"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -18979,7 +18979,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "229.00",
+	"price": 229.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -19008,7 +19008,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "469.00",
+	"price": 469.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -19037,7 +19037,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "49.00",
+	"price": 49.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -19070,8 +19070,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -19097,7 +19097,7 @@
 	"ancestors": [
 		"hAQiMNP4gQkcXBRow"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -19134,7 +19134,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "437.00",
+	"price": 437.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -19163,7 +19163,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "706.00",
+	"price": 706.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -19196,8 +19196,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -19223,7 +19223,7 @@
 	"ancestors": [
 		"iuiaeqy4NewwDqKBk"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -19260,7 +19260,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "634.00",
+	"price": 634.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -19289,7 +19289,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "825.00",
+	"price": 825.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -19322,8 +19322,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -19349,7 +19349,7 @@
 	"ancestors": [
 		"ZcWPdWyTiiyJEnMJa"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -19386,7 +19386,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "508.00",
+	"price": 508.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -19419,8 +19419,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -19446,7 +19446,7 @@
 	"ancestors": [
 		"C3kbHRaXm65JHy4cf"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -19483,7 +19483,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "371.00",
+	"price": 371.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -19512,7 +19512,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "870.00",
+	"price": 870.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -19545,8 +19545,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -19572,7 +19572,7 @@
 	"ancestors": [
 		"rf7n63d2gCzWXzXbj"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -19609,7 +19609,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "201.00",
+	"price": 201.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -19638,7 +19638,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "33.00",
+	"price": 33.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -19667,7 +19667,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "886.00",
+	"price": 886.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -19700,8 +19700,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -19727,7 +19727,7 @@
 	"ancestors": [
 		"QauDRpb79xsop5Wh7"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -19764,7 +19764,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "969.00",
+	"price": 969.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -19793,7 +19793,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "564.00",
+	"price": 564.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -19822,7 +19822,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "629.00",
+	"price": 629.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -19851,7 +19851,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "857.00",
+	"price": 857.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -19884,8 +19884,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -19911,7 +19911,7 @@
 	"ancestors": [
 		"tmwxuigMHeZHSuKdG"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -19948,7 +19948,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "697.00",
+	"price": 697.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -19977,7 +19977,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "653.00",
+	"price": 653.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -20010,8 +20010,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -20037,7 +20037,7 @@
 	"ancestors": [
 		"KHnDepaMd62arK3iE"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -20074,7 +20074,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "697.00",
+	"price": 697.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -20103,7 +20103,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "842.00",
+	"price": 842.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -20136,8 +20136,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -20163,7 +20163,7 @@
 	"ancestors": [
 		"M2mB2vhv3MiAvpi3s"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -20200,7 +20200,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "749.00",
+	"price": 749.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -20229,7 +20229,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "714.00",
+	"price": 714.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -20258,7 +20258,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "375.00",
+	"price": 375.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -20291,8 +20291,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -20318,7 +20318,7 @@
 	"ancestors": [
 		"NyPR8EJxemJ9kWoaJ"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -20355,7 +20355,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "177.00",
+	"price": 177.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -20384,7 +20384,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "307.00",
+	"price": 307.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -20417,8 +20417,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -20444,7 +20444,7 @@
 	"ancestors": [
 		"mu2EjxS788J56mpMa"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -20481,7 +20481,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "944.00",
+	"price": 944.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -20510,7 +20510,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "954.00",
+	"price": 954.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -20539,7 +20539,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "694.00",
+	"price": 694.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -20568,7 +20568,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "445.00",
+	"price": 445.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -20601,8 +20601,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -20628,7 +20628,7 @@
 	"ancestors": [
 		"g7PWA3i3wPTu9GhxJ"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -20665,7 +20665,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "91.00",
+	"price": 91.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -20694,7 +20694,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "156.00",
+	"price": 156.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -20723,7 +20723,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "994.00",
+	"price": 994.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -20752,7 +20752,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "498.00",
+	"price": 498.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -20785,8 +20785,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -20812,7 +20812,7 @@
 	"ancestors": [
 		"HCpKDapTKuBGHe2vy"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -20849,7 +20849,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "963.00",
+	"price": 963.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -20878,7 +20878,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "578.00",
+	"price": 578.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -20911,8 +20911,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -20938,7 +20938,7 @@
 	"ancestors": [
 		"vAsT4XrvdHLhC3oxE"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -20975,7 +20975,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "10.00",
+	"price": 10.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -21008,8 +21008,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -21035,7 +21035,7 @@
 	"ancestors": [
 		"W4uWZt77qJu6uLv7d"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -21072,7 +21072,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "0.00",
+	"price": 0.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -21101,7 +21101,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "669.00",
+	"price": 669.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -21130,7 +21130,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "835.00",
+	"price": 835.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -21163,8 +21163,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -21190,7 +21190,7 @@
 	"ancestors": [
 		"EMsba6K6dZcCrzuFg"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -21227,7 +21227,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "738.00",
+	"price": 738.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -21256,7 +21256,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "642.00",
+	"price": 642.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -21289,8 +21289,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -21316,7 +21316,7 @@
 	"ancestors": [
 		"8TvL4Hai3gmPjF7Si"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -21353,7 +21353,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "301.00",
+	"price": 301.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -21382,7 +21382,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "165.00",
+	"price": 165.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -21411,7 +21411,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "152.00",
+	"price": 152.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -21440,7 +21440,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "81.00",
+	"price": 81.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -21473,8 +21473,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -21500,7 +21500,7 @@
 	"ancestors": [
 		"HHJW3QKycnSgyLH5j"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -21537,7 +21537,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "378.00",
+	"price": 378.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -21570,8 +21570,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -21597,7 +21597,7 @@
 	"ancestors": [
 		"DiiPJXjeXzjYnk76X"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -21634,7 +21634,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "337.00",
+	"price": 337.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -21663,7 +21663,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "648.00",
+	"price": 648.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -21692,7 +21692,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "693.00",
+	"price": 693.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -21725,8 +21725,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -21752,7 +21752,7 @@
 	"ancestors": [
 		"AJAwLbfZyEFmcPpzv"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -21789,7 +21789,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "302.00",
+	"price": 302.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -21818,7 +21818,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "1000.00",
+	"price": 1000.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -21847,7 +21847,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "322.00",
+	"price": 322.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -21880,8 +21880,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -21907,7 +21907,7 @@
 	"ancestors": [
 		"GEHWwoLWP9FbewgiJ"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -21944,7 +21944,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "530.00",
+	"price": 530.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -21977,8 +21977,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -22004,7 +22004,7 @@
 	"ancestors": [
 		"FLJXJ9akHHbasAZzj"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -22041,7 +22041,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "75.00",
+	"price": 75.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -22070,7 +22070,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "774.00",
+	"price": 774.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -22099,7 +22099,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "53.00",
+	"price": 53.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -22132,8 +22132,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -22159,7 +22159,7 @@
 	"ancestors": [
 		"wn3Yu66roM5wRwTin"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -22196,7 +22196,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "638.00",
+	"price": 638.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -22225,7 +22225,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "761.00",
+	"price": 761.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -22258,8 +22258,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -22285,7 +22285,7 @@
 	"ancestors": [
 		"4LeXkyju7YqB3FxNC"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -22322,7 +22322,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "488.00",
+	"price": 488.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -22355,8 +22355,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -22382,7 +22382,7 @@
 	"ancestors": [
 		"pE2FdLLkBHyKPZpzk"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -22419,7 +22419,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "15.00",
+	"price": 15.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -22448,7 +22448,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "150.00",
+	"price": 150.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -22477,7 +22477,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "643.00",
+	"price": 643.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -22510,8 +22510,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -22537,7 +22537,7 @@
 	"ancestors": [
 		"yNh32kccWYuYJnZAN"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -22574,7 +22574,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "101.00",
+	"price": 101.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -22607,8 +22607,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -22634,7 +22634,7 @@
 	"ancestors": [
 		"3ybTi6gBL57iumN4B"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -22671,7 +22671,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "714.00",
+	"price": 714.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -22704,8 +22704,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -22731,7 +22731,7 @@
 	"ancestors": [
 		"5B2zh2KnMATYm6rvE"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -22768,7 +22768,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "93.00",
+	"price": 93.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -22797,7 +22797,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "914.00",
+	"price": 914.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -22826,7 +22826,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "270.00",
+	"price": 270.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -22855,7 +22855,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "92.00",
+	"price": 92.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -22888,8 +22888,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -22915,7 +22915,7 @@
 	"ancestors": [
 		"FbzabM9aHtc3kNdoE"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -22952,7 +22952,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "624.00",
+	"price": 624.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -22981,7 +22981,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "334.00",
+	"price": 334.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -23014,8 +23014,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -23041,7 +23041,7 @@
 	"ancestors": [
 		"Y7m936fYWHNSA7CTG"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -23078,7 +23078,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "664.00",
+	"price": 664.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -23111,8 +23111,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -23138,7 +23138,7 @@
 	"ancestors": [
 		"YsJZ5pTy6brqogq7m"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -23175,7 +23175,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "568.00",
+	"price": 568.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -23204,7 +23204,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "386.00",
+	"price": 386.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -23233,7 +23233,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "24.00",
+	"price": 24.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -23266,8 +23266,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -23293,7 +23293,7 @@
 	"ancestors": [
 		"bMGfbSXxdHhC9yLhC"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -23330,7 +23330,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "878.00",
+	"price": 878.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -23359,7 +23359,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "887.00",
+	"price": 887.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -23388,7 +23388,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "536.00",
+	"price": 536.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -23417,7 +23417,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "572.00",
+	"price": 572.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -23450,8 +23450,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -23477,7 +23477,7 @@
 	"ancestors": [
 		"zoBwMBS6fqJsuW34X"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -23514,7 +23514,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "201.00",
+	"price": 201.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -23543,7 +23543,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "487.00",
+	"price": 487.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -23576,8 +23576,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -23603,7 +23603,7 @@
 	"ancestors": [
 		"tK8kwCoJBqseHYQHu"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -23640,7 +23640,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "537.00",
+	"price": 537.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -23669,7 +23669,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "904.00",
+	"price": 904.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -23698,7 +23698,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "110.00",
+	"price": 110.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -23731,8 +23731,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -23758,7 +23758,7 @@
 	"ancestors": [
 		"DWkbHMZbDe4jdQxqF"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -23795,7 +23795,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "937.00",
+	"price": 937.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -23824,7 +23824,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "870.00",
+	"price": 870.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -23853,7 +23853,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "671.00",
+	"price": 671.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -23886,8 +23886,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -23913,7 +23913,7 @@
 	"ancestors": [
 		"vQHNCsDhkeYPrnyje"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -23950,7 +23950,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "995.00",
+	"price": 995.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -23979,7 +23979,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "426.00",
+	"price": 426.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -24008,7 +24008,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "212.00",
+	"price": 212.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -24041,8 +24041,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -24068,7 +24068,7 @@
 	"ancestors": [
 		"Gom7NnAi2X6kc4oFh"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -24105,7 +24105,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "392.00",
+	"price": 392.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -24134,7 +24134,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "927.00",
+	"price": 927.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -24163,7 +24163,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "160.00",
+	"price": 160.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -24192,7 +24192,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "941.00",
+	"price": 941.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -24225,8 +24225,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -24252,7 +24252,7 @@
 	"ancestors": [
 		"XSCKEBT89ryjoE6gN"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -24289,7 +24289,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "69.00",
+	"price": 69.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -24318,7 +24318,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "501.00",
+	"price": 501.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -24347,7 +24347,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "887.00",
+	"price": 887.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -24380,8 +24380,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -24407,7 +24407,7 @@
 	"ancestors": [
 		"cms3RDzrBP95vF9kp"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -24444,7 +24444,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "262.00",
+	"price": 262.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -24473,7 +24473,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "638.00",
+	"price": 638.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -24502,7 +24502,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "391.00",
+	"price": 391.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -24531,7 +24531,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "928.00",
+	"price": 928.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -24564,8 +24564,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -24591,7 +24591,7 @@
 	"ancestors": [
 		"k3S6bh3Qj2BSvt5rD"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -24628,7 +24628,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "371.00",
+	"price": 371.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -24657,7 +24657,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "444.00",
+	"price": 444.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -24686,7 +24686,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "601.00",
+	"price": 601.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -24715,7 +24715,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "235.00",
+	"price": 235.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -24748,8 +24748,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -24775,7 +24775,7 @@
 	"ancestors": [
 		"rCwFjcQic4N5p9bbK"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -24812,7 +24812,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "46.00",
+	"price": 46.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -24845,8 +24845,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -24872,7 +24872,7 @@
 	"ancestors": [
 		"eTo84koEEvCYFBPW8"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -24909,7 +24909,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "985.00",
+	"price": 985.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -24938,7 +24938,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "640.00",
+	"price": 640.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -24967,7 +24967,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "399.00",
+	"price": 399.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -24996,7 +24996,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "425.00",
+	"price": 425.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -25029,8 +25029,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -25056,7 +25056,7 @@
 	"ancestors": [
 		"PvkAu9Y7HSXJECa3c"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -25093,7 +25093,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "75.00",
+	"price": 75.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -25126,8 +25126,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -25153,7 +25153,7 @@
 	"ancestors": [
 		"4QAdSam7scy9qhZ3s"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -25190,7 +25190,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "340.00",
+	"price": 340.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -25219,7 +25219,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "697.00",
+	"price": 697.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -25248,7 +25248,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "468.00",
+	"price": 468.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -25277,7 +25277,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "939.00",
+	"price": 939.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -25310,8 +25310,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -25337,7 +25337,7 @@
 	"ancestors": [
 		"osg6HwQDwm82H7tGE"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -25374,7 +25374,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "116.00",
+	"price": 116.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -25403,7 +25403,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "519.00",
+	"price": 519.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -25432,7 +25432,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "504.00",
+	"price": 504.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -25461,7 +25461,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "665.00",
+	"price": 665.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -25494,8 +25494,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -25521,7 +25521,7 @@
 	"ancestors": [
 		"L4LmP7vMbEnGPgqmo"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -25558,7 +25558,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "198.00",
+	"price": 198.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -25587,7 +25587,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "65.00",
+	"price": 65.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -25620,8 +25620,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -25647,7 +25647,7 @@
 	"ancestors": [
 		"pF6hT8ogwCrSHYTFt"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -25684,7 +25684,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "837.00",
+	"price": 837.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -25713,7 +25713,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "964.00",
+	"price": 964.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -25742,7 +25742,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "314.00",
+	"price": 314.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -25771,7 +25771,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "202.00",
+	"price": 202.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -25804,8 +25804,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -25831,7 +25831,7 @@
 	"ancestors": [
 		"NuLEbXoXWzSiiXsM4"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -25868,7 +25868,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "556.00",
+	"price": 556.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -25897,7 +25897,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "578.00",
+	"price": 578.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -25930,8 +25930,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -25957,7 +25957,7 @@
 	"ancestors": [
 		"LGRhjXuhLxY7PTztR"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -25994,7 +25994,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "640.00",
+	"price": 640.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -26023,7 +26023,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "41.00",
+	"price": 41.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -26052,7 +26052,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "412.00",
+	"price": 412.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -26081,7 +26081,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "298.00",
+	"price": 298.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -26114,8 +26114,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -26141,7 +26141,7 @@
 	"ancestors": [
 		"yFg8HFbGLmJtazsS8"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -26178,7 +26178,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "459.00",
+	"price": 459.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -26211,8 +26211,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -26238,7 +26238,7 @@
 	"ancestors": [
 		"5mABqqyovFaHkvpnS"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -26275,7 +26275,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "246.00",
+	"price": 246.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -26304,7 +26304,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "131.00",
+	"price": 131.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -26333,7 +26333,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "781.00",
+	"price": 781.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -26366,8 +26366,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -26393,7 +26393,7 @@
 	"ancestors": [
 		"o7FuitQinEAawcLKM"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -26430,7 +26430,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "345.00",
+	"price": 345.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -26459,7 +26459,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "870.00",
+	"price": 870.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -26488,7 +26488,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "792.00",
+	"price": 792.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -26521,8 +26521,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -26548,7 +26548,7 @@
 	"ancestors": [
 		"YMBimzM2dYyJ5E72E"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -26585,7 +26585,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "869.00",
+	"price": 869.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -26614,7 +26614,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "973.00",
+	"price": 973.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -26643,7 +26643,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "885.00",
+	"price": 885.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -26672,7 +26672,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "843.00",
+	"price": 843.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -26705,8 +26705,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -26732,7 +26732,7 @@
 	"ancestors": [
 		"CnJDngHrEwWJWn7JL"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -26769,7 +26769,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "491.00",
+	"price": 491.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -26802,8 +26802,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -26829,7 +26829,7 @@
 	"ancestors": [
 		"YyLzoarJ68zk7BrzT"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -26866,7 +26866,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "435.00",
+	"price": 435.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -26895,7 +26895,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "13.00",
+	"price": 13.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -26928,8 +26928,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -26955,7 +26955,7 @@
 	"ancestors": [
 		"TDSy97gbRct8q4SEj"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -26992,7 +26992,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "343.00",
+	"price": 343.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -27025,8 +27025,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -27052,7 +27052,7 @@
 	"ancestors": [
 		"xMwu2sKxgFnNfZfkC"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -27089,7 +27089,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "981.00",
+	"price": 981.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -27118,7 +27118,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "972.00",
+	"price": 972.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -27151,8 +27151,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -27178,7 +27178,7 @@
 	"ancestors": [
 		"yHcFC5Jkv6F8WxJE7"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -27215,7 +27215,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "420.00",
+	"price": 420.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -27244,7 +27244,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "259.00",
+	"price": 259.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -27273,7 +27273,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "742.00",
+	"price": 742.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -27302,7 +27302,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "582.00",
+	"price": 582.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -27335,8 +27335,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -27362,7 +27362,7 @@
 	"ancestors": [
 		"RFb5YBG3wB75joNRz"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -27399,7 +27399,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "433.00",
+	"price": 433.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -27432,8 +27432,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -27459,7 +27459,7 @@
 	"ancestors": [
 		"bi3bx6RmMi7xKs22P"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -27496,7 +27496,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "558.00",
+	"price": 558.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -27525,7 +27525,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "205.00",
+	"price": 205.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -27554,7 +27554,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "590.00",
+	"price": 590.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -27583,7 +27583,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "375.00",
+	"price": 375.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -27616,8 +27616,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -27643,7 +27643,7 @@
 	"ancestors": [
 		"T9z3juLeigaqTXLJD"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -27680,7 +27680,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "750.00",
+	"price": 750.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -27709,7 +27709,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "165.00",
+	"price": 165.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -27738,7 +27738,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "554.00",
+	"price": 554.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -27767,7 +27767,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "69.00",
+	"price": 69.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -27800,8 +27800,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -27827,7 +27827,7 @@
 	"ancestors": [
 		"DaYt2hxEQ5RZPYCYx"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -27864,7 +27864,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "129.00",
+	"price": 129.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -27897,8 +27897,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -27924,7 +27924,7 @@
 	"ancestors": [
 		"w4Xda6j5TuHQKaqyD"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -27961,7 +27961,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "557.00",
+	"price": 557.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -27990,7 +27990,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "917.00",
+	"price": 917.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -28019,7 +28019,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "600.00",
+	"price": 600.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -28052,8 +28052,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -28079,7 +28079,7 @@
 	"ancestors": [
 		"bxoR4HfRzoDrBzTYF"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -28116,7 +28116,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "765.00",
+	"price": 765.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -28145,7 +28145,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "416.00",
+	"price": 416.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -28178,8 +28178,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -28205,7 +28205,7 @@
 	"ancestors": [
 		"BnWRmpn4D89gsdfMw"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -28242,7 +28242,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "126.00",
+	"price": 126.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -28271,7 +28271,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "828.00",
+	"price": 828.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -28304,8 +28304,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -28331,7 +28331,7 @@
 	"ancestors": [
 		"9LwJRBN9zwWus8ztJ"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -28368,7 +28368,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "161.00",
+	"price": 161.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -28397,7 +28397,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "575.00",
+	"price": 575.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -28426,7 +28426,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "827.00",
+	"price": 827.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -28459,8 +28459,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -28486,7 +28486,7 @@
 	"ancestors": [
 		"bWzMimoXQPzDYBR4c"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -28523,7 +28523,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "475.00",
+	"price": 475.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -28552,7 +28552,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "479.00",
+	"price": 479.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -28581,7 +28581,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "236.00",
+	"price": 236.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -28610,7 +28610,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "466.00",
+	"price": 466.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -28643,8 +28643,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -28670,7 +28670,7 @@
 	"ancestors": [
 		"skPQPgdWBLoQx7Cqh"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -28707,7 +28707,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "590.00",
+	"price": 590.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -28736,7 +28736,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "766.00",
+	"price": 766.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -28769,8 +28769,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -28796,7 +28796,7 @@
 	"ancestors": [
 		"RgP4bcxjv2mHotSDF"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -28833,7 +28833,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "833.00",
+	"price": 833.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -28862,7 +28862,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "473.00",
+	"price": 473.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -28891,7 +28891,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "534.00",
+	"price": 534.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -28924,8 +28924,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -28951,7 +28951,7 @@
 	"ancestors": [
 		"oBSvty9YjSmzh32KR"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -28988,7 +28988,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "162.00",
+	"price": 162.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -29017,7 +29017,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "988.00",
+	"price": 988.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -29046,7 +29046,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "459.00",
+	"price": 459.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -29079,8 +29079,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -29106,7 +29106,7 @@
 	"ancestors": [
 		"J4hqK3yRxRxcmFic3"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -29143,7 +29143,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "369.00",
+	"price": 369.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -29172,7 +29172,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "434.00",
+	"price": 434.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -29201,7 +29201,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "435.00",
+	"price": 435.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -29234,8 +29234,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -29261,7 +29261,7 @@
 	"ancestors": [
 		"bX8Zo6dy3R8L5nvYF"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -29298,7 +29298,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "894.00",
+	"price": 894.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -29327,7 +29327,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "570.00",
+	"price": 570.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -29356,7 +29356,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "881.00",
+	"price": 881.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -29385,7 +29385,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "573.00",
+	"price": 573.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -29418,8 +29418,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -29445,7 +29445,7 @@
 	"ancestors": [
 		"a2mHm4S5ggiQbgkYC"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -29482,7 +29482,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "206.00",
+	"price": 206.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -29511,7 +29511,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "923.00",
+	"price": 923.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -29544,8 +29544,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -29571,7 +29571,7 @@
 	"ancestors": [
 		"7WxojxGr4o23wsfQ6"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -29608,7 +29608,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "936.00",
+	"price": 936.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -29637,7 +29637,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "654.00",
+	"price": 654.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -29670,8 +29670,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -29697,7 +29697,7 @@
 	"ancestors": [
 		"PqRciCDYKDFLJv2PH"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -29734,7 +29734,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "117.00",
+	"price": 117.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -29763,7 +29763,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "219.00",
+	"price": 219.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -29796,8 +29796,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -29823,7 +29823,7 @@
 	"ancestors": [
 		"yZPMbQGEdg5P3Faka"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -29860,7 +29860,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "455.00",
+	"price": 455.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -29889,7 +29889,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "789.00",
+	"price": 789.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -29918,7 +29918,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "510.00",
+	"price": 510.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -29951,8 +29951,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -29978,7 +29978,7 @@
 	"ancestors": [
 		"KpdftvR4MG5bcFiJ2"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -30015,7 +30015,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "169.00",
+	"price": 169.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -30048,8 +30048,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -30075,7 +30075,7 @@
 	"ancestors": [
 		"JyxPtr3KyCKbWHdfa"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -30112,7 +30112,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "40.00",
+	"price": 40.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -30141,7 +30141,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "910.00",
+	"price": 910.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -30170,7 +30170,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "591.00",
+	"price": 591.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -30199,7 +30199,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "44.00",
+	"price": 44.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -30232,8 +30232,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -30259,7 +30259,7 @@
 	"ancestors": [
 		"sq3BkLSJAL3kA4e6b"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -30296,7 +30296,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "156.00",
+	"price": 156.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -30325,7 +30325,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "399.00",
+	"price": 399.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -30358,8 +30358,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -30385,7 +30385,7 @@
 	"ancestors": [
 		"bKZT5H2ukqzdiqKXN"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -30422,7 +30422,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "284.00",
+	"price": 284.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -30451,7 +30451,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "736.00",
+	"price": 736.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -30484,8 +30484,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -30511,7 +30511,7 @@
 	"ancestors": [
 		"YtrXAwFBoaxFqfu7x"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -30548,7 +30548,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "689.00",
+	"price": 689.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -30577,7 +30577,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "672.00",
+	"price": 672.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -30606,7 +30606,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "141.00",
+	"price": 141.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -30635,7 +30635,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "702.00",
+	"price": 702.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -30668,8 +30668,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -30695,7 +30695,7 @@
 	"ancestors": [
 		"9FpBqgHKSfhza6Q9v"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -30732,7 +30732,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "579.00",
+	"price": 579.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -30761,7 +30761,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "770.00",
+	"price": 770.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -30790,7 +30790,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "835.00",
+	"price": 835.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -30823,8 +30823,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -30850,7 +30850,7 @@
 	"ancestors": [
 		"gHH2HSkZuNssjmtRp"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -30887,7 +30887,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "334.00",
+	"price": 334.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -30916,7 +30916,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "621.00",
+	"price": 621.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -30945,7 +30945,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "242.00",
+	"price": 242.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -30978,8 +30978,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -31005,7 +31005,7 @@
 	"ancestors": [
 		"EwezwA84bjQHig2bb"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -31042,7 +31042,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "821.00",
+	"price": 821.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -31075,8 +31075,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -31102,7 +31102,7 @@
 	"ancestors": [
 		"8zXzbLF3RwGjN2Lof"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -31139,7 +31139,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "6.00",
+	"price": 6.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -31168,7 +31168,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "452.00",
+	"price": 452.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -31197,7 +31197,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "532.00",
+	"price": 532.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -31226,7 +31226,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "110.00",
+	"price": 110.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -31259,8 +31259,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -31286,7 +31286,7 @@
 	"ancestors": [
 		"pryz548aG6iv5KTFF"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -31323,7 +31323,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "580.00",
+	"price": 580.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -31352,7 +31352,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "877.00",
+	"price": 877.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -31385,8 +31385,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -31412,7 +31412,7 @@
 	"ancestors": [
 		"LhjWZZiJbAejeFNxW"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -31449,7 +31449,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "594.00",
+	"price": 594.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -31482,8 +31482,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -31509,7 +31509,7 @@
 	"ancestors": [
 		"Qq63dAMkWDPLPJZGw"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -31546,7 +31546,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "738.00",
+	"price": 738.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -31579,8 +31579,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -31606,7 +31606,7 @@
 	"ancestors": [
 		"4PPsYCppBfTTpcfRz"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -31643,7 +31643,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "220.00",
+	"price": 220.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -31672,7 +31672,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "330.00",
+	"price": 330.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -31701,7 +31701,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "909.00",
+	"price": 909.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -31730,7 +31730,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "983.00",
+	"price": 983.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -31763,8 +31763,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -31790,7 +31790,7 @@
 	"ancestors": [
 		"Zhd2timtT5N2Qqsix"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -31827,7 +31827,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "625.00",
+	"price": 625.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -31856,7 +31856,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "172.00",
+	"price": 172.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -31889,8 +31889,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -31916,7 +31916,7 @@
 	"ancestors": [
 		"sJQohJ6w4znfkDRcQ"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -31953,7 +31953,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "747.00",
+	"price": 747.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -31982,7 +31982,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "761.00",
+	"price": 761.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -32011,7 +32011,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "322.00",
+	"price": 322.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -32044,8 +32044,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -32071,7 +32071,7 @@
 	"ancestors": [
 		"eKD2AdHzL4RQ7PNpS"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -32108,7 +32108,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "627.00",
+	"price": 627.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -32141,8 +32141,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -32168,7 +32168,7 @@
 	"ancestors": [
 		"mifnFvttWHGRaDjsQ"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -32205,7 +32205,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "766.00",
+	"price": 766.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -32234,7 +32234,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "371.00",
+	"price": 371.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -32263,7 +32263,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "407.00",
+	"price": 407.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -32296,8 +32296,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -32323,7 +32323,7 @@
 	"ancestors": [
 		"i4jqPfpkhM37EH98e"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -32360,7 +32360,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "849.00",
+	"price": 849.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -32389,7 +32389,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "356.00",
+	"price": 356.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -32418,7 +32418,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "607.00",
+	"price": 607.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -32447,7 +32447,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "110.00",
+	"price": 110.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -32480,8 +32480,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -32507,7 +32507,7 @@
 	"ancestors": [
 		"wjeisigc82m4ehudS"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -32544,7 +32544,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "529.00",
+	"price": 529.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -32573,7 +32573,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "98.00",
+	"price": 98.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -32602,7 +32602,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "339.00",
+	"price": 339.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -32631,7 +32631,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "628.00",
+	"price": 628.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -32664,8 +32664,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -32691,7 +32691,7 @@
 	"ancestors": [
 		"APpxWpE9RjrHoM4Na"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -32728,7 +32728,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "444.00",
+	"price": 444.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -32757,7 +32757,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "86.00",
+	"price": 86.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -32786,7 +32786,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "925.00",
+	"price": 925.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -32815,7 +32815,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "533.00",
+	"price": 533.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -32848,8 +32848,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -32875,7 +32875,7 @@
 	"ancestors": [
 		"o5aSCv98a7Dtza2TK"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -32912,7 +32912,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "582.00",
+	"price": 582.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -32941,7 +32941,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "89.00",
+	"price": 89.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -32970,7 +32970,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "16.00",
+	"price": 16.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -33003,8 +33003,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -33030,7 +33030,7 @@
 	"ancestors": [
 		"hoz4Q2XKdTFLKAEnu"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -33067,7 +33067,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "710.00",
+	"price": 710.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -33096,7 +33096,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "229.00",
+	"price": 229.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -33129,8 +33129,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -33156,7 +33156,7 @@
 	"ancestors": [
 		"zKuigjFhSBJjRCRdw"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -33193,7 +33193,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "62.00",
+	"price": 62.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -33226,8 +33226,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -33253,7 +33253,7 @@
 	"ancestors": [
 		"r9EjnSZrE9ffFKo8F"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -33290,7 +33290,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "37.00",
+	"price": 37.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -33323,8 +33323,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -33350,7 +33350,7 @@
 	"ancestors": [
 		"TJ2aeJYX4sMhJdyXB"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -33387,7 +33387,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "124.00",
+	"price": 124.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -33416,7 +33416,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "768.00",
+	"price": 768.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -33449,8 +33449,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -33476,7 +33476,7 @@
 	"ancestors": [
 		"Yy4AZbhaEDuJRsWdo"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -33513,7 +33513,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "140.00",
+	"price": 140.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -33546,8 +33546,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -33573,7 +33573,7 @@
 	"ancestors": [
 		"6koveGu8wYbYyNby7"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -33610,7 +33610,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "618.00",
+	"price": 618.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -33643,8 +33643,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -33670,7 +33670,7 @@
 	"ancestors": [
 		"4hJSXabyxw8qXdyy3"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -33707,7 +33707,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "373.00",
+	"price": 373.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -33736,7 +33736,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "694.00",
+	"price": 694.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -33769,8 +33769,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -33796,7 +33796,7 @@
 	"ancestors": [
 		"zHe2jKmvA2iqRApgz"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -33833,7 +33833,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "443.00",
+	"price": 443.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -33862,7 +33862,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "24.00",
+	"price": 24.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -33891,7 +33891,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "367.00",
+	"price": 367.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -33924,8 +33924,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -33951,7 +33951,7 @@
 	"ancestors": [
 		"ijRxvMf4mycf4xLwu"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -33988,7 +33988,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "200.00",
+	"price": 200.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -34021,8 +34021,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -34048,7 +34048,7 @@
 	"ancestors": [
 		"dN3vykYq6HvCC5GoM"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -34085,7 +34085,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "272.00",
+	"price": 272.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -34114,7 +34114,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "759.00",
+	"price": 759.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -34143,7 +34143,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "500.00",
+	"price": 500.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -34176,8 +34176,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -34203,7 +34203,7 @@
 	"ancestors": [
 		"fTN9MWB37qF6EoSJS"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -34240,7 +34240,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "811.00",
+	"price": 811.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -34269,7 +34269,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "643.00",
+	"price": 643.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -34298,7 +34298,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "540.00",
+	"price": 540.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -34331,8 +34331,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -34358,7 +34358,7 @@
 	"ancestors": [
 		"DhXPnWrHMy26RPC8J"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -34395,7 +34395,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "873.00",
+	"price": 873.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -34424,7 +34424,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "921.00",
+	"price": 921.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -34453,7 +34453,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "94.00",
+	"price": 94.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -34486,8 +34486,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -34513,7 +34513,7 @@
 	"ancestors": [
 		"G9r4Se8HKYACxfXRR"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -34550,7 +34550,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "959.00",
+	"price": 959.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -34579,7 +34579,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "958.00",
+	"price": 958.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -34608,7 +34608,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "256.00",
+	"price": 256.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -34637,7 +34637,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "879.00",
+	"price": 879.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -34670,8 +34670,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -34697,7 +34697,7 @@
 	"ancestors": [
 		"ZwDFSCTHgsH3G9iCc"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -34734,7 +34734,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "699.00",
+	"price": 699.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -34763,7 +34763,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "180.00",
+	"price": 180.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -34796,8 +34796,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -34823,7 +34823,7 @@
 	"ancestors": [
 		"H4MimGDFp7XEvvvro"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -34860,7 +34860,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "731.00",
+	"price": 731.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -34889,7 +34889,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "94.00",
+	"price": 94.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -34918,7 +34918,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "467.00",
+	"price": 467.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -34951,8 +34951,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -34978,7 +34978,7 @@
 	"ancestors": [
 		"MAC4NKd2CgDoynKqv"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -35015,7 +35015,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "796.00",
+	"price": 796.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -35044,7 +35044,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "985.00",
+	"price": 985.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -35077,8 +35077,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -35104,7 +35104,7 @@
 	"ancestors": [
 		"p6Jf38fLrxGTeaKER"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -35141,7 +35141,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "387.00",
+	"price": 387.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -35174,8 +35174,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -35201,7 +35201,7 @@
 	"ancestors": [
 		"9CkzXieWcBdBZgNHR"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -35238,7 +35238,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "896.00",
+	"price": 896.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -35271,8 +35271,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -35298,7 +35298,7 @@
 	"ancestors": [
 		"AtL5oXyt6cfjcdwgH"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -35335,7 +35335,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "970.00",
+	"price": 970.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -35364,7 +35364,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "79.00",
+	"price": 79.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -35397,8 +35397,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -35424,7 +35424,7 @@
 	"ancestors": [
 		"zEoWYmkCoEufAEzyq"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -35461,7 +35461,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "865.00",
+	"price": 865.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -35490,7 +35490,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "467.00",
+	"price": 467.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -35519,7 +35519,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "261.00",
+	"price": 261.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -35548,7 +35548,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "796.00",
+	"price": 796.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -35581,8 +35581,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -35608,7 +35608,7 @@
 	"ancestors": [
 		"FkkMN2oAtCDaAGHho"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -35645,7 +35645,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "199.00",
+	"price": 199.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -35674,7 +35674,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "924.00",
+	"price": 924.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -35703,7 +35703,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "304.00",
+	"price": 304.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -35732,7 +35732,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "604.00",
+	"price": 604.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -35765,8 +35765,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -35792,7 +35792,7 @@
 	"ancestors": [
 		"ZTz3L4NvjJTktfKjy"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -35829,7 +35829,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "787.00",
+	"price": 787.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -35862,8 +35862,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -35889,7 +35889,7 @@
 	"ancestors": [
 		"WPxGx5k7vSmuh8kDG"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -35926,7 +35926,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "582.00",
+	"price": 582.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -35955,7 +35955,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "427.00",
+	"price": 427.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -35984,7 +35984,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "595.00",
+	"price": 595.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -36017,8 +36017,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -36044,7 +36044,7 @@
 	"ancestors": [
 		"zS7N57mSvDuQyyuCi"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -36081,7 +36081,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "849.00",
+	"price": 849.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -36110,7 +36110,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "82.00",
+	"price": 82.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -36143,8 +36143,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -36170,7 +36170,7 @@
 	"ancestors": [
 		"bgHiRezdv96dRvwZa"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -36207,7 +36207,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "720.00",
+	"price": 720.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -36236,7 +36236,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "726.00",
+	"price": 726.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -36265,7 +36265,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "921.00",
+	"price": 921.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -36294,7 +36294,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "643.00",
+	"price": 643.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -36327,8 +36327,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -36354,7 +36354,7 @@
 	"ancestors": [
 		"mciEP5mSrZ9JrPtDi"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -36391,7 +36391,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "580.00",
+	"price": 580.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -36424,8 +36424,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -36451,7 +36451,7 @@
 	"ancestors": [
 		"LgyvYG8CfF3nfg2cN"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -36488,7 +36488,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "195.00",
+	"price": 195.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -36521,8 +36521,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -36548,7 +36548,7 @@
 	"ancestors": [
 		"qMfrjBxHt8erYSR2d"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -36585,7 +36585,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "728.00",
+	"price": 728.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -36614,7 +36614,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "544.00",
+	"price": 544.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -36643,7 +36643,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "606.00",
+	"price": 606.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -36672,7 +36672,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "776.00",
+	"price": 776.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -36705,8 +36705,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -36732,7 +36732,7 @@
 	"ancestors": [
 		"Cra9kFHqJWJFRTru2"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -36769,7 +36769,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "450.00",
+	"price": 450.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -36802,8 +36802,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -36829,7 +36829,7 @@
 	"ancestors": [
 		"Ltw3hhwjMb5L3CpQW"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -36866,7 +36866,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "274.00",
+	"price": 274.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -36895,7 +36895,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "773.00",
+	"price": 773.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -36924,7 +36924,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "784.00",
+	"price": 784.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -36953,7 +36953,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "920.00",
+	"price": 920.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -36986,8 +36986,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -37013,7 +37013,7 @@
 	"ancestors": [
 		"QiPAZRGBFiZw7Ckhh"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -37050,7 +37050,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "736.00",
+	"price": 736.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -37079,7 +37079,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "159.00",
+	"price": 159.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -37108,7 +37108,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "69.00",
+	"price": 69.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -37141,8 +37141,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -37168,7 +37168,7 @@
 	"ancestors": [
 		"hQLJbeemxbrcMszEq"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -37205,7 +37205,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "442.00",
+	"price": 442.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -37238,8 +37238,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -37265,7 +37265,7 @@
 	"ancestors": [
 		"8yEw4hxrauroQdnXr"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -37302,7 +37302,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "47.00",
+	"price": 47.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -37331,7 +37331,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "504.00",
+	"price": 504.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -37360,7 +37360,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "424.00",
+	"price": 424.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -37393,8 +37393,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -37420,7 +37420,7 @@
 	"ancestors": [
 		"wpaAzirfxYuSfyTre"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -37457,7 +37457,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "924.00",
+	"price": 924.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -37486,7 +37486,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "793.00",
+	"price": 793.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -37519,8 +37519,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -37546,7 +37546,7 @@
 	"ancestors": [
 		"Jejd5DuFQe29ir4pw"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -37583,7 +37583,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "974.00",
+	"price": 974.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -37612,7 +37612,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "802.00",
+	"price": 802.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -37641,7 +37641,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "124.00",
+	"price": 124.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -37674,8 +37674,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -37701,7 +37701,7 @@
 	"ancestors": [
 		"DPkypFqpJ33Dr65JX"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -37738,7 +37738,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "653.00",
+	"price": 653.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -37767,7 +37767,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "250.00",
+	"price": 250.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -37796,7 +37796,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "484.00",
+	"price": 484.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -37825,7 +37825,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "138.00",
+	"price": 138.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -37858,8 +37858,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -37885,7 +37885,7 @@
 	"ancestors": [
 		"xxwYPHM2pD9Gx5wTX"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -37922,7 +37922,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "597.00",
+	"price": 597.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -37955,8 +37955,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -37982,7 +37982,7 @@
 	"ancestors": [
 		"uffG7FsDyyqYTs6K7"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -38019,7 +38019,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "113.00",
+	"price": 113.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -38048,7 +38048,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "350.00",
+	"price": 350.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -38081,8 +38081,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -38108,7 +38108,7 @@
 	"ancestors": [
 		"pxiJwb824AHFgnoco"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -38145,7 +38145,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "303.00",
+	"price": 303.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -38174,7 +38174,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "31.00",
+	"price": 31.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -38207,8 +38207,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -38234,7 +38234,7 @@
 	"ancestors": [
 		"oPDG2YfnzH6d7sbwe"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -38271,7 +38271,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "72.00",
+	"price": 72.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -38300,7 +38300,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "125.00",
+	"price": 125.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -38329,7 +38329,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "578.00",
+	"price": 578.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -38362,8 +38362,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -38389,7 +38389,7 @@
 	"ancestors": [
 		"gNJYvb4pdZf2rDeZJ"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -38426,7 +38426,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "131.00",
+	"price": 131.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -38459,8 +38459,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -38486,7 +38486,7 @@
 	"ancestors": [
 		"NHmkjrnDNYpXLnnsi"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -38523,7 +38523,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "294.00",
+	"price": 294.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -38552,7 +38552,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "610.00",
+	"price": 610.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -38581,7 +38581,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "69.00",
+	"price": 69.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -38614,8 +38614,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -38641,7 +38641,7 @@
 	"ancestors": [
 		"i6a4M66zNhaGtYTJe"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -38678,7 +38678,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "674.00",
+	"price": 674.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -38707,7 +38707,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "580.00",
+	"price": 580.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -38736,7 +38736,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "556.00",
+	"price": 556.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -38769,8 +38769,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -38796,7 +38796,7 @@
 	"ancestors": [
 		"QCsvjAazCbss25dzG"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -38833,7 +38833,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "884.00",
+	"price": 884.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -38862,7 +38862,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "918.00",
+	"price": 918.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -38895,8 +38895,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -38922,7 +38922,7 @@
 	"ancestors": [
 		"wGB8mPcAfsSzBPrxY"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -38959,7 +38959,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "177.00",
+	"price": 177.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -38988,7 +38988,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "708.00",
+	"price": 708.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -39021,8 +39021,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -39048,7 +39048,7 @@
 	"ancestors": [
 		"5LseskwQQZB2GLAXP"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -39085,7 +39085,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "9.00",
+	"price": 9.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -39114,7 +39114,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "988.00",
+	"price": 988.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -39143,7 +39143,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "977.00",
+	"price": 977.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -39172,7 +39172,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "757.00",
+	"price": 757.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -39205,8 +39205,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -39232,7 +39232,7 @@
 	"ancestors": [
 		"CzqLWQHvxrPpYcZQb"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -39269,7 +39269,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "65.00",
+	"price": 65.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -39302,8 +39302,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -39329,7 +39329,7 @@
 	"ancestors": [
 		"etuoGSdCWARnsiNhg"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -39366,7 +39366,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "718.00",
+	"price": 718.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -39395,7 +39395,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "533.00",
+	"price": 533.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -39424,7 +39424,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "861.00",
+	"price": 861.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -39453,7 +39453,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "427.00",
+	"price": 427.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -39486,8 +39486,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -39513,7 +39513,7 @@
 	"ancestors": [
 		"roeanx7bWmDznS8Cx"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -39550,7 +39550,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "927.00",
+	"price": 927.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -39579,7 +39579,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "721.00",
+	"price": 721.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -39612,8 +39612,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -39639,7 +39639,7 @@
 	"ancestors": [
 		"EEfYcdJqqyTKGbd6K"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -39676,7 +39676,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "474.00",
+	"price": 474.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -39705,7 +39705,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "718.00",
+	"price": 718.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -39734,7 +39734,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "855.00",
+	"price": 855.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -39763,7 +39763,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "887.00",
+	"price": 887.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -39796,8 +39796,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -39823,7 +39823,7 @@
 	"ancestors": [
 		"8PyuyuCzZYiWe6uED"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -39860,7 +39860,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "210.00",
+	"price": 210.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -39893,8 +39893,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -39920,7 +39920,7 @@
 	"ancestors": [
 		"LPfD527R5Qe2KJPz4"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -39957,7 +39957,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "251.00",
+	"price": 251.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -39986,7 +39986,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "376.00",
+	"price": 376.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -40015,7 +40015,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "770.00",
+	"price": 770.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -40048,8 +40048,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -40075,7 +40075,7 @@
 	"ancestors": [
 		"AmA3ATjjGR42KiJt3"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -40112,7 +40112,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "273.00",
+	"price": 273.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -40141,7 +40141,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "465.00",
+	"price": 465.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -40174,8 +40174,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -40201,7 +40201,7 @@
 	"ancestors": [
 		"fb3qo2wSBdXYALXuM"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -40238,7 +40238,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "412.00",
+	"price": 412.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -40271,8 +40271,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -40298,7 +40298,7 @@
 	"ancestors": [
 		"XbmMC2s2pZyc9pPAg"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -40335,7 +40335,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "621.00",
+	"price": 621.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -40364,7 +40364,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "25.00",
+	"price": 25.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -40393,7 +40393,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "355.00",
+	"price": 355.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -40422,7 +40422,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "166.00",
+	"price": 166.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -40455,8 +40455,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -40482,7 +40482,7 @@
 	"ancestors": [
 		"TCjiZFwnXNDDDPM9M"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -40519,7 +40519,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "891.00",
+	"price": 891.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -40548,7 +40548,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "860.00",
+	"price": 860.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -40577,7 +40577,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "873.00",
+	"price": 873.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -40610,8 +40610,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -40637,7 +40637,7 @@
 	"ancestors": [
 		"8CoqvzpNXWZca4LpR"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -40674,7 +40674,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "334.00",
+	"price": 334.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -40703,7 +40703,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "229.00",
+	"price": 229.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -40732,7 +40732,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "113.00",
+	"price": 113.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -40761,7 +40761,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "427.00",
+	"price": 427.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -40794,8 +40794,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -40821,7 +40821,7 @@
 	"ancestors": [
 		"mLYkS5dzAyTvSyTmA"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -40858,7 +40858,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "713.00",
+	"price": 713.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -40887,7 +40887,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "375.00",
+	"price": 375.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -40916,7 +40916,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "88.00",
+	"price": 88.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -40945,7 +40945,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "10.00",
+	"price": 10.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -40978,8 +40978,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -41005,7 +41005,7 @@
 	"ancestors": [
 		"ayNuEc6Xuq2JCWu4z"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -41042,7 +41042,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "878.00",
+	"price": 878.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -41075,8 +41075,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -41102,7 +41102,7 @@
 	"ancestors": [
 		"4XzSr4CLKG32vzQoH"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -41139,7 +41139,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "581.00",
+	"price": 581.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -41168,7 +41168,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "482.00",
+	"price": 482.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -41197,7 +41197,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "926.00",
+	"price": 926.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -41226,7 +41226,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "551.00",
+	"price": 551.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -41259,8 +41259,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -41286,7 +41286,7 @@
 	"ancestors": [
 		"7aqyKQXcbdGSQCDgE"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -41323,7 +41323,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "838.00",
+	"price": 838.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -41356,8 +41356,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -41383,7 +41383,7 @@
 	"ancestors": [
 		"ekTaCdEJ4Bz8uCW4A"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -41420,7 +41420,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "446.00",
+	"price": 446.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -41453,8 +41453,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -41480,7 +41480,7 @@
 	"ancestors": [
 		"7RXNPXogANxSsbbzN"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -41517,7 +41517,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "632.00",
+	"price": 632.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -41546,7 +41546,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "718.00",
+	"price": 718.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -41575,7 +41575,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "457.00",
+	"price": 457.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -41608,8 +41608,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -41635,7 +41635,7 @@
 	"ancestors": [
 		"Katz55RSS7m2yQySj"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -41672,7 +41672,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "62.00",
+	"price": 62.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -41701,7 +41701,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "67.00",
+	"price": 67.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -41730,7 +41730,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "730.00",
+	"price": 730.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -41759,7 +41759,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "479.00",
+	"price": 479.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -41792,8 +41792,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -41819,7 +41819,7 @@
 	"ancestors": [
 		"uX9fgL7G6TZ95jMFG"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -41856,7 +41856,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "365.00",
+	"price": 365.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -41889,8 +41889,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -41916,7 +41916,7 @@
 	"ancestors": [
 		"sMQZqP4FKSsFiRAqh"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -41953,7 +41953,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "229.00",
+	"price": 229.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -41986,8 +41986,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -42013,7 +42013,7 @@
 	"ancestors": [
 		"DkyQQqMtDePZPRX6c"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -42050,7 +42050,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "478.00",
+	"price": 478.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -42079,7 +42079,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "527.00",
+	"price": 527.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -42108,7 +42108,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "923.00",
+	"price": 923.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -42137,7 +42137,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "802.00",
+	"price": 802.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -42170,8 +42170,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -42197,7 +42197,7 @@
 	"ancestors": [
 		"4N2ggmwTR79DYhySr"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -42234,7 +42234,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "358.00",
+	"price": 358.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -42267,8 +42267,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -42294,7 +42294,7 @@
 	"ancestors": [
 		"gJjkSxeCTSPA84DWt"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -42331,7 +42331,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "115.00",
+	"price": 115.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -42364,8 +42364,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -42391,7 +42391,7 @@
 	"ancestors": [
 		"sesanw2MHaugk7wYv"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -42428,7 +42428,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "121.00",
+	"price": 121.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -42461,8 +42461,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -42488,7 +42488,7 @@
 	"ancestors": [
 		"h6qifcvyNeWzCL9Mk"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -42525,7 +42525,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "319.00",
+	"price": 319.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -42554,7 +42554,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "592.00",
+	"price": 592.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -42587,8 +42587,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -42614,7 +42614,7 @@
 	"ancestors": [
 		"vWrpoJhkHAQWMXQ7n"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -42651,7 +42651,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "1.00",
+	"price": 1.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -42680,7 +42680,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "269.00",
+	"price": 269.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -42709,7 +42709,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "768.00",
+	"price": 768.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -42742,8 +42742,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -42769,7 +42769,7 @@
 	"ancestors": [
 		"HvxvRKempSBsmgq5Z"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -42806,7 +42806,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "10.00",
+	"price": 10.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -42835,7 +42835,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "859.00",
+	"price": 859.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -42864,7 +42864,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "951.00",
+	"price": 951.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -42893,7 +42893,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "390.00",
+	"price": 390.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -42926,8 +42926,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -42953,7 +42953,7 @@
 	"ancestors": [
 		"xYCe8AApvEw4jrY2N"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -42990,7 +42990,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "862.00",
+	"price": 862.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -43019,7 +43019,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "405.00",
+	"price": 405.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -43052,8 +43052,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -43079,7 +43079,7 @@
 	"ancestors": [
 		"yvDwG7WDSujvYzFs9"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -43116,7 +43116,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "811.00",
+	"price": 811.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -43145,7 +43145,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "311.00",
+	"price": 311.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -43174,7 +43174,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "746.00",
+	"price": 746.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -43207,8 +43207,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -43234,7 +43234,7 @@
 	"ancestors": [
 		"uRccWatqLHmj56nNe"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -43271,7 +43271,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "364.00",
+	"price": 364.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -43304,8 +43304,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -43331,7 +43331,7 @@
 	"ancestors": [
 		"MZkmgeGnRHsx3WQzD"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -43368,7 +43368,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "940.00",
+	"price": 940.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -43397,7 +43397,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "746.00",
+	"price": 746.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -43426,7 +43426,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "950.00",
+	"price": 950.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -43459,8 +43459,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -43486,7 +43486,7 @@
 	"ancestors": [
 		"XxkQ9fnAMrTzuKved"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -43523,7 +43523,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "966.00",
+	"price": 966.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -43552,7 +43552,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "198.00",
+	"price": 198.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -43585,8 +43585,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -43612,7 +43612,7 @@
 	"ancestors": [
 		"FnNgHEsqnMep2qTg6"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -43649,7 +43649,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "333.00",
+	"price": 333.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -43682,8 +43682,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -43709,7 +43709,7 @@
 	"ancestors": [
 		"gEjFd9eC6xb6mMF5P"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -43746,7 +43746,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "962.00",
+	"price": 962.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -43775,7 +43775,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "430.00",
+	"price": 430.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -43808,8 +43808,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -43835,7 +43835,7 @@
 	"ancestors": [
 		"jCpnTFCdiaYT7qhKq"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -43872,7 +43872,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "289.00",
+	"price": 289.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -43901,7 +43901,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "387.00",
+	"price": 387.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -43934,8 +43934,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -43961,7 +43961,7 @@
 	"ancestors": [
 		"L99ME5JuD385QdCKJ"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -43998,7 +43998,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "92.00",
+	"price": 92.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -44027,7 +44027,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "841.00",
+	"price": 841.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -44056,7 +44056,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "112.00",
+	"price": 112.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -44085,7 +44085,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "948.00",
+	"price": 948.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -44118,8 +44118,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -44145,7 +44145,7 @@
 	"ancestors": [
 		"6shGnLRLJoMgycJ4h"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -44182,7 +44182,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "629.00",
+	"price": 629.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -44215,8 +44215,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -44242,7 +44242,7 @@
 	"ancestors": [
 		"itKqJDeRvzER9rxB2"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -44279,7 +44279,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "834.00",
+	"price": 834.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -44308,7 +44308,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "110.00",
+	"price": 110.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -44341,8 +44341,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -44368,7 +44368,7 @@
 	"ancestors": [
 		"b5X3txMAukLqCEdWr"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -44405,7 +44405,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "723.00",
+	"price": 723.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -44438,8 +44438,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -44465,7 +44465,7 @@
 	"ancestors": [
 		"u69kRdH7urhqr6nya"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -44502,7 +44502,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "47.00",
+	"price": 47.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -44531,7 +44531,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "321.00",
+	"price": 321.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -44560,7 +44560,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "783.00",
+	"price": 783.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -44589,7 +44589,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "247.00",
+	"price": 247.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -44622,8 +44622,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -44649,7 +44649,7 @@
 	"ancestors": [
 		"hLTEQ28Pnp6aHQAyT"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -44686,7 +44686,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "707.00",
+	"price": 707.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -44719,8 +44719,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -44746,7 +44746,7 @@
 	"ancestors": [
 		"tnAq5mtYpSDubmupc"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -44783,7 +44783,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "606.00",
+	"price": 606.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -44812,7 +44812,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "563.00",
+	"price": 563.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -44841,7 +44841,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "702.00",
+	"price": 702.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -44870,7 +44870,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "601.00",
+	"price": 601.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -44903,8 +44903,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -44930,7 +44930,7 @@
 	"ancestors": [
 		"ndrKBgSzRrYqCSLyd"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -44967,7 +44967,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "478.00",
+	"price": 478.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -45000,8 +45000,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -45027,7 +45027,7 @@
 	"ancestors": [
 		"H98n3dDDEnvpo33QN"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -45064,7 +45064,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "171.00",
+	"price": 171.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -45093,7 +45093,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "853.00",
+	"price": 853.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -45122,7 +45122,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "286.00",
+	"price": 286.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -45151,7 +45151,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "700.00",
+	"price": 700.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -45184,8 +45184,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -45211,7 +45211,7 @@
 	"ancestors": [
 		"4wvPPJnQanto6JTmq"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -45248,7 +45248,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "481.00",
+	"price": 481.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -45281,8 +45281,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -45308,7 +45308,7 @@
 	"ancestors": [
 		"czjSNrAiKteD8XWYd"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -45345,7 +45345,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "62.00",
+	"price": 62.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -45374,7 +45374,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "427.00",
+	"price": 427.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -45403,7 +45403,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "203.00",
+	"price": 203.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -45432,7 +45432,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "721.00",
+	"price": 721.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -45465,8 +45465,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -45492,7 +45492,7 @@
 	"ancestors": [
 		"3KXM4xGsFxdfsvsM8"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -45529,7 +45529,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "887.00",
+	"price": 887.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -45562,8 +45562,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -45589,7 +45589,7 @@
 	"ancestors": [
 		"7SQL6r7XzhD8LTyMy"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -45626,7 +45626,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "477.00",
+	"price": 477.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -45655,7 +45655,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "434.00",
+	"price": 434.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -45684,7 +45684,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "672.00",
+	"price": 672.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -45713,7 +45713,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "314.00",
+	"price": 314.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -45746,8 +45746,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -45773,7 +45773,7 @@
 	"ancestors": [
 		"FdykWuTAT9ekHv5pg"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -45810,7 +45810,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "289.00",
+	"price": 289.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -45843,8 +45843,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -45870,7 +45870,7 @@
 	"ancestors": [
 		"c5r3ajJbn7K8nQmHT"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -45907,7 +45907,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "522.00",
+	"price": 522.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -45936,7 +45936,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "968.00",
+	"price": 968.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -45969,8 +45969,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -45996,7 +45996,7 @@
 	"ancestors": [
 		"oGL6BHBaPZzGYYGru"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -46033,7 +46033,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "556.00",
+	"price": 556.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -46062,7 +46062,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "323.00",
+	"price": 323.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -46091,7 +46091,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "502.00",
+	"price": 502.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -46124,8 +46124,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -46151,7 +46151,7 @@
 	"ancestors": [
 		"E5338oii6PpW5pWju"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -46188,7 +46188,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "473.00",
+	"price": 473.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -46217,7 +46217,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "57.00",
+	"price": 57.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -46246,7 +46246,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "651.00",
+	"price": 651.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -46275,7 +46275,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "51.00",
+	"price": 51.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -46308,8 +46308,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -46335,7 +46335,7 @@
 	"ancestors": [
 		"GrJEcxrsLscouAutn"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -46372,7 +46372,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "262.00",
+	"price": 262.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -46405,8 +46405,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -46432,7 +46432,7 @@
 	"ancestors": [
 		"M36ReoAtCepjC3Z8o"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -46469,7 +46469,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "788.00",
+	"price": 788.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -46498,7 +46498,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "101.00",
+	"price": 101.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -46527,7 +46527,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "64.00",
+	"price": 64.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -46556,7 +46556,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "610.00",
+	"price": 610.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -46589,8 +46589,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -46616,7 +46616,7 @@
 	"ancestors": [
 		"Z4hdxfscwK2bqPavi"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -46653,7 +46653,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "215.00",
+	"price": 215.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -46682,7 +46682,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "49.00",
+	"price": 49.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -46711,7 +46711,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "259.00",
+	"price": 259.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -46744,8 +46744,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -46771,7 +46771,7 @@
 	"ancestors": [
 		"tv7naoyxCdRQcGxEW"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -46808,7 +46808,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "342.00",
+	"price": 342.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -46837,7 +46837,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "613.00",
+	"price": 613.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -46870,8 +46870,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -46897,7 +46897,7 @@
 	"ancestors": [
 		"xgJZ2BNzxXctZeAee"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -46934,7 +46934,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "917.00",
+	"price": 917.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -46967,8 +46967,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -46994,7 +46994,7 @@
 	"ancestors": [
 		"rCYrExFcETEqKpraX"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -47031,7 +47031,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "949.00",
+	"price": 949.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -47060,7 +47060,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "137.00",
+	"price": 137.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -47089,7 +47089,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "865.00",
+	"price": 865.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -47122,8 +47122,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -47149,7 +47149,7 @@
 	"ancestors": [
 		"8tRWjtKYxxMnzQDNt"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -47186,7 +47186,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "266.00",
+	"price": 266.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -47215,7 +47215,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "168.00",
+	"price": 168.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -47248,8 +47248,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -47275,7 +47275,7 @@
 	"ancestors": [
 		"MiXpfDJWiTLpkwRdk"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -47312,7 +47312,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "638.00",
+	"price": 638.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -47341,7 +47341,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "689.00",
+	"price": 689.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -47370,7 +47370,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "463.00",
+	"price": 463.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -47403,8 +47403,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -47430,7 +47430,7 @@
 	"ancestors": [
 		"PTRfDEN9B4LiKbs3w"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -47467,7 +47467,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "554.00",
+	"price": 554.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -47496,7 +47496,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "770.00",
+	"price": 770.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -47529,8 +47529,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -47556,7 +47556,7 @@
 	"ancestors": [
 		"xiuxdzaw3MY2aJKWH"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -47593,7 +47593,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "318.00",
+	"price": 318.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -47622,7 +47622,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "531.00",
+	"price": 531.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -47651,7 +47651,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "567.00",
+	"price": 567.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -47684,8 +47684,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -47711,7 +47711,7 @@
 	"ancestors": [
 		"RPn5k7GfGQMaorskr"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -47748,7 +47748,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "697.00",
+	"price": 697.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -47777,7 +47777,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "272.00",
+	"price": 272.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -47806,7 +47806,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "816.00",
+	"price": 816.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -47835,7 +47835,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "759.00",
+	"price": 759.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -47868,8 +47868,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -47895,7 +47895,7 @@
 	"ancestors": [
 		"NfyyFjBvAcbb9PWe4"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -47932,7 +47932,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "925.00",
+	"price": 925.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -47965,8 +47965,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -47992,7 +47992,7 @@
 	"ancestors": [
 		"ikLoMs9WnZTuoXEi2"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -48029,7 +48029,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "780.00",
+	"price": 780.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -48058,7 +48058,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "177.00",
+	"price": 177.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -48087,7 +48087,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "962.00",
+	"price": 962.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -48120,8 +48120,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -48147,7 +48147,7 @@
 	"ancestors": [
 		"xXS7q9eh3zxiudKZR"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -48184,7 +48184,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "110.00",
+	"price": 110.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -48213,7 +48213,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "851.00",
+	"price": 851.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -48242,7 +48242,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "388.00",
+	"price": 388.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -48275,8 +48275,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -48302,7 +48302,7 @@
 	"ancestors": [
 		"cBKSAbNeTLnmHzYXa"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -48339,7 +48339,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "998.00",
+	"price": 998.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -48368,7 +48368,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "453.00",
+	"price": 453.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -48401,8 +48401,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -48428,7 +48428,7 @@
 	"ancestors": [
 		"qFYWGzavFM8HnLP7u"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -48465,7 +48465,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "952.00",
+	"price": 952.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -48494,7 +48494,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "519.00",
+	"price": 519.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -48523,7 +48523,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "304.00",
+	"price": 304.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -48552,7 +48552,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "796.00",
+	"price": 796.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -48585,8 +48585,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -48612,7 +48612,7 @@
 	"ancestors": [
 		"96B4QdcHMazXW7JYm"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -48649,7 +48649,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "963.00",
+	"price": 963.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -48678,7 +48678,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "212.00",
+	"price": 212.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -48711,8 +48711,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -48738,7 +48738,7 @@
 	"ancestors": [
 		"pErq9z8yTTjuCYvh3"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -48775,7 +48775,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "266.00",
+	"price": 266.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -48804,7 +48804,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "284.00",
+	"price": 284.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -48837,8 +48837,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -48864,7 +48864,7 @@
 	"ancestors": [
 		"RGchcq9QYEmLt2Cdu"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -48901,7 +48901,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "550.00",
+	"price": 550.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -48930,7 +48930,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "156.00",
+	"price": 156.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -48959,7 +48959,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "954.00",
+	"price": 954.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -48988,7 +48988,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "657.00",
+	"price": 657.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -49021,8 +49021,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -49048,7 +49048,7 @@
 	"ancestors": [
 		"KmXtTPMmxrivjjmtb"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -49085,7 +49085,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "462.00",
+	"price": 462.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -49114,7 +49114,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "741.00",
+	"price": 741.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -49147,8 +49147,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -49174,7 +49174,7 @@
 	"ancestors": [
 		"5SAKxcv8HBhs4JBMq"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -49211,7 +49211,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "573.00",
+	"price": 573.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -49244,8 +49244,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -49271,7 +49271,7 @@
 	"ancestors": [
 		"XQFB6X24Hev8PGqAu"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -49308,7 +49308,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "534.00",
+	"price": 534.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -49337,7 +49337,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "187.00",
+	"price": 187.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -49366,7 +49366,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "261.00",
+	"price": 261.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -49395,7 +49395,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "449.00",
+	"price": 449.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -49428,8 +49428,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -49455,7 +49455,7 @@
 	"ancestors": [
 		"PSYkohBh6Qeyxk4cx"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -49492,7 +49492,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "262.00",
+	"price": 262.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -49521,7 +49521,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "158.00",
+	"price": 158.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -49550,7 +49550,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "912.00",
+	"price": 912.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -49579,7 +49579,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "980.00",
+	"price": 980.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -49612,8 +49612,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -49639,7 +49639,7 @@
 	"ancestors": [
 		"HqKFYszdnYAQY7ESy"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -49676,7 +49676,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "182.00",
+	"price": 182.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -49705,7 +49705,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "763.00",
+	"price": 763.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -49738,8 +49738,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -49765,7 +49765,7 @@
 	"ancestors": [
 		"g7DPv8gs4BchukjYD"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -49802,7 +49802,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "335.00",
+	"price": 335.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -49835,8 +49835,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -49862,7 +49862,7 @@
 	"ancestors": [
 		"NXkLCiefNRauvjgwM"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -49899,7 +49899,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "590.00",
+	"price": 590.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -49928,7 +49928,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "568.00",
+	"price": 568.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -49961,8 +49961,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -49988,7 +49988,7 @@
 	"ancestors": [
 		"pkkmbuJJNScxyqxmn"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -50025,7 +50025,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "303.00",
+	"price": 303.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -50054,7 +50054,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "511.00",
+	"price": 511.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -50083,7 +50083,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "412.00",
+	"price": 412.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -50116,8 +50116,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -50143,7 +50143,7 @@
 	"ancestors": [
 		"hXmtoa4MhcQaRfPLi"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -50180,7 +50180,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "385.00",
+	"price": 385.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -50209,7 +50209,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "487.00",
+	"price": 487.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -50238,7 +50238,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "785.00",
+	"price": 785.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -50267,7 +50267,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "336.00",
+	"price": 336.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -50300,8 +50300,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -50327,7 +50327,7 @@
 	"ancestors": [
 		"LJodJZmPB7f8WvWvj"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -50364,7 +50364,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "369.00",
+	"price": 369.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -50393,7 +50393,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "579.00",
+	"price": 579.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -50426,8 +50426,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -50453,7 +50453,7 @@
 	"ancestors": [
 		"XnjrT44rfL5KjjJ87"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -50490,7 +50490,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "413.00",
+	"price": 413.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -50523,8 +50523,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -50550,7 +50550,7 @@
 	"ancestors": [
 		"SSLQFkpK8seLGunr9"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -50587,7 +50587,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "496.00",
+	"price": 496.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -50616,7 +50616,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "338.00",
+	"price": 338.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -50645,7 +50645,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "419.00",
+	"price": 419.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -50674,7 +50674,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "857.00",
+	"price": 857.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -50707,8 +50707,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -50734,7 +50734,7 @@
 	"ancestors": [
 		"YMJqY4m3rS5RKMEfv"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -50771,7 +50771,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "904.00",
+	"price": 904.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -50800,7 +50800,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "319.00",
+	"price": 319.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -50833,8 +50833,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -50860,7 +50860,7 @@
 	"ancestors": [
 		"9BCxP2NtdkfhrzciR"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -50897,7 +50897,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "311.00",
+	"price": 311.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -50926,7 +50926,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "759.00",
+	"price": 759.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -50955,7 +50955,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "894.00",
+	"price": 894.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -50988,8 +50988,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -51015,7 +51015,7 @@
 	"ancestors": [
 		"ndArrAoDAwQeuB7hq"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -51052,7 +51052,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "717.00",
+	"price": 717.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -51081,7 +51081,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "696.00",
+	"price": 696.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -51110,7 +51110,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "295.00",
+	"price": 295.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -51143,8 +51143,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -51170,7 +51170,7 @@
 	"ancestors": [
 		"xRAWPfSrwpSPRHRto"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -51207,7 +51207,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "468.00",
+	"price": 468.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -51236,7 +51236,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "493.00",
+	"price": 493.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -51269,8 +51269,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -51296,7 +51296,7 @@
 	"ancestors": [
 		"fznEjCbqXPRshQTAz"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -51333,7 +51333,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "46.00",
+	"price": 46.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -51366,8 +51366,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -51393,7 +51393,7 @@
 	"ancestors": [
 		"WMZYvshcJm5R9Sb2E"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -51430,7 +51430,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "67.00",
+	"price": 67.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -51463,8 +51463,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -51490,7 +51490,7 @@
 	"ancestors": [
 		"3BuvwYPfZmLqR2EFj"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -51527,7 +51527,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "507.00",
+	"price": 507.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -51556,7 +51556,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "308.00",
+	"price": 308.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -51589,8 +51589,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -51616,7 +51616,7 @@
 	"ancestors": [
 		"AzNNJQJgf39GFZHbe"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -51653,7 +51653,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "126.00",
+	"price": 126.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -51686,8 +51686,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -51713,7 +51713,7 @@
 	"ancestors": [
 		"aitneFQqg3RfvSiFi"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -51750,7 +51750,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "908.00",
+	"price": 908.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -51783,8 +51783,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -51810,7 +51810,7 @@
 	"ancestors": [
 		"pxLKS3k5WMwHfRcim"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -51847,7 +51847,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "23.00",
+	"price": 23.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -51876,7 +51876,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "32.00",
+	"price": 32.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -51905,7 +51905,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "488.00",
+	"price": 488.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -51938,8 +51938,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -51965,7 +51965,7 @@
 	"ancestors": [
 		"y9fBoW6B6JhjNnjCk"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -52002,7 +52002,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "767.00",
+	"price": 767.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -52031,7 +52031,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "863.00",
+	"price": 863.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -52060,7 +52060,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "928.00",
+	"price": 928.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -52093,8 +52093,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -52120,7 +52120,7 @@
 	"ancestors": [
 		"jiTbSRaTjWvGZknbu"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -52157,7 +52157,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "392.00",
+	"price": 392.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -52186,7 +52186,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "504.00",
+	"price": 504.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -52215,7 +52215,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "515.00",
+	"price": 515.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -52248,8 +52248,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -52275,7 +52275,7 @@
 	"ancestors": [
 		"7EeB6xNZTHorpRtgn"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -52312,7 +52312,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "842.00",
+	"price": 842.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -52341,7 +52341,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "254.00",
+	"price": 254.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -52370,7 +52370,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "156.00",
+	"price": 156.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -52403,8 +52403,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -52430,7 +52430,7 @@
 	"ancestors": [
 		"pRnYn9LpRTCXsBajj"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -52467,7 +52467,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "215.00",
+	"price": 215.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -52496,7 +52496,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "513.00",
+	"price": 513.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -52525,7 +52525,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "699.00",
+	"price": 699.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -52554,7 +52554,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "127.00",
+	"price": 127.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -52587,8 +52587,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -52614,7 +52614,7 @@
 	"ancestors": [
 		"ZmZcdFM4FKKrTFXc5"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -52651,7 +52651,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "712.00",
+	"price": 712.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -52680,7 +52680,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "607.00",
+	"price": 607.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -52713,8 +52713,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -52740,7 +52740,7 @@
 	"ancestors": [
 		"QB4qmhTs7i3bx7sTi"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -52777,7 +52777,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "254.00",
+	"price": 254.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -52810,8 +52810,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -52837,7 +52837,7 @@
 	"ancestors": [
 		"e6TzpicoDzHZGsGnY"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -52874,7 +52874,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "765.00",
+	"price": 765.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -52907,8 +52907,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -52934,7 +52934,7 @@
 	"ancestors": [
 		"5ZyL3JTEmHoE7kZmZ"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -52971,7 +52971,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "870.00",
+	"price": 870.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -53000,7 +53000,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "528.00",
+	"price": 528.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -53029,7 +53029,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "347.00",
+	"price": 347.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -53058,7 +53058,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "948.00",
+	"price": 948.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -53091,8 +53091,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -53118,7 +53118,7 @@
 	"ancestors": [
 		"J8a7zFTjSNLjfwraX"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -53155,7 +53155,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "708.00",
+	"price": 708.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -53184,7 +53184,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "475.00",
+	"price": 475.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -53217,8 +53217,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -53244,7 +53244,7 @@
 	"ancestors": [
 		"eFA2kdhJyeQcySxgM"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -53281,7 +53281,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "882.00",
+	"price": 882.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -53314,8 +53314,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -53341,7 +53341,7 @@
 	"ancestors": [
 		"dz4ReHpFnni9APKB5"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -53378,7 +53378,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "127.00",
+	"price": 127.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -53407,7 +53407,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "178.00",
+	"price": 178.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -53436,7 +53436,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "770.00",
+	"price": 770.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -53465,7 +53465,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "79.00",
+	"price": 79.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -53498,8 +53498,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -53525,7 +53525,7 @@
 	"ancestors": [
 		"chr5NRaTh6M7sEKHh"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -53562,7 +53562,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "312.00",
+	"price": 312.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -53595,8 +53595,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -53622,7 +53622,7 @@
 	"ancestors": [
 		"qywfNX6FegWZK8bYF"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -53659,7 +53659,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "408.00",
+	"price": 408.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -53692,8 +53692,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -53719,7 +53719,7 @@
 	"ancestors": [
 		"L7f84v66iECcaqXji"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -53756,7 +53756,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "214.00",
+	"price": 214.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -53785,7 +53785,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "109.00",
+	"price": 109.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -53818,8 +53818,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -53845,7 +53845,7 @@
 	"ancestors": [
 		"Gn45ciT6GE4SFmDFF"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -53882,7 +53882,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "493.00",
+	"price": 493.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -53915,8 +53915,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -53942,7 +53942,7 @@
 	"ancestors": [
 		"QM9Ez5dKEiYgXuq4B"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -53979,7 +53979,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "355.00",
+	"price": 355.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -54012,8 +54012,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -54039,7 +54039,7 @@
 	"ancestors": [
 		"BtsSid7TDmtnRdkdj"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -54076,7 +54076,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "979.00",
+	"price": 979.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -54105,7 +54105,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "664.00",
+	"price": 664.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -54138,8 +54138,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -54165,7 +54165,7 @@
 	"ancestors": [
 		"GASgb32GtG6SqSY6p"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -54202,7 +54202,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "521.00",
+	"price": 521.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -54235,8 +54235,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -54262,7 +54262,7 @@
 	"ancestors": [
 		"mDHoJ2Tyfjk5QiKsw"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -54299,7 +54299,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "422.00",
+	"price": 422.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -54328,7 +54328,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "950.00",
+	"price": 950.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -54361,8 +54361,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -54388,7 +54388,7 @@
 	"ancestors": [
 		"ra7fTrcrdQXoFHCsx"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -54425,7 +54425,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "833.00",
+	"price": 833.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -54454,7 +54454,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "974.00",
+	"price": 974.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -54483,7 +54483,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "574.00",
+	"price": 574.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -54512,7 +54512,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "931.00",
+	"price": 931.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -54545,8 +54545,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -54572,7 +54572,7 @@
 	"ancestors": [
 		"EaRuoBuSDDydYrqrc"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -54609,7 +54609,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "693.00",
+	"price": 693.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -54638,7 +54638,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "415.00",
+	"price": 415.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -54667,7 +54667,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "767.00",
+	"price": 767.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -54696,7 +54696,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "398.00",
+	"price": 398.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -54729,8 +54729,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -54756,7 +54756,7 @@
 	"ancestors": [
 		"rBGDjrrcqATFZejZE"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -54793,7 +54793,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "871.00",
+	"price": 871.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -54822,7 +54822,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "6.00",
+	"price": 6.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -54855,8 +54855,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -54882,7 +54882,7 @@
 	"ancestors": [
 		"s8dLGzYTtoddm3r3H"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -54919,7 +54919,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "585.00",
+	"price": 585.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -54948,7 +54948,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "704.00",
+	"price": 704.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -54981,8 +54981,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -55008,7 +55008,7 @@
 	"ancestors": [
 		"a26aufhXAXEHGymkT"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -55045,7 +55045,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "89.00",
+	"price": 89.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -55078,8 +55078,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -55105,7 +55105,7 @@
 	"ancestors": [
 		"2Yi7Y7DW6FJN2zLnz"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -55142,7 +55142,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "145.00",
+	"price": 145.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -55171,7 +55171,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "184.00",
+	"price": 184.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -55200,7 +55200,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "82.00",
+	"price": 82.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -55229,7 +55229,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "678.00",
+	"price": 678.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -55262,8 +55262,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -55289,7 +55289,7 @@
 	"ancestors": [
 		"3iW7vnhfEgHNHSKeW"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -55326,7 +55326,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "71.00",
+	"price": 71.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -55359,8 +55359,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -55386,7 +55386,7 @@
 	"ancestors": [
 		"ms9rx77mmxtr5ecqz"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -55423,7 +55423,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "714.00",
+	"price": 714.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -55452,7 +55452,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "945.00",
+	"price": 945.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -55485,8 +55485,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -55512,7 +55512,7 @@
 	"ancestors": [
 		"cKkYbJZEENhDbXMoR"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -55549,7 +55549,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "352.00",
+	"price": 352.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -55578,7 +55578,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "462.00",
+	"price": 462.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -55611,8 +55611,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -55638,7 +55638,7 @@
 	"ancestors": [
 		"viiiZZzaPw8anfrXz"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -55675,7 +55675,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "51.00",
+	"price": 51.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -55704,7 +55704,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "391.00",
+	"price": 391.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -55737,8 +55737,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -55764,7 +55764,7 @@
 	"ancestors": [
 		"7tG5HG5hjHZZRuxRk"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -55801,7 +55801,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "150.00",
+	"price": 150.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -55830,7 +55830,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "65.00",
+	"price": 65.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -55859,7 +55859,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "28.00",
+	"price": 28.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -55888,7 +55888,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "144.00",
+	"price": 144.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -55921,8 +55921,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -55948,7 +55948,7 @@
 	"ancestors": [
 		"K5zHBPkgBweJhkqd9"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -55985,7 +55985,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "941.00",
+	"price": 941.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -56014,7 +56014,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "678.00",
+	"price": 678.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -56043,7 +56043,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "67.00",
+	"price": 67.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -56076,8 +56076,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -56103,7 +56103,7 @@
 	"ancestors": [
 		"7didqtNecFG2bEpjE"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -56140,7 +56140,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "604.00",
+	"price": 604.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -56173,8 +56173,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -56200,7 +56200,7 @@
 	"ancestors": [
 		"5F5gTNZyzdm92qHsR"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -56237,7 +56237,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "997.00",
+	"price": 997.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -56266,7 +56266,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "145.00",
+	"price": 145.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -56299,8 +56299,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -56326,7 +56326,7 @@
 	"ancestors": [
 		"9MWowb3foNYCSirjT"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -56363,7 +56363,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "844.00",
+	"price": 844.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -56392,7 +56392,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "32.00",
+	"price": 32.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -56425,8 +56425,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -56452,7 +56452,7 @@
 	"ancestors": [
 		"tsooi8dHL4XpMBP3Y"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -56489,7 +56489,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "347.00",
+	"price": 347.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -56518,7 +56518,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "776.00",
+	"price": 776.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -56551,8 +56551,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -56578,7 +56578,7 @@
 	"ancestors": [
 		"EiNu5Ph3YcRYTgcvX"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -56615,7 +56615,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "715.00",
+	"price": 715.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -56644,7 +56644,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "949.00",
+	"price": 949.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -56673,7 +56673,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "528.00",
+	"price": 528.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -56702,7 +56702,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "873.00",
+	"price": 873.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -56735,8 +56735,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -56762,7 +56762,7 @@
 	"ancestors": [
 		"9uvaZjBoAfdBnihj2"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -56799,7 +56799,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "919.00",
+	"price": 919.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -56828,7 +56828,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "981.00",
+	"price": 981.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -56861,8 +56861,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -56888,7 +56888,7 @@
 	"ancestors": [
 		"rj7NFQ5FTsgvrxWmq"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -56925,7 +56925,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "960.00",
+	"price": 960.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -56954,7 +56954,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "87.00",
+	"price": 87.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -56987,8 +56987,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -57014,7 +57014,7 @@
 	"ancestors": [
 		"SiRHvCEcktbotYL7w"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -57051,7 +57051,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "630.00",
+	"price": 630.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -57080,7 +57080,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "242.00",
+	"price": 242.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -57109,7 +57109,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "466.00",
+	"price": 466.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -57142,8 +57142,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -57169,7 +57169,7 @@
 	"ancestors": [
 		"2ZNFx2K69iZHjRMsi"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -57206,7 +57206,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "584.00",
+	"price": 584.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -57235,7 +57235,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "259.00",
+	"price": 259.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -57268,8 +57268,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -57295,7 +57295,7 @@
 	"ancestors": [
 		"Lp3u4rezHrRKPAMSA"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -57332,7 +57332,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "831.00",
+	"price": 831.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -57361,7 +57361,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "614.00",
+	"price": 614.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -57390,7 +57390,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "253.00",
+	"price": 253.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -57419,7 +57419,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "629.00",
+	"price": 629.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -57452,8 +57452,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -57479,7 +57479,7 @@
 	"ancestors": [
 		"fBKMtvjCTxqXqX2Tn"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -57516,7 +57516,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "672.00",
+	"price": 672.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -57545,7 +57545,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "816.00",
+	"price": 816.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -57574,7 +57574,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "461.00",
+	"price": 461.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -57603,7 +57603,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "298.00",
+	"price": 298.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -57636,8 +57636,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -57663,7 +57663,7 @@
 	"ancestors": [
 		"teB6bs4koRWd92pQE"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -57700,7 +57700,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "611.00",
+	"price": 611.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -57729,7 +57729,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "782.00",
+	"price": 782.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -57758,7 +57758,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "294.00",
+	"price": 294.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -57787,7 +57787,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "797.00",
+	"price": 797.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -57820,8 +57820,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -57847,7 +57847,7 @@
 	"ancestors": [
 		"7b7YhokghhHmma89p"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -57884,7 +57884,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "300.00",
+	"price": 300.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -57913,7 +57913,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "500.00",
+	"price": 500.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -57942,7 +57942,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "404.00",
+	"price": 404.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -57975,8 +57975,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -58002,7 +58002,7 @@
 	"ancestors": [
 		"NwCgtAboPPBLmyQNE"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -58039,7 +58039,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "62.00",
+	"price": 62.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -58068,7 +58068,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "415.00",
+	"price": 415.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -58101,8 +58101,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -58128,7 +58128,7 @@
 	"ancestors": [
 		"8DLX5QcnwYhstdJtR"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -58165,7 +58165,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "468.00",
+	"price": 468.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -58194,7 +58194,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "119.00",
+	"price": 119.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -58223,7 +58223,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "354.00",
+	"price": 354.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -58252,7 +58252,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "690.00",
+	"price": 690.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -58285,8 +58285,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -58312,7 +58312,7 @@
 	"ancestors": [
 		"CuDg6gMdu2HatCofh"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -58349,7 +58349,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "999.00",
+	"price": 999.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -58382,8 +58382,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -58409,7 +58409,7 @@
 	"ancestors": [
 		"yectfCBKaMxjHXJEy"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -58446,7 +58446,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "221.00",
+	"price": 221.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -58479,8 +58479,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -58506,7 +58506,7 @@
 	"ancestors": [
 		"9b3NNBSEJfntTzYJW"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -58543,7 +58543,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "46.00",
+	"price": 46.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -58576,8 +58576,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -58603,7 +58603,7 @@
 	"ancestors": [
 		"ENXSAcEuCDxyAkc2D"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -58640,7 +58640,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "126.00",
+	"price": 126.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -58673,8 +58673,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -58700,7 +58700,7 @@
 	"ancestors": [
 		"EyxA3qgKww8KAwsEd"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -58737,7 +58737,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "911.00",
+	"price": 911.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -58766,7 +58766,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "922.00",
+	"price": 922.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -58795,7 +58795,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "372.00",
+	"price": 372.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -58824,7 +58824,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "55.00",
+	"price": 55.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -58857,8 +58857,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -58884,7 +58884,7 @@
 	"ancestors": [
 		"jHA8CbXSt5ds9BMTk"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -58921,7 +58921,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "58.00",
+	"price": 58.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -58950,7 +58950,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "780.00",
+	"price": 780.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -58979,7 +58979,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "229.00",
+	"price": 229.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -59008,7 +59008,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "744.00",
+	"price": 744.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -59041,8 +59041,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -59068,7 +59068,7 @@
 	"ancestors": [
 		"gDH2ju2Scb9PQ8vdp"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -59105,7 +59105,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "530.00",
+	"price": 530.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -59134,7 +59134,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "941.00",
+	"price": 941.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -59163,7 +59163,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "245.00",
+	"price": 245.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -59192,7 +59192,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "575.00",
+	"price": 575.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -59225,8 +59225,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -59252,7 +59252,7 @@
 	"ancestors": [
 		"vKCfzcf8uQ3h4k3xT"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -59289,7 +59289,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "121.00",
+	"price": 121.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -59318,7 +59318,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "657.00",
+	"price": 657.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -59347,7 +59347,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "781.00",
+	"price": 781.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -59376,7 +59376,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "145.00",
+	"price": 145.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -59409,8 +59409,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -59436,7 +59436,7 @@
 	"ancestors": [
 		"6sxTDumbhALw5sf6W"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -59473,7 +59473,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "859.00",
+	"price": 859.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -59506,8 +59506,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -59533,7 +59533,7 @@
 	"ancestors": [
 		"j5XJHz6Ae9ce48saA"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -59570,7 +59570,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "68.00",
+	"price": 68.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -59603,8 +59603,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -59630,7 +59630,7 @@
 	"ancestors": [
 		"HQkMXazaJFMR8FRZi"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -59667,7 +59667,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "988.00",
+	"price": 988.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -59696,7 +59696,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "666.00",
+	"price": 666.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -59725,7 +59725,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "100.00",
+	"price": 100.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -59754,7 +59754,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "508.00",
+	"price": 508.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -59787,8 +59787,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -59814,7 +59814,7 @@
 	"ancestors": [
 		"b9pWBdsGdxjoS2sZd"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -59851,7 +59851,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "621.00",
+	"price": 621.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -59880,7 +59880,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "606.00",
+	"price": 606.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -59913,8 +59913,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -59940,7 +59940,7 @@
 	"ancestors": [
 		"AjJGMtn6rA6WQ7j7M"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -59977,7 +59977,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "416.00",
+	"price": 416.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -60006,7 +60006,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "330.00",
+	"price": 330.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -60039,8 +60039,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -60066,7 +60066,7 @@
 	"ancestors": [
 		"uifiojRwLM73HhKMa"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -60103,7 +60103,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "220.00",
+	"price": 220.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -60136,8 +60136,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -60163,7 +60163,7 @@
 	"ancestors": [
 		"zSyuupLPZSQBf4FNR"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -60200,7 +60200,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "639.00",
+	"price": 639.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -60229,7 +60229,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "480.00",
+	"price": 480.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -60258,7 +60258,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "761.00",
+	"price": 761.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -60287,7 +60287,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "615.00",
+	"price": 615.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -60320,8 +60320,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -60347,7 +60347,7 @@
 	"ancestors": [
 		"Fs7mhLP3MaCQHdcne"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -60384,7 +60384,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "433.00",
+	"price": 433.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -60417,8 +60417,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -60444,7 +60444,7 @@
 	"ancestors": [
 		"9LQnQHWGcsKxmZdA3"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -60481,7 +60481,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "589.00",
+	"price": 589.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -60514,8 +60514,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -60541,7 +60541,7 @@
 	"ancestors": [
 		"j3oNNKpcuhW8GiHgy"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -60578,7 +60578,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "748.00",
+	"price": 748.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -60611,8 +60611,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -60638,7 +60638,7 @@
 	"ancestors": [
 		"7MwHEDyzMTZ9t4bsg"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -60675,7 +60675,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "39.00",
+	"price": 39.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -60704,7 +60704,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "824.00",
+	"price": 824.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -60737,8 +60737,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -60764,7 +60764,7 @@
 	"ancestors": [
 		"JJwAMf64KguhCWva2"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -60801,7 +60801,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "784.00",
+	"price": 784.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -60830,7 +60830,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "367.00",
+	"price": 367.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -60859,7 +60859,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "4.00",
+	"price": 4.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -60888,7 +60888,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "891.00",
+	"price": 891.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -60921,8 +60921,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -60948,7 +60948,7 @@
 	"ancestors": [
 		"dYQ4dmQv3AkzfWLZo"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -60985,7 +60985,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "222.00",
+	"price": 222.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -61014,7 +61014,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "108.00",
+	"price": 108.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -61043,7 +61043,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "372.00",
+	"price": 372.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -61072,7 +61072,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "286.00",
+	"price": 286.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -61105,8 +61105,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -61132,7 +61132,7 @@
 	"ancestors": [
 		"Jo5mP2vAGMtuD3sc6"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -61169,7 +61169,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "175.00",
+	"price": 175.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -61198,7 +61198,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "982.00",
+	"price": 982.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -61227,7 +61227,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "777.00",
+	"price": 777.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -61260,8 +61260,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -61287,7 +61287,7 @@
 	"ancestors": [
 		"3fSFXs64ZdFsJB5hR"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -61324,7 +61324,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "896.00",
+	"price": 896.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -61353,7 +61353,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "330.00",
+	"price": 330.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -61386,8 +61386,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -61413,7 +61413,7 @@
 	"ancestors": [
 		"inBeunsiovzfiHWyY"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -61450,7 +61450,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "764.00",
+	"price": 764.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -61479,7 +61479,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "435.00",
+	"price": 435.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -61512,8 +61512,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -61539,7 +61539,7 @@
 	"ancestors": [
 		"Cbyj7fEpBE3qw5rqi"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -61576,7 +61576,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "371.00",
+	"price": 371.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -61605,7 +61605,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "726.00",
+	"price": 726.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -61638,8 +61638,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -61665,7 +61665,7 @@
 	"ancestors": [
 		"FR2yGXv4zW7KkSWiu"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -61702,7 +61702,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "52.00",
+	"price": 52.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -61731,7 +61731,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "281.00",
+	"price": 281.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -61760,7 +61760,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "698.00",
+	"price": 698.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -61793,8 +61793,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -61820,7 +61820,7 @@
 	"ancestors": [
 		"3WofZ6W5hAKnQWvkE"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -61857,7 +61857,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "456.00",
+	"price": 456.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -61886,7 +61886,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "35.00",
+	"price": 35.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -61915,7 +61915,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "959.00",
+	"price": 959.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -61944,7 +61944,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "913.00",
+	"price": 913.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -61977,8 +61977,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -62004,7 +62004,7 @@
 	"ancestors": [
 		"9bMYz5zfuhvDdMG2R"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -62041,7 +62041,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "511.00",
+	"price": 511.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -62070,7 +62070,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "64.00",
+	"price": 64.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -62099,7 +62099,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "786.00",
+	"price": 786.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -62132,8 +62132,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -62159,7 +62159,7 @@
 	"ancestors": [
 		"nKMRrn3MbyCohFDDS"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -62196,7 +62196,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "152.00",
+	"price": 152.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -62229,8 +62229,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -62256,7 +62256,7 @@
 	"ancestors": [
 		"LC6xrDnujpr42xrii"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -62293,7 +62293,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "665.00",
+	"price": 665.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -62322,7 +62322,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "890.00",
+	"price": 890.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -62351,7 +62351,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "413.00",
+	"price": 413.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -62384,8 +62384,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -62411,7 +62411,7 @@
 	"ancestors": [
 		"HasQYPE58pCmk7iLg"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -62448,7 +62448,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "996.00",
+	"price": 996.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -62477,7 +62477,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "891.00",
+	"price": 891.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -62506,7 +62506,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "532.00",
+	"price": 532.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -62535,7 +62535,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "333.00",
+	"price": 333.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -62568,8 +62568,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -62595,7 +62595,7 @@
 	"ancestors": [
 		"2N4p8GBidFNfz8YLj"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -62632,7 +62632,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "482.00",
+	"price": 482.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -62661,7 +62661,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "554.00",
+	"price": 554.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -62694,8 +62694,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -62721,7 +62721,7 @@
 	"ancestors": [
 		"vLaCJ7GWHqQ6RbBZw"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -62758,7 +62758,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "189.00",
+	"price": 189.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -62787,7 +62787,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "682.00",
+	"price": 682.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -62816,7 +62816,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "221.00",
+	"price": 221.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -62845,7 +62845,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "104.00",
+	"price": 104.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -62878,8 +62878,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -62905,7 +62905,7 @@
 	"ancestors": [
 		"R764Z5CySPcsaWhxz"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -62942,7 +62942,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "965.00",
+	"price": 965.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -62971,7 +62971,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "682.00",
+	"price": 682.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -63000,7 +63000,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "209.00",
+	"price": 209.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -63033,8 +63033,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -63060,7 +63060,7 @@
 	"ancestors": [
 		"NzQF32SPPnvjQLNoX"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -63097,7 +63097,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "431.00",
+	"price": 431.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -63130,8 +63130,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -63157,7 +63157,7 @@
 	"ancestors": [
 		"3EZirrr4kkbZswjgf"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -63194,7 +63194,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "866.00",
+	"price": 866.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -63223,7 +63223,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "831.00",
+	"price": 831.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -63256,8 +63256,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -63283,7 +63283,7 @@
 	"ancestors": [
 		"ELqwzD9TBLg27DjZD"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -63320,7 +63320,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "247.00",
+	"price": 247.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -63349,7 +63349,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "319.00",
+	"price": 319.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -63382,8 +63382,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -63409,7 +63409,7 @@
 	"ancestors": [
 		"tD7WmJvDeE97QFej9"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -63446,7 +63446,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "891.00",
+	"price": 891.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -63475,7 +63475,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "657.00",
+	"price": 657.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -63504,7 +63504,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "596.00",
+	"price": 596.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -63537,8 +63537,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -63564,7 +63564,7 @@
 	"ancestors": [
 		"dCpnGuvxo2BuZoiFg"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -63601,7 +63601,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "80.00",
+	"price": 80.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -63630,7 +63630,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "33.00",
+	"price": 33.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -63659,7 +63659,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "198.00",
+	"price": 198.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -63688,7 +63688,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "376.00",
+	"price": 376.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -63721,8 +63721,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -63748,7 +63748,7 @@
 	"ancestors": [
 		"zfvxyELyR62LLwD6J"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -63785,7 +63785,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "975.00",
+	"price": 975.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -63814,7 +63814,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "228.00",
+	"price": 228.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -63843,7 +63843,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "95.00",
+	"price": 95.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -63872,7 +63872,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "88.00",
+	"price": 88.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -63905,8 +63905,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -63932,7 +63932,7 @@
 	"ancestors": [
 		"NT7ZTCjcyKQLYKrSR"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -63969,7 +63969,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "602.00",
+	"price": 602.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -63998,7 +63998,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "473.00",
+	"price": 473.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -64027,7 +64027,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "700.00",
+	"price": 700.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -64056,7 +64056,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "668.00",
+	"price": 668.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -64089,8 +64089,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -64116,7 +64116,7 @@
 	"ancestors": [
 		"8PbMJBLyQxcqaTobW"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -64153,7 +64153,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "365.00",
+	"price": 365.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -64182,7 +64182,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "966.00",
+	"price": 966.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -64215,8 +64215,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -64242,7 +64242,7 @@
 	"ancestors": [
 		"RMaf7A6m8W2LBJh86"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -64279,7 +64279,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "570.00",
+	"price": 570.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -64308,7 +64308,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "77.00",
+	"price": 77.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -64337,7 +64337,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "314.00",
+	"price": 314.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -64366,7 +64366,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "980.00",
+	"price": 980.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -64399,8 +64399,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -64426,7 +64426,7 @@
 	"ancestors": [
 		"T7K88Q5NH72HK7bqh"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -64463,7 +64463,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "637.00",
+	"price": 637.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -64496,8 +64496,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -64523,7 +64523,7 @@
 	"ancestors": [
 		"mNT5PAxoWBQRSAjzB"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -64560,7 +64560,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "818.00",
+	"price": 818.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -64589,7 +64589,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "741.00",
+	"price": 741.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -64622,8 +64622,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -64649,7 +64649,7 @@
 	"ancestors": [
 		"ZFb7BZNyWMN3WqDna"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -64686,7 +64686,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "530.00",
+	"price": 530.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -64715,7 +64715,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "567.00",
+	"price": 567.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -64748,8 +64748,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -64775,7 +64775,7 @@
 	"ancestors": [
 		"Wwj6WEvb5SDmx2NiC"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -64812,7 +64812,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "816.00",
+	"price": 816.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -64841,7 +64841,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "656.00",
+	"price": 656.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -64870,7 +64870,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "264.00",
+	"price": 264.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -64903,8 +64903,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -64930,7 +64930,7 @@
 	"ancestors": [
 		"mZN8bpYedqGSzhdip"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -64967,7 +64967,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "434.00",
+	"price": 434.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -64996,7 +64996,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "93.00",
+	"price": 93.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -65025,7 +65025,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "691.00",
+	"price": 691.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -65058,8 +65058,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -65085,7 +65085,7 @@
 	"ancestors": [
 		"JLXwJzNxwYqhoY3Bh"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -65122,7 +65122,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "395.00",
+	"price": 395.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -65151,7 +65151,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "442.00",
+	"price": 442.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -65184,8 +65184,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -65211,7 +65211,7 @@
 	"ancestors": [
 		"8xrmhH34Xv7NTvPu5"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -65248,7 +65248,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "141.00",
+	"price": 141.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -65277,7 +65277,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "819.00",
+	"price": 819.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -65306,7 +65306,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "334.00",
+	"price": 334.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -65335,7 +65335,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "460.00",
+	"price": 460.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -65368,8 +65368,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -65395,7 +65395,7 @@
 	"ancestors": [
 		"aJEuNAoHEmFXEZ5fi"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -65432,7 +65432,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "364.00",
+	"price": 364.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -65461,7 +65461,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "328.00",
+	"price": 328.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -65490,7 +65490,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "81.00",
+	"price": 81.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -65519,7 +65519,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "893.00",
+	"price": 893.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -65552,8 +65552,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -65579,7 +65579,7 @@
 	"ancestors": [
 		"nrXsPTni9BBo7EHDA"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -65616,7 +65616,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "632.00",
+	"price": 632.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -65645,7 +65645,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "668.00",
+	"price": 668.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -65678,8 +65678,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -65705,7 +65705,7 @@
 	"ancestors": [
 		"ZEjb5yDWqc358n87i"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -65742,7 +65742,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "584.00",
+	"price": 584.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -65775,8 +65775,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -65802,7 +65802,7 @@
 	"ancestors": [
 		"d8DSuXKSuDZYpZ9bk"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -65839,7 +65839,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "547.00",
+	"price": 547.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -65868,7 +65868,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "919.00",
+	"price": 919.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -65901,8 +65901,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -65928,7 +65928,7 @@
 	"ancestors": [
 		"HKxepwEryFm2vLCc3"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -65965,7 +65965,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "113.00",
+	"price": 113.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -65994,7 +65994,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "383.00",
+	"price": 383.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -66027,8 +66027,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -66054,7 +66054,7 @@
 	"ancestors": [
 		"ao4BRNMDzDnMQpDzz"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -66091,7 +66091,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "543.00",
+	"price": 543.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -66120,7 +66120,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "950.00",
+	"price": 950.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -66149,7 +66149,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "176.00",
+	"price": 176.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -66182,8 +66182,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -66209,7 +66209,7 @@
 	"ancestors": [
 		"YYEbSA3SMQSBsoqJp"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -66246,7 +66246,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "828.00",
+	"price": 828.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -66275,7 +66275,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "881.00",
+	"price": 881.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -66308,8 +66308,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -66335,7 +66335,7 @@
 	"ancestors": [
 		"9im8pfEEcbWSMQjFS"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -66372,7 +66372,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "415.00",
+	"price": 415.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -66401,7 +66401,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "5.00",
+	"price": 5.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -66434,8 +66434,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -66461,7 +66461,7 @@
 	"ancestors": [
 		"ggqWn9hTPuCB68Qtx"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -66498,7 +66498,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "644.00",
+	"price": 644.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -66527,7 +66527,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "94.00",
+	"price": 94.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -66556,7 +66556,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "950.00",
+	"price": 950.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -66585,7 +66585,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "561.00",
+	"price": 561.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -66618,8 +66618,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -66645,7 +66645,7 @@
 	"ancestors": [
 		"uYvuucgCB5b3iBrZc"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -66682,7 +66682,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "9.00",
+	"price": 9.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -66711,7 +66711,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "752.00",
+	"price": 752.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -66740,7 +66740,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "452.00",
+	"price": 452.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -66773,8 +66773,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -66800,7 +66800,7 @@
 	"ancestors": [
 		"WL2nnHS8v58NrnXik"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -66837,7 +66837,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "923.00",
+	"price": 923.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -66866,7 +66866,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "965.00",
+	"price": 965.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -66895,7 +66895,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "511.00",
+	"price": 511.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -66928,8 +66928,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -66955,7 +66955,7 @@
 	"ancestors": [
 		"mAXQWkcnDKADCwcMz"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -66992,7 +66992,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "540.00",
+	"price": 540.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -67021,7 +67021,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "837.00",
+	"price": 837.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -67050,7 +67050,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "27.00",
+	"price": 27.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -67083,8 +67083,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -67110,7 +67110,7 @@
 	"ancestors": [
 		"BsCyK4hHhRf2W8Bs5"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -67147,7 +67147,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "501.00",
+	"price": 501.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -67180,8 +67180,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -67207,7 +67207,7 @@
 	"ancestors": [
 		"joMXnpcLNFRgEh7AQ"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -67244,7 +67244,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "576.00",
+	"price": 576.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -67273,7 +67273,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "619.00",
+	"price": 619.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -67306,8 +67306,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -67333,7 +67333,7 @@
 	"ancestors": [
 		"wqoaJEWeyn8pHrsi4"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -67370,7 +67370,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "783.00",
+	"price": 783.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -67399,7 +67399,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "645.00",
+	"price": 645.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -67428,7 +67428,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "565.00",
+	"price": 565.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -67461,8 +67461,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -67488,7 +67488,7 @@
 	"ancestors": [
 		"y8zKq8CZbxzZi65bj"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -67525,7 +67525,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "675.00",
+	"price": 675.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -67554,7 +67554,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "423.00",
+	"price": 423.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -67583,7 +67583,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "977.00",
+	"price": 977.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -67612,7 +67612,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "950.00",
+	"price": 950.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -67645,8 +67645,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -67672,7 +67672,7 @@
 	"ancestors": [
 		"sTFzgpZmrNu59Q7Kz"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -67709,7 +67709,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "317.00",
+	"price": 317.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -67738,7 +67738,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "937.00",
+	"price": 937.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -67771,8 +67771,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -67798,7 +67798,7 @@
 	"ancestors": [
 		"M3vfzodY6pHKPLKe8"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -67835,7 +67835,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "198.00",
+	"price": 198.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -67864,7 +67864,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "710.00",
+	"price": 710.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -67893,7 +67893,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "135.00",
+	"price": 135.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -67926,8 +67926,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -67953,7 +67953,7 @@
 	"ancestors": [
 		"EBe67FYesCHf6qkpu"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -67990,7 +67990,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "939.00",
+	"price": 939.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -68019,7 +68019,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "32.00",
+	"price": 32.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -68048,7 +68048,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "462.00",
+	"price": 462.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -68081,8 +68081,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -68108,7 +68108,7 @@
 	"ancestors": [
 		"bfHquAeWsa6gCiSXH"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -68145,7 +68145,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "375.00",
+	"price": 375.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -68174,7 +68174,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "464.00",
+	"price": 464.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -68207,8 +68207,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -68234,7 +68234,7 @@
 	"ancestors": [
 		"FbuuKimx5Wzn6qG9P"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -68271,7 +68271,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "617.00",
+	"price": 617.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -68300,7 +68300,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "859.00",
+	"price": 859.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -68333,8 +68333,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -68360,7 +68360,7 @@
 	"ancestors": [
 		"2zG6duoxRPG23irsz"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -68397,7 +68397,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "458.00",
+	"price": 458.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -68426,7 +68426,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "471.00",
+	"price": 471.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -68459,8 +68459,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -68486,7 +68486,7 @@
 	"ancestors": [
 		"wLF8zB3W7JRMBgJmy"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -68523,7 +68523,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "373.00",
+	"price": 373.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -68552,7 +68552,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "987.00",
+	"price": 987.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -68581,7 +68581,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "901.00",
+	"price": 901.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -68614,8 +68614,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -68641,7 +68641,7 @@
 	"ancestors": [
 		"zrSoY6umnG9DecxnH"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -68678,7 +68678,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "317.00",
+	"price": 317.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -68711,8 +68711,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -68738,7 +68738,7 @@
 	"ancestors": [
 		"qNSNgP5QEMJMsxjvB"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -68775,7 +68775,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "784.00",
+	"price": 784.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -68808,8 +68808,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -68835,7 +68835,7 @@
 	"ancestors": [
 		"sNpDGD3HrawRDcsaq"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -68872,7 +68872,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "60.00",
+	"price": 60.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -68901,7 +68901,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "415.00",
+	"price": 415.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -68934,8 +68934,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -68961,7 +68961,7 @@
 	"ancestors": [
 		"sDX6iHvLYvRqfqsiZ"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -68998,7 +68998,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "924.00",
+	"price": 924.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -69031,8 +69031,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -69058,7 +69058,7 @@
 	"ancestors": [
 		"ShZnfxzHWMuzD3kyv"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -69095,7 +69095,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "684.00",
+	"price": 684.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -69124,7 +69124,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "113.00",
+	"price": 113.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -69157,8 +69157,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -69184,7 +69184,7 @@
 	"ancestors": [
 		"ZHhFdyBe9v3PgjRZD"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -69221,7 +69221,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "313.00",
+	"price": 313.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -69250,7 +69250,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "877.00",
+	"price": 877.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -69279,7 +69279,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "99.00",
+	"price": 99.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -69308,7 +69308,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "20.00",
+	"price": 20.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -69341,8 +69341,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -69368,7 +69368,7 @@
 	"ancestors": [
 		"8JQDkQwJQJo7DQfXp"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -69405,7 +69405,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "143.00",
+	"price": 143.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -69434,7 +69434,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "850.00",
+	"price": 850.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -69467,8 +69467,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -69494,7 +69494,7 @@
 	"ancestors": [
 		"ez3dkymXxGEiMqe7X"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -69531,7 +69531,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "337.00",
+	"price": 337.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -69560,7 +69560,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "106.00",
+	"price": 106.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -69589,7 +69589,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "367.00",
+	"price": 367.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -69622,8 +69622,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -69649,7 +69649,7 @@
 	"ancestors": [
 		"Q6Jd372nQnCK2FX8s"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -69686,7 +69686,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "294.00",
+	"price": 294.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -69715,7 +69715,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "348.00",
+	"price": 348.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -69744,7 +69744,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "2.00",
+	"price": 2.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -69773,7 +69773,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "262.00",
+	"price": 262.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -69806,8 +69806,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -69833,7 +69833,7 @@
 	"ancestors": [
 		"bY5gx9FTXSygQYbkz"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -69870,7 +69870,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "581.00",
+	"price": 581.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -69899,7 +69899,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "1.00",
+	"price": 1.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -69928,7 +69928,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "490.00",
+	"price": 490.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -69961,8 +69961,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -69988,7 +69988,7 @@
 	"ancestors": [
 		"dwNnBpstaRRKDFqzj"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -70025,7 +70025,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "938.00",
+	"price": 938.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -70058,8 +70058,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -70085,7 +70085,7 @@
 	"ancestors": [
 		"hnQdkgatpts7tHRdy"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -70122,7 +70122,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "124.00",
+	"price": 124.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -70151,7 +70151,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "139.00",
+	"price": 139.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -70180,7 +70180,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "484.00",
+	"price": 484.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -70209,7 +70209,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "108.00",
+	"price": 108.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -70242,8 +70242,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -70269,7 +70269,7 @@
 	"ancestors": [
 		"7JckownNYZKd2ku6A"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -70306,7 +70306,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "680.00",
+	"price": 680.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -70335,7 +70335,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "235.00",
+	"price": 235.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -70368,8 +70368,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -70395,7 +70395,7 @@
 	"ancestors": [
 		"8a5pJGq63ytPgoLoq"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -70432,7 +70432,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "879.00",
+	"price": 879.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -70461,7 +70461,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "272.00",
+	"price": 272.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -70490,7 +70490,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "561.00",
+	"price": 561.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -70519,7 +70519,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "297.00",
+	"price": 297.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -70552,8 +70552,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -70579,7 +70579,7 @@
 	"ancestors": [
 		"KxmAfa28yEszAqYSz"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -70616,7 +70616,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "195.00",
+	"price": 195.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -70645,7 +70645,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "426.00",
+	"price": 426.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -70678,8 +70678,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -70705,7 +70705,7 @@
 	"ancestors": [
 		"o29egC5MtMwujScP9"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -70742,7 +70742,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "653.00",
+	"price": 653.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -70771,7 +70771,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "531.00",
+	"price": 531.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -70800,7 +70800,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "510.00",
+	"price": 510.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -70833,8 +70833,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -70860,7 +70860,7 @@
 	"ancestors": [
 		"bmBuCuzkAtdg4G8sY"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -70897,7 +70897,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "375.00",
+	"price": 375.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -70926,7 +70926,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "716.00",
+	"price": 716.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -70955,7 +70955,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "843.00",
+	"price": 843.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -70988,8 +70988,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -71015,7 +71015,7 @@
 	"ancestors": [
 		"XHsY9ai3py2vE43Rk"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -71052,7 +71052,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "638.00",
+	"price": 638.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -71081,7 +71081,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "517.00",
+	"price": 517.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -71114,8 +71114,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -71141,7 +71141,7 @@
 	"ancestors": [
 		"9CX2PzwPtsMaeWkGi"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -71178,7 +71178,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "839.00",
+	"price": 839.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -71211,8 +71211,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -71238,7 +71238,7 @@
 	"ancestors": [
 		"ShWN4mQNTZo2qQ4zd"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -71275,7 +71275,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "467.00",
+	"price": 467.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -71304,7 +71304,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "32.00",
+	"price": 32.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -71333,7 +71333,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "215.00",
+	"price": 215.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -71362,7 +71362,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "715.00",
+	"price": 715.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -71395,8 +71395,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -71422,7 +71422,7 @@
 	"ancestors": [
 		"9ffjdu2kYDprN7ep5"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -71459,7 +71459,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "241.00",
+	"price": 241.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -71488,7 +71488,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "850.00",
+	"price": 850.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -71517,7 +71517,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "838.00",
+	"price": 838.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -71550,8 +71550,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -71577,7 +71577,7 @@
 	"ancestors": [
 		"pcNFFFSQWXfLNzthG"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -71614,7 +71614,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "939.00",
+	"price": 939.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -71643,7 +71643,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "219.00",
+	"price": 219.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -71672,7 +71672,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "368.00",
+	"price": 368.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -71701,7 +71701,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "732.00",
+	"price": 732.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -71734,8 +71734,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -71761,7 +71761,7 @@
 	"ancestors": [
 		"RLeR5LwPGjQuXroK3"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -71798,7 +71798,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "532.00",
+	"price": 532.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -71827,7 +71827,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "699.00",
+	"price": 699.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -71856,7 +71856,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "310.00",
+	"price": 310.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -71889,8 +71889,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -71916,7 +71916,7 @@
 	"ancestors": [
 		"NsHgD9PRA4K6DsJFa"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -71953,7 +71953,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "380.00",
+	"price": 380.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -71982,7 +71982,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "945.00",
+	"price": 945.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -72011,7 +72011,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "358.00",
+	"price": 358.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -72040,7 +72040,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "14.00",
+	"price": 14.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -72073,8 +72073,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -72100,7 +72100,7 @@
 	"ancestors": [
 		"XotkvxS9hbRMdxkMa"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -72137,7 +72137,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "753.00",
+	"price": 753.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -72170,8 +72170,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -72197,7 +72197,7 @@
 	"ancestors": [
 		"MgvEzpWC4fPxEBcmk"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -72234,7 +72234,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "732.00",
+	"price": 732.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -72263,7 +72263,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "503.00",
+	"price": 503.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -72292,7 +72292,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "64.00",
+	"price": 64.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -72325,8 +72325,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -72352,7 +72352,7 @@
 	"ancestors": [
 		"kGRQ9yF5sX8PKpmjz"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -72389,7 +72389,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "150.00",
+	"price": 150.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -72418,7 +72418,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "174.00",
+	"price": 174.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -72447,7 +72447,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "32.00",
+	"price": 32.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -72480,8 +72480,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -72507,7 +72507,7 @@
 	"ancestors": [
 		"xzRZnzhspjJRJQdbn"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -72544,7 +72544,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "930.00",
+	"price": 930.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -72573,7 +72573,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "237.00",
+	"price": 237.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -72602,7 +72602,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "182.00",
+	"price": 182.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -72635,8 +72635,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -72662,7 +72662,7 @@
 	"ancestors": [
 		"Zj5kQiRnA9eWiebwM"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -72699,7 +72699,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "717.00",
+	"price": 717.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -72728,7 +72728,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "789.00",
+	"price": 789.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -72761,8 +72761,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -72788,7 +72788,7 @@
 	"ancestors": [
 		"8ZW3sZwYNyAE7wYWs"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -72825,7 +72825,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "677.00",
+	"price": 677.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -72854,7 +72854,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "823.00",
+	"price": 823.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -72887,8 +72887,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -72914,7 +72914,7 @@
 	"ancestors": [
 		"6ZR5XnyG6Tvx5RTJX"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -72951,7 +72951,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "278.00",
+	"price": 278.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -72980,7 +72980,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "77.00",
+	"price": 77.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -73013,8 +73013,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -73040,7 +73040,7 @@
 	"ancestors": [
 		"5Yv7r6W7P7G7szABY"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -73077,7 +73077,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "781.00",
+	"price": 781.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -73106,7 +73106,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "626.00",
+	"price": 626.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -73139,8 +73139,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -73166,7 +73166,7 @@
 	"ancestors": [
 		"96Y4HfKiBdosLfbWY"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -73203,7 +73203,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "63.00",
+	"price": 63.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -73236,8 +73236,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -73263,7 +73263,7 @@
 	"ancestors": [
 		"KGBxmnzevL3Y8ZNEn"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -73300,7 +73300,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "637.00",
+	"price": 637.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -73329,7 +73329,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "623.00",
+	"price": 623.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -73362,8 +73362,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -73389,7 +73389,7 @@
 	"ancestors": [
 		"2E58yACHN4JnQFPv9"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -73426,7 +73426,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "330.00",
+	"price": 330.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -73455,7 +73455,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "690.00",
+	"price": 690.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -73484,7 +73484,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "663.00",
+	"price": 663.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -73513,7 +73513,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "618.00",
+	"price": 618.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -73546,8 +73546,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -73573,7 +73573,7 @@
 	"ancestors": [
 		"L5jPA2negLQEgy3o3"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -73610,7 +73610,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "46.00",
+	"price": 46.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -73643,8 +73643,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -73670,7 +73670,7 @@
 	"ancestors": [
 		"YpM9MgDnM6Ezzu55i"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -73707,7 +73707,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "29.00",
+	"price": 29.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -73740,8 +73740,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -73767,7 +73767,7 @@
 	"ancestors": [
 		"vdyBAuix7Gdd5NtQz"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -73804,7 +73804,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "22.00",
+	"price": 22.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -73833,7 +73833,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "940.00",
+	"price": 940.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -73862,7 +73862,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "79.00",
+	"price": 79.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -73895,8 +73895,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -73922,7 +73922,7 @@
 	"ancestors": [
 		"8mQp2AaMQTqfHtWQs"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -73959,7 +73959,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "35.00",
+	"price": 35.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -73988,7 +73988,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "597.00",
+	"price": 597.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -74017,7 +74017,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "134.00",
+	"price": 134.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -74050,8 +74050,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -74077,7 +74077,7 @@
 	"ancestors": [
 		"WTy9eyZtabYunEW2t"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -74114,7 +74114,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "646.00",
+	"price": 646.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -74143,7 +74143,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "3.00",
+	"price": 3.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -74172,7 +74172,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "84.00",
+	"price": 84.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -74205,8 +74205,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -74232,7 +74232,7 @@
 	"ancestors": [
 		"oxk7fxegETdPqr5DT"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -74269,7 +74269,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "923.00",
+	"price": 923.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -74298,7 +74298,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "399.00",
+	"price": 399.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -74331,8 +74331,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -74358,7 +74358,7 @@
 	"ancestors": [
 		"g8mMj85AeDW85MYGY"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -74395,7 +74395,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "29.00",
+	"price": 29.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -74424,7 +74424,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "240.00",
+	"price": 240.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -74453,7 +74453,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "683.00",
+	"price": 683.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -74486,8 +74486,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -74513,7 +74513,7 @@
 	"ancestors": [
 		"A45mJgoE2cRdZ7xqX"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -74550,7 +74550,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "805.00",
+	"price": 805.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -74583,8 +74583,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -74610,7 +74610,7 @@
 	"ancestors": [
 		"jmwTHXk3z5SRwv346"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -74647,7 +74647,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "898.00",
+	"price": 898.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -74676,7 +74676,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "785.00",
+	"price": 785.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -74709,8 +74709,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -74736,7 +74736,7 @@
 	"ancestors": [
 		"QCHqZYXLaA3yZ62mS"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -74773,7 +74773,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "984.00",
+	"price": 984.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -74806,8 +74806,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -74833,7 +74833,7 @@
 	"ancestors": [
 		"PWigqv9kSycRPr4iP"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -74870,7 +74870,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "990.00",
+	"price": 990.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -74899,7 +74899,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "605.00",
+	"price": 605.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -74932,8 +74932,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -74959,7 +74959,7 @@
 	"ancestors": [
 		"zdkpoqGZT9YozpTyJ"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -74996,7 +74996,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "442.00",
+	"price": 442.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -75029,8 +75029,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -75056,7 +75056,7 @@
 	"ancestors": [
 		"LGLwCS8fLcPQ2MFnX"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -75093,7 +75093,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "988.00",
+	"price": 988.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -75122,7 +75122,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "576.00",
+	"price": 576.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -75155,8 +75155,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -75182,7 +75182,7 @@
 	"ancestors": [
 		"QfSw5bgM7Lp85XFum"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -75219,7 +75219,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "907.00",
+	"price": 907.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -75252,8 +75252,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -75279,7 +75279,7 @@
 	"ancestors": [
 		"GbwxayzXmDb2rWdqm"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -75316,7 +75316,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "383.00",
+	"price": 383.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -75349,8 +75349,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -75376,7 +75376,7 @@
 	"ancestors": [
 		"TYp3KPv9TBiQccSoH"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -75413,7 +75413,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "152.00",
+	"price": 152.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -75442,7 +75442,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "840.00",
+	"price": 840.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -75471,7 +75471,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "473.00",
+	"price": 473.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -75500,7 +75500,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "219.00",
+	"price": 219.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -75533,8 +75533,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -75560,7 +75560,7 @@
 	"ancestors": [
 		"5eHnvg3vcj66a3Qqs"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -75597,7 +75597,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "361.00",
+	"price": 361.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -75630,8 +75630,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -75657,7 +75657,7 @@
 	"ancestors": [
 		"DmcLuqLZ8qt9mGvnW"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -75694,7 +75694,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "634.00",
+	"price": 634.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -75723,7 +75723,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "599.00",
+	"price": 599.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -75756,8 +75756,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -75783,7 +75783,7 @@
 	"ancestors": [
 		"eqgMEY9o8jePWcnv2"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -75820,7 +75820,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "599.00",
+	"price": 599.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -75853,8 +75853,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -75880,7 +75880,7 @@
 	"ancestors": [
 		"DJzxmPsr4YkxamSyC"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -75917,7 +75917,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "927.00",
+	"price": 927.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -75950,8 +75950,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -75977,7 +75977,7 @@
 	"ancestors": [
 		"Enj6ZhFJ9GvfQe9SL"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -76014,7 +76014,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "96.00",
+	"price": 96.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -76043,7 +76043,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "498.00",
+	"price": 498.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -76072,7 +76072,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "297.00",
+	"price": 297.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -76101,7 +76101,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "49.00",
+	"price": 49.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -76134,8 +76134,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -76161,7 +76161,7 @@
 	"ancestors": [
 		"75XANnuh9NKBAjKJe"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -76198,7 +76198,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "828.00",
+	"price": 828.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -76231,8 +76231,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -76258,7 +76258,7 @@
 	"ancestors": [
 		"jGLbzA3F9aLRJZW52"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -76295,7 +76295,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "566.00",
+	"price": 566.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -76324,7 +76324,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "869.00",
+	"price": 869.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -76353,7 +76353,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "808.00",
+	"price": 808.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -76386,8 +76386,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -76413,7 +76413,7 @@
 	"ancestors": [
 		"KAoRqA8M3mtfDjGQA"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -76450,7 +76450,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "321.00",
+	"price": 321.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -76479,7 +76479,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "275.00",
+	"price": 275.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -76508,7 +76508,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "712.00",
+	"price": 712.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -76541,8 +76541,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -76568,7 +76568,7 @@
 	"ancestors": [
 		"ieCgec85aD3j55w7u"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -76605,7 +76605,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "972.00",
+	"price": 972.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -76634,7 +76634,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "88.00",
+	"price": 88.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -76663,7 +76663,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "643.00",
+	"price": 643.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -76696,8 +76696,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -76723,7 +76723,7 @@
 	"ancestors": [
 		"fSt2zaCX8pYyZaFrq"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -76760,7 +76760,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "65.00",
+	"price": 65.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -76789,7 +76789,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "459.00",
+	"price": 459.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -76818,7 +76818,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "90.00",
+	"price": 90.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -76851,8 +76851,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -76878,7 +76878,7 @@
 	"ancestors": [
 		"7zmzDgs2XdPFJwSx3"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -76915,7 +76915,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "515.00",
+	"price": 515.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -76948,8 +76948,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -76975,7 +76975,7 @@
 	"ancestors": [
 		"zcGfhWJHxn4GYtr6w"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -77012,7 +77012,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "322.00",
+	"price": 322.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -77045,8 +77045,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -77072,7 +77072,7 @@
 	"ancestors": [
 		"Ko4tcuYREuuFb2LN5"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -77109,7 +77109,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "535.00",
+	"price": 535.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -77142,8 +77142,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -77169,7 +77169,7 @@
 	"ancestors": [
 		"wA3rWKwPPum4SWe6j"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -77206,7 +77206,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "240.00",
+	"price": 240.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -77235,7 +77235,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "581.00",
+	"price": 581.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -77264,7 +77264,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "134.00",
+	"price": 134.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -77293,7 +77293,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "303.00",
+	"price": 303.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -77326,8 +77326,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -77353,7 +77353,7 @@
 	"ancestors": [
 		"sXv9ksbzbEnobyjTA"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -77390,7 +77390,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "738.00",
+	"price": 738.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -77419,7 +77419,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "773.00",
+	"price": 773.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -77448,7 +77448,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "620.00",
+	"price": 620.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -77477,7 +77477,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "997.00",
+	"price": 997.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -77510,8 +77510,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -77537,7 +77537,7 @@
 	"ancestors": [
 		"hgs7Fn6NQWMfPW5cG"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -77574,7 +77574,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "676.00",
+	"price": 676.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -77603,7 +77603,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "384.00",
+	"price": 384.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -77632,7 +77632,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "984.00",
+	"price": 984.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -77661,7 +77661,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "50.00",
+	"price": 50.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -77694,8 +77694,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -77721,7 +77721,7 @@
 	"ancestors": [
 		"DzNE5d4ZRq2xP62Gf"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -77758,7 +77758,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "974.00",
+	"price": 974.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -77787,7 +77787,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "439.00",
+	"price": 439.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -77820,8 +77820,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -77847,7 +77847,7 @@
 	"ancestors": [
 		"jLcePkThmLgrqjzuq"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -77884,7 +77884,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "617.00",
+	"price": 617.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -77913,7 +77913,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "512.00",
+	"price": 512.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -77942,7 +77942,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "303.00",
+	"price": 303.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -77975,8 +77975,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -78002,7 +78002,7 @@
 	"ancestors": [
 		"A9XSuYo6SBq5goJk7"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -78039,7 +78039,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "164.00",
+	"price": 164.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -78068,7 +78068,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "871.00",
+	"price": 871.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -78097,7 +78097,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "122.00",
+	"price": 122.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -78126,7 +78126,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "356.00",
+	"price": 356.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -78159,8 +78159,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -78186,7 +78186,7 @@
 	"ancestors": [
 		"SXJtk9FYHJ5f9M32a"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -78223,7 +78223,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "492.00",
+	"price": 492.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -78252,7 +78252,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "808.00",
+	"price": 808.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -78285,8 +78285,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -78312,7 +78312,7 @@
 	"ancestors": [
 		"7o5nyuBtWMTFznxEb"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -78349,7 +78349,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "186.00",
+	"price": 186.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -78378,7 +78378,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "89.00",
+	"price": 89.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -78407,7 +78407,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "883.00",
+	"price": 883.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -78440,8 +78440,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -78467,7 +78467,7 @@
 	"ancestors": [
 		"rFgDXQaj26Zbvha9v"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -78504,7 +78504,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "595.00",
+	"price": 595.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -78533,7 +78533,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "413.00",
+	"price": 413.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -78562,7 +78562,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "616.00",
+	"price": 616.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -78591,7 +78591,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "394.00",
+	"price": 394.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -78624,8 +78624,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -78651,7 +78651,7 @@
 	"ancestors": [
 		"ffz86otdLniG22Jx3"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -78688,7 +78688,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "926.00",
+	"price": 926.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -78717,7 +78717,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "318.00",
+	"price": 318.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -78750,8 +78750,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -78777,7 +78777,7 @@
 	"ancestors": [
 		"qT6Q27ZgPydPf4AN8"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -78814,7 +78814,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "519.00",
+	"price": 519.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -78843,7 +78843,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "426.00",
+	"price": 426.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -78872,7 +78872,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "31.00",
+	"price": 31.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -78905,8 +78905,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -78932,7 +78932,7 @@
 	"ancestors": [
 		"9jwkwXcatbiByRWws"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -78969,7 +78969,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "783.00",
+	"price": 783.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -78998,7 +78998,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "451.00",
+	"price": 451.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -79027,7 +79027,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "650.00",
+	"price": 650.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -79060,8 +79060,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -79087,7 +79087,7 @@
 	"ancestors": [
 		"fvgXFz69LvLK3f28c"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -79124,7 +79124,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "284.00",
+	"price": 284.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -79157,8 +79157,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -79184,7 +79184,7 @@
 	"ancestors": [
 		"nxiWbakBDF38BydHC"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -79221,7 +79221,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "311.00",
+	"price": 311.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -79250,7 +79250,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "126.00",
+	"price": 126.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -79283,8 +79283,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -79310,7 +79310,7 @@
 	"ancestors": [
 		"B4NAWTKhHiW8eWRCH"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -79347,7 +79347,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "34.00",
+	"price": 34.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -79376,7 +79376,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "851.00",
+	"price": 851.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -79409,8 +79409,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -79436,7 +79436,7 @@
 	"ancestors": [
 		"24NA4BtpWDqrPbT3Z"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -79473,7 +79473,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "208.00",
+	"price": 208.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -79502,7 +79502,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "958.00",
+	"price": 958.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -79535,8 +79535,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -79562,7 +79562,7 @@
 	"ancestors": [
 		"tzvq86xEdbz9FMhsD"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -79599,7 +79599,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "501.00",
+	"price": 501.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -79628,7 +79628,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "646.00",
+	"price": 646.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -79657,7 +79657,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "33.00",
+	"price": 33.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -79690,8 +79690,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -79717,7 +79717,7 @@
 	"ancestors": [
 		"2wTy8tJdQv3f3wa6d"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -79754,7 +79754,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "191.00",
+	"price": 191.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -79783,7 +79783,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "390.00",
+	"price": 390.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -79812,7 +79812,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "93.00",
+	"price": 93.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -79841,7 +79841,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "486.00",
+	"price": 486.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -79874,8 +79874,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -79901,7 +79901,7 @@
 	"ancestors": [
 		"oAmeeALWYmRFEDqEa"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -79938,7 +79938,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "439.00",
+	"price": 439.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -79967,7 +79967,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "218.00",
+	"price": 218.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -79996,7 +79996,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "822.00",
+	"price": 822.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -80025,7 +80025,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "887.00",
+	"price": 887.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -80058,8 +80058,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -80085,7 +80085,7 @@
 	"ancestors": [
 		"xuNziFJAKLouad4iA"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -80122,7 +80122,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "483.00",
+	"price": 483.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -80151,7 +80151,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "290.00",
+	"price": 290.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -80180,7 +80180,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "216.00",
+	"price": 216.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -80213,8 +80213,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -80240,7 +80240,7 @@
 	"ancestors": [
 		"2P4cQ2Kt7ZYg5tM4N"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -80277,7 +80277,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "999.00",
+	"price": 999.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -80310,8 +80310,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -80337,7 +80337,7 @@
 	"ancestors": [
 		"bgLJYMus5NAmyQ8pX"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -80374,7 +80374,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "560.00",
+	"price": 560.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -80403,7 +80403,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "646.00",
+	"price": 646.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -80436,8 +80436,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -80463,7 +80463,7 @@
 	"ancestors": [
 		"rJdrGAkz6AmCwDNCb"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -80500,7 +80500,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "226.00",
+	"price": 226.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -80529,7 +80529,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "282.00",
+	"price": 282.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -80558,7 +80558,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "416.00",
+	"price": 416.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -80591,8 +80591,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -80618,7 +80618,7 @@
 	"ancestors": [
 		"9yJ3wsmkv4axwjund"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -80655,7 +80655,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "435.00",
+	"price": 435.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -80684,7 +80684,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "215.00",
+	"price": 215.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -80713,7 +80713,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "38.00",
+	"price": 38.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -80746,8 +80746,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -80773,7 +80773,7 @@
 	"ancestors": [
 		"qfbh7x7Tjponzcfc5"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -80810,7 +80810,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "888.00",
+	"price": 888.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -80843,8 +80843,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -80870,7 +80870,7 @@
 	"ancestors": [
 		"7LjunCMgfBB2HNNJS"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -80907,7 +80907,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "428.00",
+	"price": 428.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -80940,8 +80940,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -80967,7 +80967,7 @@
 	"ancestors": [
 		"cvPzxz8z8f94cgTDW"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -81004,7 +81004,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "622.00",
+	"price": 622.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -81033,7 +81033,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "551.00",
+	"price": 551.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -81066,8 +81066,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -81093,7 +81093,7 @@
 	"ancestors": [
 		"jrNXWTweS3aZwygBp"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -81130,7 +81130,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "624.00",
+	"price": 624.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -81163,8 +81163,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -81190,7 +81190,7 @@
 	"ancestors": [
 		"6nhZmoq9u96vtXF38"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -81227,7 +81227,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "195.00",
+	"price": 195.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -81260,8 +81260,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -81287,7 +81287,7 @@
 	"ancestors": [
 		"zGw7ktX82DGgrYDDQ"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -81324,7 +81324,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "529.00",
+	"price": 529.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -81357,8 +81357,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -81384,7 +81384,7 @@
 	"ancestors": [
 		"zpGdMaY4biP7p76Nw"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -81421,7 +81421,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "53.00",
+	"price": 53.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -81450,7 +81450,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "121.00",
+	"price": 121.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -81479,7 +81479,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "625.00",
+	"price": 625.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -81508,7 +81508,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "629.00",
+	"price": 629.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -81541,8 +81541,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -81568,7 +81568,7 @@
 	"ancestors": [
 		"dWdeMYKpoMp3KD8sr"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -81605,7 +81605,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "665.00",
+	"price": 665.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -81634,7 +81634,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "792.00",
+	"price": 792.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -81663,7 +81663,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "449.00",
+	"price": 449.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -81696,8 +81696,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -81723,7 +81723,7 @@
 	"ancestors": [
 		"JYi6pWhfQmoA8vaJ9"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -81760,7 +81760,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "661.00",
+	"price": 661.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -81789,7 +81789,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "2.00",
+	"price": 2.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -81822,8 +81822,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -81849,7 +81849,7 @@
 	"ancestors": [
 		"LoTSftJ3FTnSyRSfs"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -81886,7 +81886,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "233.00",
+	"price": 233.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -81915,7 +81915,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "661.00",
+	"price": 661.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -81944,7 +81944,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "527.00",
+	"price": 527.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -81973,7 +81973,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "217.00",
+	"price": 217.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -82006,8 +82006,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -82033,7 +82033,7 @@
 	"ancestors": [
 		"LpEW7WiANkB4JBcgh"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -82070,7 +82070,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "416.00",
+	"price": 416.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -82103,8 +82103,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -82130,7 +82130,7 @@
 	"ancestors": [
 		"JjXe8Lwqbavt3g9x8"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -82167,7 +82167,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "900.00",
+	"price": 900.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -82196,7 +82196,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "326.00",
+	"price": 326.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -82225,7 +82225,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "119.00",
+	"price": 119.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -82258,8 +82258,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -82285,7 +82285,7 @@
 	"ancestors": [
 		"cytxhCBx9rDfx5QAD"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -82322,7 +82322,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "794.00",
+	"price": 794.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -82351,7 +82351,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "785.00",
+	"price": 785.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -82384,8 +82384,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -82411,7 +82411,7 @@
 	"ancestors": [
 		"aHwZkegN7chPcoJ9a"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -82448,7 +82448,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "750.00",
+	"price": 750.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -82477,7 +82477,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "419.00",
+	"price": 419.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -82506,7 +82506,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "52.00",
+	"price": 52.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -82539,8 +82539,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -82566,7 +82566,7 @@
 	"ancestors": [
 		"HAjf8xwvh7mTvJnjm"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -82603,7 +82603,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "179.00",
+	"price": 179.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -82632,7 +82632,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "732.00",
+	"price": 732.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -82661,7 +82661,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "697.00",
+	"price": 697.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -82694,8 +82694,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -82721,7 +82721,7 @@
 	"ancestors": [
 		"YMr8aHmiocq4tmuyJ"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -82758,7 +82758,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "570.00",
+	"price": 570.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -82787,7 +82787,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "576.00",
+	"price": 576.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -82816,7 +82816,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "583.00",
+	"price": 583.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -82845,7 +82845,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "637.00",
+	"price": 637.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -82878,8 +82878,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -82905,7 +82905,7 @@
 	"ancestors": [
 		"5W475d9aQR4n6n4kP"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -82942,7 +82942,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "685.00",
+	"price": 685.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -82971,7 +82971,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "272.00",
+	"price": 272.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -83000,7 +83000,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "17.00",
+	"price": 17.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -83029,7 +83029,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "970.00",
+	"price": 970.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -83062,8 +83062,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -83089,7 +83089,7 @@
 	"ancestors": [
 		"fuJE6SjHPGbSuaucw"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -83126,7 +83126,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "914.00",
+	"price": 914.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -83155,7 +83155,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "425.00",
+	"price": 425.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -83184,7 +83184,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "589.00",
+	"price": 589.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -83213,7 +83213,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "992.00",
+	"price": 992.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -83246,8 +83246,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -83273,7 +83273,7 @@
 	"ancestors": [
 		"kiTfp2hShxEvTML85"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -83310,7 +83310,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "752.00",
+	"price": 752.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -83343,8 +83343,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -83370,7 +83370,7 @@
 	"ancestors": [
 		"23jD43sBRyEdTp25Q"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -83407,7 +83407,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "656.00",
+	"price": 656.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -83440,8 +83440,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -83467,7 +83467,7 @@
 	"ancestors": [
 		"dvuDotcgRomp9bMAa"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -83504,7 +83504,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "965.00",
+	"price": 965.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -83537,8 +83537,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -83564,7 +83564,7 @@
 	"ancestors": [
 		"Sr9BMtKG3vroJYByQ"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -83601,7 +83601,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "587.00",
+	"price": 587.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -83630,7 +83630,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "299.00",
+	"price": 299.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -83659,7 +83659,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "456.00",
+	"price": 456.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -83692,8 +83692,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -83719,7 +83719,7 @@
 	"ancestors": [
 		"RaAq8HyoWSKKuL5jy"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -83756,7 +83756,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "15.00",
+	"price": 15.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -83789,8 +83789,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -83816,7 +83816,7 @@
 	"ancestors": [
 		"g6GbdZMJpt4A3g26a"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -83853,7 +83853,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "920.00",
+	"price": 920.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -83882,7 +83882,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "264.00",
+	"price": 264.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -83915,8 +83915,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -83942,7 +83942,7 @@
 	"ancestors": [
 		"xzqCYWu8Q46cXZKsM"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -83979,7 +83979,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "893.00",
+	"price": 893.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -84008,7 +84008,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "599.00",
+	"price": 599.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -84037,7 +84037,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "187.00",
+	"price": 187.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -84066,7 +84066,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "265.00",
+	"price": 265.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -84099,8 +84099,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -84126,7 +84126,7 @@
 	"ancestors": [
 		"apLxcqHc5Cn6oYkmk"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -84163,7 +84163,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "863.00",
+	"price": 863.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -84196,8 +84196,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -84223,7 +84223,7 @@
 	"ancestors": [
 		"o9huiXdoxs376gM5x"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -84260,7 +84260,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "918.00",
+	"price": 918.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -84289,7 +84289,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "34.00",
+	"price": 34.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -84322,8 +84322,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -84349,7 +84349,7 @@
 	"ancestors": [
 		"usroJQiPW345yAW6y"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -84386,7 +84386,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "697.00",
+	"price": 697.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -84415,7 +84415,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "262.00",
+	"price": 262.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -84448,8 +84448,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -84475,7 +84475,7 @@
 	"ancestors": [
 		"ksEwtopdAeFQWLLcS"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -84512,7 +84512,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "223.00",
+	"price": 223.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -84541,7 +84541,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "735.00",
+	"price": 735.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -84574,8 +84574,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -84601,7 +84601,7 @@
 	"ancestors": [
 		"fTSDz9XgQRPjNHNkv"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -84638,7 +84638,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "196.00",
+	"price": 196.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -84667,7 +84667,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "718.00",
+	"price": 718.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -84696,7 +84696,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "617.00",
+	"price": 617.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -84729,8 +84729,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -84756,7 +84756,7 @@
 	"ancestors": [
 		"bZwzN3z9JTiiN7QtB"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -84793,7 +84793,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "783.00",
+	"price": 783.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -84822,7 +84822,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "25.00",
+	"price": 25.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -84851,7 +84851,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "304.00",
+	"price": 304.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -84884,8 +84884,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -84911,7 +84911,7 @@
 	"ancestors": [
 		"x8Z3GeF4tgcHgie5P"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -84948,7 +84948,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "915.00",
+	"price": 915.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -84977,7 +84977,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "721.00",
+	"price": 721.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -85006,7 +85006,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "947.00",
+	"price": 947.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -85035,7 +85035,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "823.00",
+	"price": 823.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -85068,8 +85068,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -85095,7 +85095,7 @@
 	"ancestors": [
 		"gwyg2ZPg8ainCiQ6A"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -85132,7 +85132,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "910.00",
+	"price": 910.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -85161,7 +85161,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "41.00",
+	"price": 41.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -85194,8 +85194,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -85221,7 +85221,7 @@
 	"ancestors": [
 		"sF7NMxkKb6BWcxThJ"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -85258,7 +85258,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "319.00",
+	"price": 319.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -85287,7 +85287,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "285.00",
+	"price": 285.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -85320,8 +85320,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -85347,7 +85347,7 @@
 	"ancestors": [
 		"Jkw4astctfdpjsMAq"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -85384,7 +85384,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "901.00",
+	"price": 901.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -85413,7 +85413,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "599.00",
+	"price": 599.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -85442,7 +85442,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "102.00",
+	"price": 102.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -85471,7 +85471,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "536.00",
+	"price": 536.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -85504,8 +85504,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -85531,7 +85531,7 @@
 	"ancestors": [
 		"pRpE3DAjXaNmvA2bx"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -85568,7 +85568,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "676.00",
+	"price": 676.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -85601,8 +85601,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -85628,7 +85628,7 @@
 	"ancestors": [
 		"5SycjqMLyEHkZSZ8h"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -85665,7 +85665,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "825.00",
+	"price": 825.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -85694,7 +85694,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "430.00",
+	"price": 430.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -85727,8 +85727,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -85754,7 +85754,7 @@
 	"ancestors": [
 		"rLjxM5PJXnNa6B6zT"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -85791,7 +85791,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "428.00",
+	"price": 428.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -85820,7 +85820,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "133.00",
+	"price": 133.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -85849,7 +85849,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "930.00",
+	"price": 930.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -85878,7 +85878,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "744.00",
+	"price": 744.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -85911,8 +85911,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -85938,7 +85938,7 @@
 	"ancestors": [
 		"aesdLiWvBQWPqxtJD"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -85975,7 +85975,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "53.00",
+	"price": 53.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -86004,7 +86004,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "990.00",
+	"price": 990.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -86033,7 +86033,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "370.00",
+	"price": 370.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -86066,8 +86066,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -86093,7 +86093,7 @@
 	"ancestors": [
 		"gWFi6W5tgpWBfk5XS"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -86130,7 +86130,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "710.00",
+	"price": 710.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -86159,7 +86159,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "566.00",
+	"price": 566.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -86192,8 +86192,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -86219,7 +86219,7 @@
 	"ancestors": [
 		"wpdQYjiTyvsyBhN57"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -86256,7 +86256,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "87.00",
+	"price": 87.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -86285,7 +86285,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "286.00",
+	"price": 286.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -86318,8 +86318,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -86345,7 +86345,7 @@
 	"ancestors": [
 		"Zzk9HnjRDsmy3GFix"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -86382,7 +86382,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "801.00",
+	"price": 801.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -86411,7 +86411,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "973.00",
+	"price": 973.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -86444,8 +86444,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -86471,7 +86471,7 @@
 	"ancestors": [
 		"rbLoM2r8BCjXQK5br"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -86508,7 +86508,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "858.00",
+	"price": 858.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -86537,7 +86537,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "553.00",
+	"price": 553.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -86566,7 +86566,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "42.00",
+	"price": 42.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -86595,7 +86595,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "491.00",
+	"price": 491.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -86628,8 +86628,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -86655,7 +86655,7 @@
 	"ancestors": [
 		"RJgCqxJ5HGCXd2GrZ"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -86692,7 +86692,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "632.00",
+	"price": 632.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -86721,7 +86721,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "899.00",
+	"price": 899.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -86750,7 +86750,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "223.00",
+	"price": 223.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -86783,8 +86783,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -86810,7 +86810,7 @@
 	"ancestors": [
 		"A44KTS8sbS2PTATML"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -86847,7 +86847,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "238.00",
+	"price": 238.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -86876,7 +86876,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "196.00",
+	"price": 196.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -86905,7 +86905,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "27.00",
+	"price": 27.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -86934,7 +86934,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "586.00",
+	"price": 586.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -86967,8 +86967,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -86994,7 +86994,7 @@
 	"ancestors": [
 		"DeGWRz3ru62kqKdQ9"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -87031,7 +87031,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "717.00",
+	"price": 717.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -87060,7 +87060,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "224.00",
+	"price": 224.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -87093,8 +87093,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -87120,7 +87120,7 @@
 	"ancestors": [
 		"QJ8tcZvnu57ozNW9f"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -87157,7 +87157,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "480.00",
+	"price": 480.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -87186,7 +87186,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "90.00",
+	"price": 90.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -87215,7 +87215,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "773.00",
+	"price": 773.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -87244,7 +87244,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "761.00",
+	"price": 761.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -87277,8 +87277,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -87304,7 +87304,7 @@
 	"ancestors": [
 		"886yPjNzB28uzZJzf"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -87341,7 +87341,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "780.00",
+	"price": 780.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -87370,7 +87370,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "152.00",
+	"price": 152.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -87403,8 +87403,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -87430,7 +87430,7 @@
 	"ancestors": [
 		"QExGhrn2MWRHytbMh"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -87467,7 +87467,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "482.00",
+	"price": 482.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -87496,7 +87496,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "88.00",
+	"price": 88.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -87525,7 +87525,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "355.00",
+	"price": 355.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -87554,7 +87554,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "299.00",
+	"price": 299.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -87587,8 +87587,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -87614,7 +87614,7 @@
 	"ancestors": [
 		"Xov7idwC8khFrMfNC"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -87651,7 +87651,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "869.00",
+	"price": 869.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -87680,7 +87680,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "541.00",
+	"price": 541.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -87713,8 +87713,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -87740,7 +87740,7 @@
 	"ancestors": [
 		"BRq6a6LQ4ZmTmaEG5"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -87777,7 +87777,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "487.00",
+	"price": 487.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -87810,8 +87810,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -87837,7 +87837,7 @@
 	"ancestors": [
 		"3c6WRf7JGNprpHfvN"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -87874,7 +87874,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "971.00",
+	"price": 971.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -87907,8 +87907,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -87934,7 +87934,7 @@
 	"ancestors": [
 		"jDL5Fn3EtuW3HnNhB"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -87971,7 +87971,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "535.00",
+	"price": 535.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -88004,8 +88004,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -88031,7 +88031,7 @@
 	"ancestors": [
 		"NADJzfLreSAvjhJ8G"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -88068,7 +88068,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "334.00",
+	"price": 334.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -88097,7 +88097,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "929.00",
+	"price": 929.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -88126,7 +88126,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "994.00",
+	"price": 994.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -88159,8 +88159,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -88186,7 +88186,7 @@
 	"ancestors": [
 		"KXHEZFz7pSHPBAktH"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -88223,7 +88223,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "904.00",
+	"price": 904.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -88252,7 +88252,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "965.00",
+	"price": 965.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -88285,8 +88285,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -88312,7 +88312,7 @@
 	"ancestors": [
 		"EFBf2vpfLLNrnFDr4"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -88349,7 +88349,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "538.00",
+	"price": 538.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -88378,7 +88378,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "742.00",
+	"price": 742.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -88407,7 +88407,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "274.00",
+	"price": 274.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -88440,8 +88440,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -88467,7 +88467,7 @@
 	"ancestors": [
 		"hjoq226bJsbNdjzLs"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -88504,7 +88504,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "484.00",
+	"price": 484.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -88533,7 +88533,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "536.00",
+	"price": 536.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -88562,7 +88562,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "458.00",
+	"price": 458.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -88591,7 +88591,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "726.00",
+	"price": 726.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -88624,8 +88624,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -88651,7 +88651,7 @@
 	"ancestors": [
 		"CT2uohJroC6PgPWaF"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -88688,7 +88688,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "498.00",
+	"price": 498.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -88717,7 +88717,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "443.00",
+	"price": 443.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -88750,8 +88750,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -88777,7 +88777,7 @@
 	"ancestors": [
 		"zGFEC7HMFWMBXKgLB"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -88814,7 +88814,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "101.00",
+	"price": 101.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -88847,8 +88847,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -88874,7 +88874,7 @@
 	"ancestors": [
 		"Pe8QBXvq3rkFuKbpd"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -88911,7 +88911,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "752.00",
+	"price": 752.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -88940,7 +88940,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "221.00",
+	"price": 221.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -88973,8 +88973,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -89000,7 +89000,7 @@
 	"ancestors": [
 		"FztZzr3jNbbnuZSPF"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -89037,7 +89037,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "121.00",
+	"price": 121.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -89070,8 +89070,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -89097,7 +89097,7 @@
 	"ancestors": [
 		"c2c8xAxkmeme99BQp"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -89134,7 +89134,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "573.00",
+	"price": 573.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -89163,7 +89163,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "3.00",
+	"price": 3.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -89192,7 +89192,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "649.00",
+	"price": 649.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -89225,8 +89225,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -89252,7 +89252,7 @@
 	"ancestors": [
 		"FASyHxy54xyLqh9Ce"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -89289,7 +89289,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "559.00",
+	"price": 559.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -89318,7 +89318,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "109.00",
+	"price": 109.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -89347,7 +89347,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "241.00",
+	"price": 241.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -89376,7 +89376,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "404.00",
+	"price": 404.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -89409,8 +89409,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -89436,7 +89436,7 @@
 	"ancestors": [
 		"iGWev6ycNqrGqfSm4"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -89473,7 +89473,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "548.00",
+	"price": 548.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -89506,8 +89506,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -89533,7 +89533,7 @@
 	"ancestors": [
 		"2QrC3CbL8rZWFRjYY"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -89570,7 +89570,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "995.00",
+	"price": 995.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -89599,7 +89599,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "17.00",
+	"price": 17.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -89632,8 +89632,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -89659,7 +89659,7 @@
 	"ancestors": [
 		"KTsJRWiRGTnPYkQED"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -89696,7 +89696,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "716.00",
+	"price": 716.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -89729,8 +89729,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -89756,7 +89756,7 @@
 	"ancestors": [
 		"KtmBETb7DqxeMrTiJ"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -89793,7 +89793,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "605.00",
+	"price": 605.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -89826,8 +89826,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -89853,7 +89853,7 @@
 	"ancestors": [
 		"rvp3k9AR9DzAkwEGY"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -89890,7 +89890,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "383.00",
+	"price": 383.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -89919,7 +89919,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "67.00",
+	"price": 67.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -89948,7 +89948,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "887.00",
+	"price": 887.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -89981,8 +89981,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -90008,7 +90008,7 @@
 	"ancestors": [
 		"kd4tFojk6ZGNmkgdm"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -90045,7 +90045,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "293.00",
+	"price": 293.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -90078,8 +90078,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -90105,7 +90105,7 @@
 	"ancestors": [
 		"gXK4kFLHrmZK6keNe"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -90142,7 +90142,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "89.00",
+	"price": 89.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -90171,7 +90171,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "31.00",
+	"price": 31.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -90204,8 +90204,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -90231,7 +90231,7 @@
 	"ancestors": [
 		"CLWBuZrMsh8kjqAEM"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -90268,7 +90268,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "121.00",
+	"price": 121.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -90297,7 +90297,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "598.00",
+	"price": 598.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -90326,7 +90326,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "221.00",
+	"price": 221.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -90359,8 +90359,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -90386,7 +90386,7 @@
 	"ancestors": [
 		"LWa8CHEx8d3kuQkQp"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -90423,7 +90423,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "705.00",
+	"price": 705.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -90456,8 +90456,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -90483,7 +90483,7 @@
 	"ancestors": [
 		"CSLz3qzn5xYHA5BmK"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -90520,7 +90520,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "800.00",
+	"price": 800.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -90549,7 +90549,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "708.00",
+	"price": 708.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -90582,8 +90582,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -90609,7 +90609,7 @@
 	"ancestors": [
 		"h8Au2pB3SXRkh3DFd"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -90646,7 +90646,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "225.00",
+	"price": 225.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -90679,8 +90679,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -90706,7 +90706,7 @@
 	"ancestors": [
 		"afnoSTpuouvatmzCp"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -90743,7 +90743,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "984.00",
+	"price": 984.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -90772,7 +90772,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "41.00",
+	"price": 41.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -90801,7 +90801,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "876.00",
+	"price": 876.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -90830,7 +90830,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "164.00",
+	"price": 164.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -90863,8 +90863,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -90890,7 +90890,7 @@
 	"ancestors": [
 		"XxiETDpZFye9b3vnf"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -90927,7 +90927,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "634.00",
+	"price": 634.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -90956,7 +90956,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "495.00",
+	"price": 495.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -90985,7 +90985,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "698.00",
+	"price": 698.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -91018,8 +91018,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -91045,7 +91045,7 @@
 	"ancestors": [
 		"xGyf6kFnQK7ynNhry"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -91082,7 +91082,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "99.00",
+	"price": 99.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -91111,7 +91111,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "388.00",
+	"price": 388.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -91140,7 +91140,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "150.00",
+	"price": 150.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -91173,8 +91173,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -91200,7 +91200,7 @@
 	"ancestors": [
 		"azbwvZi6pP2MjAQjv"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -91237,7 +91237,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "63.00",
+	"price": 63.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -91266,7 +91266,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "650.00",
+	"price": 650.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -91295,7 +91295,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "329.00",
+	"price": 329.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -91328,8 +91328,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -91355,7 +91355,7 @@
 	"ancestors": [
 		"4CnJDuDSzHbzcPkSj"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -91392,7 +91392,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "882.00",
+	"price": 882.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -91425,8 +91425,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -91452,7 +91452,7 @@
 	"ancestors": [
 		"u3Mdkf8pZm9oLg8eX"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -91489,7 +91489,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "622.00",
+	"price": 622.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -91522,8 +91522,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -91549,7 +91549,7 @@
 	"ancestors": [
 		"FSAxyMtc8tn6EG3Ke"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -91586,7 +91586,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "542.00",
+	"price": 542.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -91615,7 +91615,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "549.00",
+	"price": 549.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -91644,7 +91644,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "42.00",
+	"price": 42.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -91677,8 +91677,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -91704,7 +91704,7 @@
 	"ancestors": [
 		"XHFseo68JpBcNjDSq"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -91741,7 +91741,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "161.00",
+	"price": 161.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -91770,7 +91770,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "779.00",
+	"price": 779.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -91799,7 +91799,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "476.00",
+	"price": 476.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -91828,7 +91828,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "845.00",
+	"price": 845.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -91861,8 +91861,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -91888,7 +91888,7 @@
 	"ancestors": [
 		"98K67YfRxg4doLvxP"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -91925,7 +91925,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "374.00",
+	"price": 374.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -91954,7 +91954,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "265.00",
+	"price": 265.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -91983,7 +91983,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "366.00",
+	"price": 366.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -92012,7 +92012,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "938.00",
+	"price": 938.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -92045,8 +92045,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -92072,7 +92072,7 @@
 	"ancestors": [
 		"fdzbCYAYfv2TACB9N"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -92109,7 +92109,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "258.00",
+	"price": 258.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -92142,8 +92142,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -92169,7 +92169,7 @@
 	"ancestors": [
 		"8pDwSAQ2TNZ4LFCMR"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -92206,7 +92206,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "183.00",
+	"price": 183.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -92235,7 +92235,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "461.00",
+	"price": 461.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -92264,7 +92264,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "669.00",
+	"price": 669.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -92297,8 +92297,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -92324,7 +92324,7 @@
 	"ancestors": [
 		"ih9sR2fzT4iBkprxk"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -92361,7 +92361,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "73.00",
+	"price": 73.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -92390,7 +92390,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "623.00",
+	"price": 623.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -92419,7 +92419,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "740.00",
+	"price": 740.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -92448,7 +92448,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "191.00",
+	"price": 191.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -92481,8 +92481,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -92508,7 +92508,7 @@
 	"ancestors": [
 		"yht6kigWgPfoihQ6s"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -92545,7 +92545,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "189.00",
+	"price": 189.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -92574,7 +92574,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "566.00",
+	"price": 566.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -92607,8 +92607,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -92634,7 +92634,7 @@
 	"ancestors": [
 		"GsQmRK8QYcPf8YacT"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -92671,7 +92671,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "476.00",
+	"price": 476.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -92700,7 +92700,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "447.00",
+	"price": 447.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -92733,8 +92733,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -92760,7 +92760,7 @@
 	"ancestors": [
 		"P2sQm3fRWZKoJbp2X"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -92797,7 +92797,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "310.00",
+	"price": 310.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -92826,7 +92826,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "561.00",
+	"price": 561.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -92855,7 +92855,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "886.00",
+	"price": 886.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -92888,8 +92888,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -92915,7 +92915,7 @@
 	"ancestors": [
 		"wDcdSFB8TLHBKSbDt"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -92952,7 +92952,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "101.00",
+	"price": 101.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -92981,7 +92981,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "24.00",
+	"price": 24.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -93014,8 +93014,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -93041,7 +93041,7 @@
 	"ancestors": [
 		"s8b2XThFHKTAsJ7GR"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -93078,7 +93078,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "635.00",
+	"price": 635.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -93107,7 +93107,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "841.00",
+	"price": 841.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -93136,7 +93136,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "597.00",
+	"price": 597.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -93165,7 +93165,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "331.00",
+	"price": 331.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -93198,8 +93198,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -93225,7 +93225,7 @@
 	"ancestors": [
 		"f7hymiNS6wNmQRgsN"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -93262,7 +93262,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "78.00",
+	"price": 78.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -93291,7 +93291,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "491.00",
+	"price": 491.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -93320,7 +93320,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "880.00",
+	"price": 880.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -93353,8 +93353,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -93380,7 +93380,7 @@
 	"ancestors": [
 		"s2C74nBAccjYraHTx"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -93417,7 +93417,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "256.00",
+	"price": 256.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -93446,7 +93446,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "933.00",
+	"price": 933.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -93475,7 +93475,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "915.00",
+	"price": 915.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -93504,7 +93504,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "27.00",
+	"price": 27.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -93537,8 +93537,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -93564,7 +93564,7 @@
 	"ancestors": [
 		"7Cm9mndafa7PgS9Xa"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -93601,7 +93601,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "300.00",
+	"price": 300.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -93630,7 +93630,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "634.00",
+	"price": 634.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -93659,7 +93659,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "958.00",
+	"price": 958.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -93692,8 +93692,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -93719,7 +93719,7 @@
 	"ancestors": [
 		"YS49RG9o793mJF2KK"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -93756,7 +93756,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "262.00",
+	"price": 262.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -93785,7 +93785,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "610.00",
+	"price": 610.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -93814,7 +93814,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "907.00",
+	"price": 907.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -93847,8 +93847,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -93874,7 +93874,7 @@
 	"ancestors": [
 		"qctdH5tWrNDrd6xr7"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -93911,7 +93911,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "661.00",
+	"price": 661.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -93940,7 +93940,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "820.00",
+	"price": 820.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -93969,7 +93969,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "426.00",
+	"price": 426.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -94002,8 +94002,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -94029,7 +94029,7 @@
 	"ancestors": [
 		"K894zFggk4o96J9Ye"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -94066,7 +94066,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "350.00",
+	"price": 350.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -94099,8 +94099,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -94126,7 +94126,7 @@
 	"ancestors": [
 		"zCcRdyBPrbeRr875W"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -94163,7 +94163,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "517.00",
+	"price": 517.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -94192,7 +94192,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "523.00",
+	"price": 523.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -94221,7 +94221,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "900.00",
+	"price": 900.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -94250,7 +94250,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "746.00",
+	"price": 746.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -94283,8 +94283,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -94310,7 +94310,7 @@
 	"ancestors": [
 		"YSMGvapjRwjdqu4Jh"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -94347,7 +94347,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "721.00",
+	"price": 721.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -94376,7 +94376,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "7.00",
+	"price": 7.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -94405,7 +94405,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "960.00",
+	"price": 960.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -94434,7 +94434,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "153.00",
+	"price": 153.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -94467,8 +94467,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -94494,7 +94494,7 @@
 	"ancestors": [
 		"BnRpJwohnMQDi3bzM"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -94531,7 +94531,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "461.00",
+	"price": 461.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -94560,7 +94560,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "959.00",
+	"price": 959.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -94589,7 +94589,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "260.00",
+	"price": 260.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -94622,8 +94622,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -94649,7 +94649,7 @@
 	"ancestors": [
 		"npiS9syB5MmAJJHe3"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -94686,7 +94686,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "318.00",
+	"price": 318.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -94715,7 +94715,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "736.00",
+	"price": 736.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -94748,8 +94748,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -94775,7 +94775,7 @@
 	"ancestors": [
 		"8ZmRcDBbNXLe4NJp9"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -94812,7 +94812,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "189.00",
+	"price": 189.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -94845,8 +94845,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -94872,7 +94872,7 @@
 	"ancestors": [
 		"M26qZWpp3pA8puBcT"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -94909,7 +94909,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "806.00",
+	"price": 806.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -94942,8 +94942,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -94969,7 +94969,7 @@
 	"ancestors": [
 		"EnGBg9j4q5G6won7B"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -95006,7 +95006,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "82.00",
+	"price": 82.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -95035,7 +95035,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "148.00",
+	"price": 148.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -95064,7 +95064,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "506.00",
+	"price": 506.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -95097,8 +95097,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -95124,7 +95124,7 @@
 	"ancestors": [
 		"mc7QmASBu4AjqcJRf"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -95161,7 +95161,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "804.00",
+	"price": 804.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -95190,7 +95190,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "144.00",
+	"price": 144.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -95223,8 +95223,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -95250,7 +95250,7 @@
 	"ancestors": [
 		"yuwrZ6eutdCH46eys"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -95287,7 +95287,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "161.00",
+	"price": 161.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -95320,8 +95320,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -95347,7 +95347,7 @@
 	"ancestors": [
 		"yvBHkqZqzjB4653X4"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -95384,7 +95384,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "800.00",
+	"price": 800.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -95413,7 +95413,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "899.00",
+	"price": 899.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -95446,8 +95446,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -95473,7 +95473,7 @@
 	"ancestors": [
 		"HAPb2qL5rYqt9jD75"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -95510,7 +95510,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "110.00",
+	"price": 110.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -95539,7 +95539,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "867.00",
+	"price": 867.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -95568,7 +95568,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "55.00",
+	"price": 55.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -95601,8 +95601,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -95628,7 +95628,7 @@
 	"ancestors": [
 		"wveBfvRKCzL5JAxQj"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -95665,7 +95665,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "993.00",
+	"price": 993.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -95694,7 +95694,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "66.00",
+	"price": 66.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -95723,7 +95723,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "879.00",
+	"price": 879.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -95752,7 +95752,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "120.00",
+	"price": 120.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -95785,8 +95785,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -95812,7 +95812,7 @@
 	"ancestors": [
 		"Sz6RkF9pmcipKLSy9"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -95849,7 +95849,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "878.00",
+	"price": 878.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -95878,7 +95878,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "725.00",
+	"price": 725.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -95907,7 +95907,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "719.00",
+	"price": 719.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -95940,8 +95940,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -95967,7 +95967,7 @@
 	"ancestors": [
 		"RQj9KDADCJk6F8CuF"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -96004,7 +96004,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "467.00",
+	"price": 467.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -96033,7 +96033,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "395.00",
+	"price": 395.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -96062,7 +96062,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "849.00",
+	"price": 849.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -96095,8 +96095,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -96122,7 +96122,7 @@
 	"ancestors": [
 		"GPRoeyCSL7NDtAwds"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -96159,7 +96159,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "185.00",
+	"price": 185.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -96188,7 +96188,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "319.00",
+	"price": 319.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -96217,7 +96217,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "763.00",
+	"price": 763.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -96246,7 +96246,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "653.00",
+	"price": 653.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -96279,8 +96279,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -96306,7 +96306,7 @@
 	"ancestors": [
 		"77pW8YbCDqFNmDZon"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -96343,7 +96343,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "541.00",
+	"price": 541.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -96372,7 +96372,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "566.00",
+	"price": 566.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -96405,8 +96405,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -96432,7 +96432,7 @@
 	"ancestors": [
 		"JGpHpfLrgCgz38d4u"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -96469,7 +96469,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "944.00",
+	"price": 944.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -96502,8 +96502,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -96529,7 +96529,7 @@
 	"ancestors": [
 		"yvwjWwmKDmKv7wagt"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -96566,7 +96566,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "873.00",
+	"price": 873.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -96595,7 +96595,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "194.00",
+	"price": 194.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -96628,8 +96628,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -96655,7 +96655,7 @@
 	"ancestors": [
 		"HES2JrdFpJ4DMMiy2"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -96692,7 +96692,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "644.00",
+	"price": 644.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -96721,7 +96721,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "626.00",
+	"price": 626.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -96750,7 +96750,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "867.00",
+	"price": 867.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -96783,8 +96783,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -96810,7 +96810,7 @@
 	"ancestors": [
 		"BYndJ9ghtbxjM92pL"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -96847,7 +96847,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "417.00",
+	"price": 417.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -96876,7 +96876,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "805.00",
+	"price": 805.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -96905,7 +96905,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "462.00",
+	"price": 462.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -96934,7 +96934,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "198.00",
+	"price": 198.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -96967,8 +96967,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -96994,7 +96994,7 @@
 	"ancestors": [
 		"QvmLaEKeYASx7C5AS"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -97031,7 +97031,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "107.00",
+	"price": 107.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -97064,8 +97064,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -97091,7 +97091,7 @@
 	"ancestors": [
 		"aP8ZskigpGCo5FtWT"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -97128,7 +97128,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "391.00",
+	"price": 391.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -97157,7 +97157,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "38.00",
+	"price": 38.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -97190,8 +97190,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -97217,7 +97217,7 @@
 	"ancestors": [
 		"qcuSjiLTBe9yX9BsF"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -97254,7 +97254,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "163.00",
+	"price": 163.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -97283,7 +97283,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "196.00",
+	"price": 196.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -97312,7 +97312,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "776.00",
+	"price": 776.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -97341,7 +97341,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "916.00",
+	"price": 916.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -97374,8 +97374,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -97401,7 +97401,7 @@
 	"ancestors": [
 		"YmG6HrwbzLzx9sqiM"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -97438,7 +97438,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "435.00",
+	"price": 435.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -97467,7 +97467,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "972.00",
+	"price": 972.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -97496,7 +97496,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "482.00",
+	"price": 482.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -97529,8 +97529,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -97556,7 +97556,7 @@
 	"ancestors": [
 		"vLRCm8THYxuJu995M"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -97593,7 +97593,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "256.00",
+	"price": 256.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -97622,7 +97622,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "89.00",
+	"price": 89.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -97655,8 +97655,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -97682,7 +97682,7 @@
 	"ancestors": [
 		"rC6s5MHmqE92fg2QQ"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -97719,7 +97719,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "230.00",
+	"price": 230.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -97748,7 +97748,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "246.00",
+	"price": 246.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -97781,8 +97781,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -97808,7 +97808,7 @@
 	"ancestors": [
 		"xHfkMQYoo4sDY9aKG"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -97845,7 +97845,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "175.00",
+	"price": 175.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -97874,7 +97874,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "989.00",
+	"price": 989.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -97907,8 +97907,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -97934,7 +97934,7 @@
 	"ancestors": [
 		"r5GFEoQQaSmJdDgnP"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -97971,7 +97971,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "10.00",
+	"price": 10.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -98000,7 +98000,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "719.00",
+	"price": 719.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -98033,8 +98033,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -98060,7 +98060,7 @@
 	"ancestors": [
 		"tQBKkPvEvsg6E7Eiq"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -98097,7 +98097,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "913.00",
+	"price": 913.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -98126,7 +98126,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "346.00",
+	"price": 346.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -98155,7 +98155,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "266.00",
+	"price": 266.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -98184,7 +98184,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "565.00",
+	"price": 565.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -98217,8 +98217,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -98244,7 +98244,7 @@
 	"ancestors": [
 		"zi7kkh7Sb7cEtRGzg"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -98281,7 +98281,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "7.00",
+	"price": 7.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -98310,7 +98310,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "429.00",
+	"price": 429.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -98339,7 +98339,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "508.00",
+	"price": 508.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -98368,7 +98368,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "856.00",
+	"price": 856.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -98401,8 +98401,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -98428,7 +98428,7 @@
 	"ancestors": [
 		"fJxeGz6F8xxTJtzJK"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -98465,7 +98465,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "674.00",
+	"price": 674.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -98494,7 +98494,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "745.00",
+	"price": 745.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -98523,7 +98523,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "264.00",
+	"price": 264.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -98556,8 +98556,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -98583,7 +98583,7 @@
 	"ancestors": [
 		"35AYAD9hbqjfi2XHq"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -98620,7 +98620,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "486.00",
+	"price": 486.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -98649,7 +98649,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "109.00",
+	"price": 109.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -98678,7 +98678,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "417.00",
+	"price": 417.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -98711,8 +98711,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -98738,7 +98738,7 @@
 	"ancestors": [
 		"uYSifry6CjvGGrMvW"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -98775,7 +98775,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "275.00",
+	"price": 275.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -98804,7 +98804,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "825.00",
+	"price": 825.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -98837,8 +98837,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -98864,7 +98864,7 @@
 	"ancestors": [
 		"co3RAWJHGSTPRGPH6"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -98901,7 +98901,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "323.00",
+	"price": 323.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -98934,8 +98934,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -98961,7 +98961,7 @@
 	"ancestors": [
 		"oeuaKcchtfgdqXY2J"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -98998,7 +98998,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "563.00",
+	"price": 563.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -99027,7 +99027,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "531.00",
+	"price": 531.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -99056,7 +99056,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "199.00",
+	"price": 199.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -99085,7 +99085,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "286.00",
+	"price": 286.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -99118,8 +99118,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -99145,7 +99145,7 @@
 	"ancestors": [
 		"9AwXECnYf94A9x48h"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -99182,7 +99182,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "253.00",
+	"price": 253.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -99211,7 +99211,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "44.00",
+	"price": 44.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -99244,8 +99244,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -99271,7 +99271,7 @@
 	"ancestors": [
 		"Hc8inem28yLCtmmB7"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -99308,7 +99308,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "244.00",
+	"price": 244.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -99337,7 +99337,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "176.00",
+	"price": 176.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -99370,8 +99370,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -99397,7 +99397,7 @@
 	"ancestors": [
 		"WEFsbkRvCkFuxtNvj"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -99434,7 +99434,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "213.00",
+	"price": 213.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -99463,7 +99463,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "551.00",
+	"price": 551.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -99496,8 +99496,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -99523,7 +99523,7 @@
 	"ancestors": [
 		"kWyq8ZXNTN4nrosRt"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -99560,7 +99560,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "295.00",
+	"price": 295.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -99593,8 +99593,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -99620,7 +99620,7 @@
 	"ancestors": [
 		"q7pbHBwiGHPYTE3e7"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -99657,7 +99657,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "753.00",
+	"price": 753.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -99686,7 +99686,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "287.00",
+	"price": 287.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -99715,7 +99715,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "410.00",
+	"price": 410.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -99744,7 +99744,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "342.00",
+	"price": 342.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -99777,8 +99777,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -99804,7 +99804,7 @@
 	"ancestors": [
 		"3CRWrqoRwuyNf9BBp"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -99841,7 +99841,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "20.00",
+	"price": 20.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -99870,7 +99870,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "873.00",
+	"price": 873.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -99903,8 +99903,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -99930,7 +99930,7 @@
 	"ancestors": [
 		"xsc7jichskQAEK3xX"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -99967,7 +99967,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "309.00",
+	"price": 309.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -99996,7 +99996,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "821.00",
+	"price": 821.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -100025,7 +100025,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "311.00",
+	"price": 311.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -100054,7 +100054,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "325.00",
+	"price": 325.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -100087,8 +100087,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -100114,7 +100114,7 @@
 	"ancestors": [
 		"sbfxZDuLF59Lz3NvM"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -100151,7 +100151,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "512.00",
+	"price": 512.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -100180,7 +100180,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "984.00",
+	"price": 984.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -100213,8 +100213,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -100240,7 +100240,7 @@
 	"ancestors": [
 		"5D6yxdi7Jrh75Dpf4"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -100277,7 +100277,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "137.00",
+	"price": 137.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -100306,7 +100306,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "88.00",
+	"price": 88.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -100335,7 +100335,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "243.00",
+	"price": 243.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -100368,8 +100368,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -100395,7 +100395,7 @@
 	"ancestors": [
 		"H6q8g4JZ2qDsLNyQS"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -100432,7 +100432,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "914.00",
+	"price": 914.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -100465,8 +100465,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -100492,7 +100492,7 @@
 	"ancestors": [
 		"vyDqeEMJDwzM9sohR"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -100529,7 +100529,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "890.00",
+	"price": 890.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -100558,7 +100558,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "873.00",
+	"price": 873.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -100587,7 +100587,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "574.00",
+	"price": 574.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -100620,8 +100620,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -100647,7 +100647,7 @@
 	"ancestors": [
 		"3974JXXdg65iGryNP"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -100684,7 +100684,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "925.00",
+	"price": 925.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -100713,7 +100713,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "32.00",
+	"price": 32.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -100742,7 +100742,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "67.00",
+	"price": 67.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -100775,8 +100775,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -100802,7 +100802,7 @@
 	"ancestors": [
 		"EEumB5de7wYJoTTcE"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -100839,7 +100839,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "662.00",
+	"price": 662.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -100868,7 +100868,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "548.00",
+	"price": 548.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -100897,7 +100897,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "586.00",
+	"price": 586.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -100926,7 +100926,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "584.00",
+	"price": 584.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -100959,8 +100959,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -100986,7 +100986,7 @@
 	"ancestors": [
 		"mWDGaZYkgNRTh349R"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -101023,7 +101023,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "128.00",
+	"price": 128.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -101052,7 +101052,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "634.00",
+	"price": 634.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -101081,7 +101081,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "424.00",
+	"price": 424.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -101114,8 +101114,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -101141,7 +101141,7 @@
 	"ancestors": [
 		"6bmgcKsjux8cxLoC5"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -101178,7 +101178,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "166.00",
+	"price": 166.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -101211,8 +101211,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -101238,7 +101238,7 @@
 	"ancestors": [
 		"hw6nJYqNNa8YKSGxn"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -101275,7 +101275,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "747.00",
+	"price": 747.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -101304,7 +101304,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "313.00",
+	"price": 313.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -101333,7 +101333,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "305.00",
+	"price": 305.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -101362,7 +101362,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "438.00",
+	"price": 438.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -101395,8 +101395,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -101422,7 +101422,7 @@
 	"ancestors": [
 		"hevDbreq47TiP7Xba"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -101459,7 +101459,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "734.00",
+	"price": 734.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -101488,7 +101488,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "14.00",
+	"price": 14.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -101517,7 +101517,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "712.00",
+	"price": 712.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -101546,7 +101546,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "68.00",
+	"price": 68.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -101579,8 +101579,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -101606,7 +101606,7 @@
 	"ancestors": [
 		"mkQfwsLRKqPs5n9Hg"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -101643,7 +101643,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "889.00",
+	"price": 889.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -101672,7 +101672,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "509.00",
+	"price": 509.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -101701,7 +101701,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "101.00",
+	"price": 101.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -101730,7 +101730,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "5.00",
+	"price": 5.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -101763,8 +101763,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -101790,7 +101790,7 @@
 	"ancestors": [
 		"3xGuTonaTdZMSnuwh"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -101827,7 +101827,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "167.00",
+	"price": 167.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -101856,7 +101856,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "579.00",
+	"price": 579.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -101885,7 +101885,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "538.00",
+	"price": 538.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -101918,8 +101918,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -101945,7 +101945,7 @@
 	"ancestors": [
 		"F6XCYDPyjqPFSeMHe"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -101982,7 +101982,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "496.00",
+	"price": 496.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -102011,7 +102011,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "367.00",
+	"price": 367.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -102044,8 +102044,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -102071,7 +102071,7 @@
 	"ancestors": [
 		"Xk2SXs8hZKF9c2i2a"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -102108,7 +102108,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "984.00",
+	"price": 984.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -102141,8 +102141,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -102168,7 +102168,7 @@
 	"ancestors": [
 		"5JrcEorS9QYFkAhNd"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -102205,7 +102205,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "253.00",
+	"price": 253.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -102234,7 +102234,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "639.00",
+	"price": 639.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -102263,7 +102263,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "546.00",
+	"price": 546.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -102296,8 +102296,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -102323,7 +102323,7 @@
 	"ancestors": [
 		"ZpxkSbAo7W9JW5jSt"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -102360,7 +102360,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "992.00",
+	"price": 992.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -102393,8 +102393,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -102420,7 +102420,7 @@
 	"ancestors": [
 		"QRREpeoaCd2kzAJHN"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -102457,7 +102457,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "849.00",
+	"price": 849.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -102490,8 +102490,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -102517,7 +102517,7 @@
 	"ancestors": [
 		"8eJQqqWxJBkZB4qTQ"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -102554,7 +102554,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "508.00",
+	"price": 508.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -102583,7 +102583,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "134.00",
+	"price": 134.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -102612,7 +102612,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "528.00",
+	"price": 528.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -102641,7 +102641,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "284.00",
+	"price": 284.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -102674,8 +102674,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -102701,7 +102701,7 @@
 	"ancestors": [
 		"BAdAeve2HZKtgLJbK"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -102738,7 +102738,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "791.00",
+	"price": 791.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -102771,8 +102771,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -102798,7 +102798,7 @@
 	"ancestors": [
 		"YhtHMRzoPvz4WLqsS"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -102835,7 +102835,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "110.00",
+	"price": 110.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -102864,7 +102864,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "231.00",
+	"price": 231.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -102893,7 +102893,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "207.00",
+	"price": 207.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -102926,8 +102926,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -102953,7 +102953,7 @@
 	"ancestors": [
 		"yqCxvP4MAzPnvaaoY"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -102990,7 +102990,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "854.00",
+	"price": 854.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -103019,7 +103019,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "684.00",
+	"price": 684.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -103052,8 +103052,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -103079,7 +103079,7 @@
 	"ancestors": [
 		"SThBtGcQmaZLcNYdN"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -103116,7 +103116,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "701.00",
+	"price": 701.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -103145,7 +103145,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "253.00",
+	"price": 253.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -103178,8 +103178,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -103205,7 +103205,7 @@
 	"ancestors": [
 		"siKgFAugR8yuMci3i"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -103242,7 +103242,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "534.00",
+	"price": 534.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -103275,8 +103275,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -103302,7 +103302,7 @@
 	"ancestors": [
 		"2WTweopkf5gSah3Ad"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -103339,7 +103339,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "73.00",
+	"price": 73.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -103368,7 +103368,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "638.00",
+	"price": 638.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -103397,7 +103397,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "743.00",
+	"price": 743.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -103430,8 +103430,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -103457,7 +103457,7 @@
 	"ancestors": [
 		"yJXCzS8hPx64pkKv2"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -103494,7 +103494,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "398.00",
+	"price": 398.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -103523,7 +103523,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "593.00",
+	"price": 593.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -103552,7 +103552,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "993.00",
+	"price": 993.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -103585,8 +103585,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -103612,7 +103612,7 @@
 	"ancestors": [
 		"JY82kntsRhyp698ct"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -103649,7 +103649,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "225.00",
+	"price": 225.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -103678,7 +103678,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "1000.00",
+	"price": 1000.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -103707,7 +103707,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "871.00",
+	"price": 871.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -103740,8 +103740,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -103767,7 +103767,7 @@
 	"ancestors": [
 		"osZ9QfatBB8yWysSA"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -103804,7 +103804,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "534.00",
+	"price": 534.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -103837,8 +103837,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -103864,7 +103864,7 @@
 	"ancestors": [
 		"8rXrofqjnLdC9uMzW"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -103901,7 +103901,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "448.00",
+	"price": 448.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -103934,8 +103934,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -103961,7 +103961,7 @@
 	"ancestors": [
 		"xvseG3JDLTTbsnmvN"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -103998,7 +103998,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "243.00",
+	"price": 243.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -104027,7 +104027,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "818.00",
+	"price": 818.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -104060,8 +104060,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -104087,7 +104087,7 @@
 	"ancestors": [
 		"ALCg87Gd2zSQoHRar"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -104124,7 +104124,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "462.00",
+	"price": 462.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -104153,7 +104153,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "723.00",
+	"price": 723.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -104182,7 +104182,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "455.00",
+	"price": 455.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -104211,7 +104211,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "418.00",
+	"price": 418.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -104244,8 +104244,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -104271,7 +104271,7 @@
 	"ancestors": [
 		"GGRe7WN76swtnziCG"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -104308,7 +104308,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "962.00",
+	"price": 962.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -104337,7 +104337,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "909.00",
+	"price": 909.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -104366,7 +104366,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "778.00",
+	"price": 778.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -104399,8 +104399,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -104426,7 +104426,7 @@
 	"ancestors": [
 		"ZTTrY9kioxdCX9yM8"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -104463,7 +104463,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "312.00",
+	"price": 312.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -104492,7 +104492,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "847.00",
+	"price": 847.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -104521,7 +104521,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "714.00",
+	"price": 714.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -104554,8 +104554,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -104581,7 +104581,7 @@
 	"ancestors": [
 		"QHpGg7saPWNDHXCje"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -104618,7 +104618,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "553.00",
+	"price": 553.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -104651,8 +104651,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -104678,7 +104678,7 @@
 	"ancestors": [
 		"nC3qdjmfmxXPMXHtA"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -104715,7 +104715,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "249.00",
+	"price": 249.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -104744,7 +104744,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "828.00",
+	"price": 828.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -104773,7 +104773,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "573.00",
+	"price": 573.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -104806,8 +104806,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -104833,7 +104833,7 @@
 	"ancestors": [
 		"7brgn9e4zF2BmaEsS"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -104870,7 +104870,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "126.00",
+	"price": 126.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -104899,7 +104899,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "299.00",
+	"price": 299.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -104928,7 +104928,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "267.00",
+	"price": 267.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -104961,8 +104961,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -104988,7 +104988,7 @@
 	"ancestors": [
 		"t9gEn4Zip4dtKguiP"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -105025,7 +105025,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "837.00",
+	"price": 837.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -105054,7 +105054,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "335.00",
+	"price": 335.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -105083,7 +105083,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "197.00",
+	"price": 197.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -105112,7 +105112,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "888.00",
+	"price": 888.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -105145,8 +105145,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -105172,7 +105172,7 @@
 	"ancestors": [
 		"BJniTBYC9jvTrJDNQ"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -105209,7 +105209,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "826.00",
+	"price": 826.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -105238,7 +105238,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "392.00",
+	"price": 392.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -105267,7 +105267,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "749.00",
+	"price": 749.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -105296,7 +105296,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "304.00",
+	"price": 304.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -105329,8 +105329,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -105356,7 +105356,7 @@
 	"ancestors": [
 		"wsPhE72X3DZ6x3vdK"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -105393,7 +105393,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "521.00",
+	"price": 521.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -105422,7 +105422,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "509.00",
+	"price": 509.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -105451,7 +105451,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "68.00",
+	"price": 68.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -105484,8 +105484,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -105511,7 +105511,7 @@
 	"ancestors": [
 		"jfHSoSZ9LyGMFfHew"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -105548,7 +105548,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "663.00",
+	"price": 663.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -105577,7 +105577,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "254.00",
+	"price": 254.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -105610,8 +105610,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -105637,7 +105637,7 @@
 	"ancestors": [
 		"ynSwZ7PuPDrysZovw"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -105674,7 +105674,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "33.00",
+	"price": 33.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -105703,7 +105703,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "758.00",
+	"price": 758.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -105732,7 +105732,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "384.00",
+	"price": 384.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -105765,8 +105765,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -105792,7 +105792,7 @@
 	"ancestors": [
 		"cr8LrAQANX5vC3ak7"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -105829,7 +105829,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "393.00",
+	"price": 393.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -105862,8 +105862,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -105889,7 +105889,7 @@
 	"ancestors": [
 		"z8mb7PCjk7pWY4HsH"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -105926,7 +105926,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "198.00",
+	"price": 198.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -105959,8 +105959,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -105986,7 +105986,7 @@
 	"ancestors": [
 		"c85PZ4btkxEwXjXC7"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -106023,7 +106023,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "618.00",
+	"price": 618.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -106056,8 +106056,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -106083,7 +106083,7 @@
 	"ancestors": [
 		"htRiAsdaqfkWWgrri"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -106120,7 +106120,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "762.00",
+	"price": 762.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -106149,7 +106149,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "115.00",
+	"price": 115.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -106178,7 +106178,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "814.00",
+	"price": 814.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -106207,7 +106207,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "215.00",
+	"price": 215.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -106240,8 +106240,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -106267,7 +106267,7 @@
 	"ancestors": [
 		"jWrmjF3ALHAnDXPPK"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -106304,7 +106304,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "195.00",
+	"price": 195.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -106333,7 +106333,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "112.00",
+	"price": 112.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -106362,7 +106362,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "996.00",
+	"price": 996.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -106391,7 +106391,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "343.00",
+	"price": 343.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -106424,8 +106424,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -106451,7 +106451,7 @@
 	"ancestors": [
 		"hf6zWXhF8zrbDDJgw"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -106488,7 +106488,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "355.00",
+	"price": 355.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -106517,7 +106517,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "630.00",
+	"price": 630.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -106546,7 +106546,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "617.00",
+	"price": 617.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -106575,7 +106575,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "673.00",
+	"price": 673.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -106608,8 +106608,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -106635,7 +106635,7 @@
 	"ancestors": [
 		"9Y6J9s5Cd6SCfjvpm"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -106672,7 +106672,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "17.00",
+	"price": 17.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -106701,7 +106701,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "905.00",
+	"price": 905.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -106730,7 +106730,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "518.00",
+	"price": 518.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -106763,8 +106763,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -106790,7 +106790,7 @@
 	"ancestors": [
 		"7avN2DryazWtFgBrc"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -106827,7 +106827,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "703.00",
+	"price": 703.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -106856,7 +106856,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "558.00",
+	"price": 558.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -106889,8 +106889,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -106916,7 +106916,7 @@
 	"ancestors": [
 		"B86vBNWwKRWBzsg9y"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -106953,7 +106953,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "827.00",
+	"price": 827.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -106982,7 +106982,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "6.00",
+	"price": 6.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -107011,7 +107011,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "329.00",
+	"price": 329.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -107040,7 +107040,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "723.00",
+	"price": 723.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -107073,8 +107073,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -107100,7 +107100,7 @@
 	"ancestors": [
 		"qzii8mFQdYSLiFnjc"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -107137,7 +107137,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "816.00",
+	"price": 816.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -107166,7 +107166,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "254.00",
+	"price": 254.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -107195,7 +107195,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "799.00",
+	"price": 799.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -107224,7 +107224,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "307.00",
+	"price": 307.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -107257,8 +107257,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -107284,7 +107284,7 @@
 	"ancestors": [
 		"KNJMw73ygnnkqAX2c"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -107321,7 +107321,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "767.00",
+	"price": 767.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -107350,7 +107350,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "264.00",
+	"price": 264.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -107383,8 +107383,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -107410,7 +107410,7 @@
 	"ancestors": [
 		"tdb8dtbGyejgkbXzf"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -107447,7 +107447,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "695.00",
+	"price": 695.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -107476,7 +107476,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "731.00",
+	"price": 731.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -107509,8 +107509,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -107536,7 +107536,7 @@
 	"ancestors": [
 		"tAv9ZY7TTTSJcgDHa"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -107573,7 +107573,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "218.00",
+	"price": 218.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -107606,8 +107606,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -107633,7 +107633,7 @@
 	"ancestors": [
 		"47hN2w5PSXmoQCTtf"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -107670,7 +107670,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "507.00",
+	"price": 507.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -107699,7 +107699,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "913.00",
+	"price": 913.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -107728,7 +107728,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "555.00",
+	"price": 555.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -107761,8 +107761,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -107788,7 +107788,7 @@
 	"ancestors": [
 		"F5uyn9eSuXiygSQ4P"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -107825,7 +107825,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "247.00",
+	"price": 247.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -107854,7 +107854,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "330.00",
+	"price": 330.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -107883,7 +107883,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "177.00",
+	"price": 177.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -107912,7 +107912,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "205.00",
+	"price": 205.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -107945,8 +107945,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -107972,7 +107972,7 @@
 	"ancestors": [
 		"ds39Z9u4gKjm9pXDS"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -108009,7 +108009,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "238.00",
+	"price": 238.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -108038,7 +108038,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "829.00",
+	"price": 829.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -108067,7 +108067,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "295.00",
+	"price": 295.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -108100,8 +108100,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -108127,7 +108127,7 @@
 	"ancestors": [
 		"trs8JoqXMmgMFnNHY"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -108164,7 +108164,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "383.00",
+	"price": 383.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -108197,8 +108197,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -108224,7 +108224,7 @@
 	"ancestors": [
 		"enzg69Ss6j8TBwGXJ"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -108261,7 +108261,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "463.00",
+	"price": 463.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -108290,7 +108290,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "837.00",
+	"price": 837.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -108319,7 +108319,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "937.00",
+	"price": 937.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -108352,8 +108352,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -108379,7 +108379,7 @@
 	"ancestors": [
 		"3SpcFcMnbZ9JcKcGM"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -108416,7 +108416,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "420.00",
+	"price": 420.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -108449,8 +108449,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -108476,7 +108476,7 @@
 	"ancestors": [
 		"tqHWwZwTPmv7yhWh2"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -108513,7 +108513,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "421.00",
+	"price": 421.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -108546,8 +108546,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -108573,7 +108573,7 @@
 	"ancestors": [
 		"btDmXxptJE4kfYcyg"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -108610,7 +108610,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "987.00",
+	"price": 987.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -108639,7 +108639,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "889.00",
+	"price": 889.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -108668,7 +108668,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "308.00",
+	"price": 308.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -108701,8 +108701,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -108728,7 +108728,7 @@
 	"ancestors": [
 		"vRaGXsHSme2srAXue"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -108765,7 +108765,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "869.00",
+	"price": 869.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -108794,7 +108794,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "672.00",
+	"price": 672.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -108823,7 +108823,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "177.00",
+	"price": 177.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -108856,8 +108856,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -108883,7 +108883,7 @@
 	"ancestors": [
 		"m96ghZYJXMhzvhoDy"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -108920,7 +108920,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "141.00",
+	"price": 141.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -108949,7 +108949,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "317.00",
+	"price": 317.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -108978,7 +108978,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "494.00",
+	"price": 494.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -109007,7 +109007,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "708.00",
+	"price": 708.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -109040,8 +109040,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -109067,7 +109067,7 @@
 	"ancestors": [
 		"fP3b5bosBHgorYkkb"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -109104,7 +109104,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "450.00",
+	"price": 450.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -109133,7 +109133,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "456.00",
+	"price": 456.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -109162,7 +109162,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "485.00",
+	"price": 485.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -109195,8 +109195,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -109222,7 +109222,7 @@
 	"ancestors": [
 		"RLEt5RshF4ZYDNH6C"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -109259,7 +109259,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "79.00",
+	"price": 79.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -109288,7 +109288,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "969.00",
+	"price": 969.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -109317,7 +109317,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "632.00",
+	"price": 632.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -109346,7 +109346,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "407.00",
+	"price": 407.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -109379,8 +109379,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -109406,7 +109406,7 @@
 	"ancestors": [
 		"6FAdijesZWMZY8Gug"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -109443,7 +109443,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "984.00",
+	"price": 984.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -109472,7 +109472,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "793.00",
+	"price": 793.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -109501,7 +109501,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "6.00",
+	"price": 6.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -109534,8 +109534,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -109561,7 +109561,7 @@
 	"ancestors": [
 		"gZ5baAdK3fEWPkyhw"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -109598,7 +109598,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "627.00",
+	"price": 627.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -109627,7 +109627,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "922.00",
+	"price": 922.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -109660,8 +109660,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -109687,7 +109687,7 @@
 	"ancestors": [
 		"oMtJiPiLxgyvoYEWW"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -109724,7 +109724,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "706.00",
+	"price": 706.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -109753,7 +109753,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "337.00",
+	"price": 337.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -109782,7 +109782,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "121.00",
+	"price": 121.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -109811,7 +109811,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "956.00",
+	"price": 956.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -109844,8 +109844,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -109871,7 +109871,7 @@
 	"ancestors": [
 		"ADrR9BHcWtposgYnc"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -109908,7 +109908,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "839.00",
+	"price": 839.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -109937,7 +109937,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "961.00",
+	"price": 961.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -109966,7 +109966,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "27.00",
+	"price": 27.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -109999,8 +109999,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -110026,7 +110026,7 @@
 	"ancestors": [
 		"WbDj8FD9jc76Sefyd"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -110063,7 +110063,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "237.00",
+	"price": 237.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -110092,7 +110092,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "429.00",
+	"price": 429.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -110125,8 +110125,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -110152,7 +110152,7 @@
 	"ancestors": [
 		"3ZxMCB8LCMD4ezevF"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -110189,7 +110189,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "120.00",
+	"price": 120.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -110218,7 +110218,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "791.00",
+	"price": 791.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -110247,7 +110247,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "861.00",
+	"price": 861.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -110276,7 +110276,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "265.00",
+	"price": 265.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -110309,8 +110309,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -110336,7 +110336,7 @@
 	"ancestors": [
 		"2pnFqsY3sbsSBDF6c"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -110373,7 +110373,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "750.00",
+	"price": 750.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -110402,7 +110402,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "702.00",
+	"price": 702.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -110431,7 +110431,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "823.00",
+	"price": 823.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -110460,7 +110460,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "100.00",
+	"price": 100.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -110493,8 +110493,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -110520,7 +110520,7 @@
 	"ancestors": [
 		"C7MXpAxSJmFfdJv3R"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -110557,7 +110557,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "238.00",
+	"price": 238.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -110586,7 +110586,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "249.00",
+	"price": 249.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -110615,7 +110615,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "121.00",
+	"price": 121.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -110648,8 +110648,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -110675,7 +110675,7 @@
 	"ancestors": [
 		"Wo7Pt6rtwCgkMdbRp"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -110712,7 +110712,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "238.00",
+	"price": 238.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -110745,8 +110745,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -110772,7 +110772,7 @@
 	"ancestors": [
 		"re9Ra8a8ouiEx8BQH"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -110809,7 +110809,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "443.00",
+	"price": 443.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -110838,7 +110838,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "713.00",
+	"price": 713.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -110871,8 +110871,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -110898,7 +110898,7 @@
 	"ancestors": [
 		"3M5kXCS36ZdhFFLuA"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -110935,7 +110935,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "619.00",
+	"price": 619.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -110964,7 +110964,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "917.00",
+	"price": 917.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -110997,8 +110997,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -111024,7 +111024,7 @@
 	"ancestors": [
 		"WtG9cim6D9ZcNF5Br"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -111061,7 +111061,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "723.00",
+	"price": 723.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -111090,7 +111090,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "424.00",
+	"price": 424.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -111119,7 +111119,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "957.00",
+	"price": 957.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -111148,7 +111148,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "880.00",
+	"price": 880.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -111181,8 +111181,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -111208,7 +111208,7 @@
 	"ancestors": [
 		"MC2eNZ3bk7DSbL6vj"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -111245,7 +111245,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "206.00",
+	"price": 206.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -111278,8 +111278,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -111305,7 +111305,7 @@
 	"ancestors": [
 		"86oMAowvXd8Ja4NoG"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -111342,7 +111342,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "853.00",
+	"price": 853.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -111371,7 +111371,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "846.00",
+	"price": 846.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -111400,7 +111400,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "917.00",
+	"price": 917.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -111429,7 +111429,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "165.00",
+	"price": 165.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -111462,8 +111462,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -111489,7 +111489,7 @@
 	"ancestors": [
 		"LixbQRPkZEwTSZoee"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -111526,7 +111526,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "572.00",
+	"price": 572.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -111555,7 +111555,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "459.00",
+	"price": 459.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -111588,8 +111588,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -111615,7 +111615,7 @@
 	"ancestors": [
 		"BWMp6JXP7wr8vHRWM"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -111652,7 +111652,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "581.00",
+	"price": 581.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -111685,8 +111685,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -111712,7 +111712,7 @@
 	"ancestors": [
 		"pq6gwbui4s8sDhGcg"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -111749,7 +111749,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "632.00",
+	"price": 632.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -111778,7 +111778,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "892.00",
+	"price": 892.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -111807,7 +111807,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "350.00",
+	"price": 350.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -111836,7 +111836,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "801.00",
+	"price": 801.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -111869,8 +111869,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -111896,7 +111896,7 @@
 	"ancestors": [
 		"mPkYcnhciJJgdKrGc"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -111933,7 +111933,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "201.00",
+	"price": 201.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -111962,7 +111962,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "279.00",
+	"price": 279.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -111991,7 +111991,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "115.00",
+	"price": 115.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -112020,7 +112020,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "514.00",
+	"price": 514.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -112053,8 +112053,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -112080,7 +112080,7 @@
 	"ancestors": [
 		"hCEafipxnwbZhfaSH"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -112117,7 +112117,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "372.00",
+	"price": 372.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -112146,7 +112146,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "277.00",
+	"price": 277.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -112175,7 +112175,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "598.00",
+	"price": 598.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -112208,8 +112208,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -112235,7 +112235,7 @@
 	"ancestors": [
 		"YaauChmGix2ymSvLk"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -112272,7 +112272,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "77.00",
+	"price": 77.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -112301,7 +112301,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "2.00",
+	"price": 2.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -112334,8 +112334,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -112361,7 +112361,7 @@
 	"ancestors": [
 		"njSqhtSrzd4WqnJxH"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -112398,7 +112398,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "793.00",
+	"price": 793.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -112427,7 +112427,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "615.00",
+	"price": 615.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -112456,7 +112456,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "835.00",
+	"price": 835.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -112485,7 +112485,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "644.00",
+	"price": 644.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -112518,8 +112518,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -112545,7 +112545,7 @@
 	"ancestors": [
 		"m4ANAokZgnqMLizoD"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -112582,7 +112582,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "198.00",
+	"price": 198.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -112611,7 +112611,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "529.00",
+	"price": 529.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -112644,8 +112644,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -112671,7 +112671,7 @@
 	"ancestors": [
 		"dZKoHfGkApzG7T8zG"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -112708,7 +112708,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "332.00",
+	"price": 332.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -112737,7 +112737,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "748.00",
+	"price": 748.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -112766,7 +112766,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "460.00",
+	"price": 460.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -112799,8 +112799,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -112826,7 +112826,7 @@
 	"ancestors": [
 		"aJnm3vDA5xzAwRqaX"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -112863,7 +112863,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "964.00",
+	"price": 964.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -112892,7 +112892,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "654.00",
+	"price": 654.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -112925,8 +112925,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -112952,7 +112952,7 @@
 	"ancestors": [
 		"QwZbWxGhKqdRExESe"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -112989,7 +112989,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "627.00",
+	"price": 627.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -113018,7 +113018,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "836.00",
+	"price": 836.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -113047,7 +113047,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "944.00",
+	"price": 944.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -113080,8 +113080,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -113107,7 +113107,7 @@
 	"ancestors": [
 		"c8yXosxb5eB3xjq8z"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -113144,7 +113144,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "984.00",
+	"price": 984.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -113173,7 +113173,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "695.00",
+	"price": 695.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -113202,7 +113202,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "841.00",
+	"price": 841.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -113231,7 +113231,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "861.00",
+	"price": 861.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -113264,8 +113264,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -113291,7 +113291,7 @@
 	"ancestors": [
 		"m4hGexszDKFjzKvWz"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -113328,7 +113328,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "655.00",
+	"price": 655.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -113357,7 +113357,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "667.00",
+	"price": 667.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -113386,7 +113386,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "237.00",
+	"price": 237.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -113419,8 +113419,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -113446,7 +113446,7 @@
 	"ancestors": [
 		"Eh4epbL2JGAbZm35k"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -113483,7 +113483,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "661.00",
+	"price": 661.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -113516,8 +113516,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -113543,7 +113543,7 @@
 	"ancestors": [
 		"tMLiX6WGyMrw3qpHD"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -113580,7 +113580,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "597.00",
+	"price": 597.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -113609,7 +113609,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "890.00",
+	"price": 890.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -113638,7 +113638,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "985.00",
+	"price": 985.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -113671,8 +113671,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -113698,7 +113698,7 @@
 	"ancestors": [
 		"ASurgJk5uBGgAu5YK"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -113735,7 +113735,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "508.00",
+	"price": 508.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -113764,7 +113764,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "45.00",
+	"price": 45.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -113793,7 +113793,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "147.00",
+	"price": 147.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -113826,8 +113826,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -113853,7 +113853,7 @@
 	"ancestors": [
 		"3mGCvj3ha4gYvxFbA"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -113890,7 +113890,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "43.00",
+	"price": 43.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -113919,7 +113919,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "787.00",
+	"price": 787.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -113948,7 +113948,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "128.00",
+	"price": 128.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -113981,8 +113981,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -114008,7 +114008,7 @@
 	"ancestors": [
 		"SYDw7ZF2g4wZ92KPC"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -114045,7 +114045,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "713.00",
+	"price": 713.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -114074,7 +114074,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "942.00",
+	"price": 942.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -114103,7 +114103,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "109.00",
+	"price": 109.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -114136,8 +114136,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -114163,7 +114163,7 @@
 	"ancestors": [
 		"ZntFfNaxtPXCgPL82"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -114200,7 +114200,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "381.00",
+	"price": 381.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -114229,7 +114229,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "939.00",
+	"price": 939.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -114258,7 +114258,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "606.00",
+	"price": 606.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -114287,7 +114287,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "928.00",
+	"price": 928.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -114320,8 +114320,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -114347,7 +114347,7 @@
 	"ancestors": [
 		"83cLbs6hWN4GDGFzs"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -114384,7 +114384,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "781.00",
+	"price": 781.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -114413,7 +114413,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "145.00",
+	"price": 145.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -114446,8 +114446,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -114473,7 +114473,7 @@
 	"ancestors": [
 		"MqaBvqCbALYKyWpHW"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -114510,7 +114510,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "996.00",
+	"price": 996.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -114539,7 +114539,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "622.00",
+	"price": 622.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -114572,8 +114572,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -114599,7 +114599,7 @@
 	"ancestors": [
 		"iD65SCbda48RYeSWb"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -114636,7 +114636,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "164.00",
+	"price": 164.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -114669,8 +114669,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -114696,7 +114696,7 @@
 	"ancestors": [
 		"3MMMneNQs9evvLGvK"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -114733,7 +114733,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "876.00",
+	"price": 876.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -114762,7 +114762,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "358.00",
+	"price": 358.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -114791,7 +114791,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "154.00",
+	"price": 154.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -114820,7 +114820,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "365.00",
+	"price": 365.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -114853,8 +114853,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -114880,7 +114880,7 @@
 	"ancestors": [
 		"TPmM7NF84t3rBeBgR"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -114917,7 +114917,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "337.00",
+	"price": 337.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -114946,7 +114946,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "130.00",
+	"price": 130.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -114975,7 +114975,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "173.00",
+	"price": 173.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -115004,7 +115004,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "759.00",
+	"price": 759.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -115037,8 +115037,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -115064,7 +115064,7 @@
 	"ancestors": [
 		"BBAvtJwGxdtauJo9r"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -115101,7 +115101,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "234.00",
+	"price": 234.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -115130,7 +115130,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "627.00",
+	"price": 627.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -115163,8 +115163,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -115190,7 +115190,7 @@
 	"ancestors": [
 		"3qiDs7mZiSni5p8nw"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -115227,7 +115227,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "306.00",
+	"price": 306.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -115260,8 +115260,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -115287,7 +115287,7 @@
 	"ancestors": [
 		"JuyBuFTvkfEqADydy"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -115324,7 +115324,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "833.00",
+	"price": 833.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -115357,8 +115357,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -115384,7 +115384,7 @@
 	"ancestors": [
 		"9Cm46XXGvzGioosxn"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -115421,7 +115421,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "64.00",
+	"price": 64.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -115450,7 +115450,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "739.00",
+	"price": 739.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -115483,8 +115483,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -115510,7 +115510,7 @@
 	"ancestors": [
 		"eEif5rKskETxk6vvo"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -115547,7 +115547,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "934.00",
+	"price": 934.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -115576,7 +115576,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "996.00",
+	"price": 996.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -115605,7 +115605,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "867.00",
+	"price": 867.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -115634,7 +115634,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "403.00",
+	"price": 403.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -115667,8 +115667,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -115694,7 +115694,7 @@
 	"ancestors": [
 		"tiEamtzxm9Eb47gHT"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -115731,7 +115731,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "788.00",
+	"price": 788.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -115760,7 +115760,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "275.00",
+	"price": 275.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -115789,7 +115789,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "871.00",
+	"price": 871.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -115822,8 +115822,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -115849,7 +115849,7 @@
 	"ancestors": [
 		"9ut7bED6euHMTn6nA"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -115886,7 +115886,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "278.00",
+	"price": 278.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -115919,8 +115919,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -115946,7 +115946,7 @@
 	"ancestors": [
 		"CWgg8KvKR3gHzefFf"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -115983,7 +115983,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "145.00",
+	"price": 145.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -116012,7 +116012,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "500.00",
+	"price": 500.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -116041,7 +116041,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "888.00",
+	"price": 888.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -116074,8 +116074,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -116101,7 +116101,7 @@
 	"ancestors": [
 		"mdRvq7N5JSGdMTJAv"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -116138,7 +116138,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "223.00",
+	"price": 223.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -116167,7 +116167,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "787.00",
+	"price": 787.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -116200,8 +116200,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -116227,7 +116227,7 @@
 	"ancestors": [
 		"cG3DRKcg99tiTiv2Q"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -116264,7 +116264,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "343.00",
+	"price": 343.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -116297,8 +116297,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -116324,7 +116324,7 @@
 	"ancestors": [
 		"TA2tqzpBmRpQmtzJs"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -116361,7 +116361,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "130.00",
+	"price": 130.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -116390,7 +116390,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "0.00",
+	"price": 0.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -116419,7 +116419,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "504.00",
+	"price": 504.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -116448,7 +116448,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "224.00",
+	"price": 224.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -116481,8 +116481,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -116508,7 +116508,7 @@
 	"ancestors": [
 		"wgTkhRZm3gg3TFred"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -116545,7 +116545,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "652.00",
+	"price": 652.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -116578,8 +116578,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -116605,7 +116605,7 @@
 	"ancestors": [
 		"fQvKQcjaGD4pwSraL"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -116642,7 +116642,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "694.00",
+	"price": 694.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -116675,8 +116675,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -116702,7 +116702,7 @@
 	"ancestors": [
 		"F3R7euWJRu8wL23MS"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -116739,7 +116739,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "771.00",
+	"price": 771.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -116768,7 +116768,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "203.00",
+	"price": 203.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -116797,7 +116797,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "49.00",
+	"price": 49.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -116830,8 +116830,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -116857,7 +116857,7 @@
 	"ancestors": [
 		"BNCsCfqKcPohLNEKk"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -116894,7 +116894,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "15.00",
+	"price": 15.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -116923,7 +116923,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "549.00",
+	"price": 549.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -116952,7 +116952,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "411.00",
+	"price": 411.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -116981,7 +116981,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "529.00",
+	"price": 529.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -117014,8 +117014,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -117041,7 +117041,7 @@
 	"ancestors": [
 		"TqLpYPDQbpc4YkQ6E"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -117078,7 +117078,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "259.00",
+	"price": 259.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -117111,8 +117111,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -117138,7 +117138,7 @@
 	"ancestors": [
 		"qh25qzopJL5CD6CMi"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -117175,7 +117175,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "980.00",
+	"price": 980.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -117204,7 +117204,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "535.00",
+	"price": 535.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -117237,8 +117237,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -117264,7 +117264,7 @@
 	"ancestors": [
 		"PAQY6KfTFaYZAs8nH"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -117301,7 +117301,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "21.00",
+	"price": 21.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -117334,8 +117334,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -117361,7 +117361,7 @@
 	"ancestors": [
 		"pGrxFibYJhqFy4MZf"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -117398,7 +117398,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "539.00",
+	"price": 539.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -117431,8 +117431,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -117458,7 +117458,7 @@
 	"ancestors": [
 		"9g8J7AHqPjjnMLdYo"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -117495,7 +117495,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "661.00",
+	"price": 661.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -117524,7 +117524,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "301.00",
+	"price": 301.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -117557,8 +117557,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -117584,7 +117584,7 @@
 	"ancestors": [
 		"b3gyGCEwsjKL6hd9w"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -117621,7 +117621,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "307.00",
+	"price": 307.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -117654,8 +117654,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -117681,7 +117681,7 @@
 	"ancestors": [
 		"uBXF9QRJcBPLRXBFd"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -117718,7 +117718,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "667.00",
+	"price": 667.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -117747,7 +117747,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "770.00",
+	"price": 770.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -117776,7 +117776,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "349.00",
+	"price": 349.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -117809,8 +117809,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -117836,7 +117836,7 @@
 	"ancestors": [
 		"hZexpfJW7NrTpA5kT"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -117873,7 +117873,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "545.00",
+	"price": 545.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -117902,7 +117902,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "773.00",
+	"price": 773.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -117931,7 +117931,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "690.00",
+	"price": 690.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -117964,8 +117964,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -117991,7 +117991,7 @@
 	"ancestors": [
 		"WE2GQPhnEGTeLp6qa"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -118028,7 +118028,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "925.00",
+	"price": 925.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -118057,7 +118057,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "26.00",
+	"price": 26.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -118090,8 +118090,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -118117,7 +118117,7 @@
 	"ancestors": [
 		"Wv3C3xbEg33NtfiZ6"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -118154,7 +118154,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "146.00",
+	"price": 146.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -118183,7 +118183,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "639.00",
+	"price": 639.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -118212,7 +118212,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "9.00",
+	"price": 9.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -118241,7 +118241,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "540.00",
+	"price": 540.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -118274,8 +118274,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -118301,7 +118301,7 @@
 	"ancestors": [
 		"RL5BS4tqNwmsaKabZ"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -118338,7 +118338,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "700.00",
+	"price": 700.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -118367,7 +118367,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "235.00",
+	"price": 235.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -118400,8 +118400,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -118427,7 +118427,7 @@
 	"ancestors": [
 		"m9wdFzSWuLzZS9K5w"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -118464,7 +118464,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "331.00",
+	"price": 331.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -118493,7 +118493,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "393.00",
+	"price": 393.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -118526,8 +118526,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -118553,7 +118553,7 @@
 	"ancestors": [
 		"HRze3oSipq5zmC9M7"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -118590,7 +118590,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "584.00",
+	"price": 584.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -118619,7 +118619,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "597.00",
+	"price": 597.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -118652,8 +118652,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -118679,7 +118679,7 @@
 	"ancestors": [
 		"q2hM7SxA4H6PQm4u4"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -118716,7 +118716,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "4.00",
+	"price": 4.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -118749,8 +118749,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -118776,7 +118776,7 @@
 	"ancestors": [
 		"9wx9M8BK82x3dnyXd"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -118813,7 +118813,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "786.00",
+	"price": 786.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -118842,7 +118842,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "809.00",
+	"price": 809.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -118871,7 +118871,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "924.00",
+	"price": 924.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -118904,8 +118904,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -118931,7 +118931,7 @@
 	"ancestors": [
 		"SMn3By3aijyF7mzfD"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -118968,7 +118968,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "241.00",
+	"price": 241.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -118997,7 +118997,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "980.00",
+	"price": 980.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -119026,7 +119026,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "589.00",
+	"price": 589.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -119059,8 +119059,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -119086,7 +119086,7 @@
 	"ancestors": [
 		"dA32YLRia2yKcKw2j"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -119123,7 +119123,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "354.00",
+	"price": 354.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -119152,7 +119152,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "615.00",
+	"price": 615.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -119181,7 +119181,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "818.00",
+	"price": 818.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -119210,7 +119210,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "365.00",
+	"price": 365.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -119243,8 +119243,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -119270,7 +119270,7 @@
 	"ancestors": [
 		"32u6NWF9ndhhFiCAp"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -119307,7 +119307,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "32.00",
+	"price": 32.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -119340,8 +119340,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -119367,7 +119367,7 @@
 	"ancestors": [
 		"bs6nE7rENwTEPB9rM"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -119404,7 +119404,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "990.00",
+	"price": 990.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -119433,7 +119433,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "342.00",
+	"price": 342.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -119462,7 +119462,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "885.00",
+	"price": 885.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -119491,7 +119491,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "956.00",
+	"price": 956.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -119524,8 +119524,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -119551,7 +119551,7 @@
 	"ancestors": [
 		"Jg4dBbb2x7e6soWqo"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -119588,7 +119588,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "510.00",
+	"price": 510.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -119617,7 +119617,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "507.00",
+	"price": 507.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -119646,7 +119646,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "366.00",
+	"price": 366.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -119679,8 +119679,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -119706,7 +119706,7 @@
 	"ancestors": [
 		"STcg9NquPHCZxTeSe"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -119743,7 +119743,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "727.00",
+	"price": 727.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -119776,8 +119776,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -119803,7 +119803,7 @@
 	"ancestors": [
 		"n3WxhcJDkY5nr2yeD"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -119840,7 +119840,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "8.00",
+	"price": 8.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -119873,8 +119873,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -119900,7 +119900,7 @@
 	"ancestors": [
 		"u356EY6C5m4LbKndW"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -119937,7 +119937,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "632.00",
+	"price": 632.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -119966,7 +119966,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "676.00",
+	"price": 676.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -119995,7 +119995,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "45.00",
+	"price": 45.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -120024,7 +120024,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "684.00",
+	"price": 684.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -120057,8 +120057,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -120084,7 +120084,7 @@
 	"ancestors": [
 		"tmHunDxou36xuLihH"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -120121,7 +120121,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "174.00",
+	"price": 174.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -120150,7 +120150,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "669.00",
+	"price": 669.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -120179,7 +120179,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "338.00",
+	"price": 338.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -120208,7 +120208,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "512.00",
+	"price": 512.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -120241,8 +120241,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -120268,7 +120268,7 @@
 	"ancestors": [
 		"5nTdGyN5Qu4ys54Ga"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -120305,7 +120305,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "253.00",
+	"price": 253.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -120334,7 +120334,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "706.00",
+	"price": 706.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -120367,8 +120367,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -120394,7 +120394,7 @@
 	"ancestors": [
 		"E4JxNchtw9NXyC8fd"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -120431,7 +120431,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "840.00",
+	"price": 840.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -120460,7 +120460,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "245.00",
+	"price": 245.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -120489,7 +120489,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "50.00",
+	"price": 50.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -120518,7 +120518,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "518.00",
+	"price": 518.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -120551,8 +120551,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -120578,7 +120578,7 @@
 	"ancestors": [
 		"gq8e6wpSsxcu5SmmM"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -120615,7 +120615,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "118.00",
+	"price": 118.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -120644,7 +120644,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "564.00",
+	"price": 564.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -120677,8 +120677,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -120704,7 +120704,7 @@
 	"ancestors": [
 		"2FtQyvfMqRhfED26L"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -120741,7 +120741,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "408.00",
+	"price": 408.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -120774,8 +120774,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -120801,7 +120801,7 @@
 	"ancestors": [
 		"hz7arokfhXnbMgbSL"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -120838,7 +120838,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "515.00",
+	"price": 515.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -120871,8 +120871,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -120898,7 +120898,7 @@
 	"ancestors": [
 		"3x9swomg6qAm45H8g"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -120935,7 +120935,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "491.00",
+	"price": 491.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -120964,7 +120964,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "235.00",
+	"price": 235.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -120993,7 +120993,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "318.00",
+	"price": 318.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -121026,8 +121026,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -121053,7 +121053,7 @@
 	"ancestors": [
 		"7MdBh2dEQxRo3GesQ"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -121090,7 +121090,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "249.00",
+	"price": 249.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -121119,7 +121119,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "270.00",
+	"price": 270.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -121148,7 +121148,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "494.00",
+	"price": 494.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -121181,8 +121181,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -121208,7 +121208,7 @@
 	"ancestors": [
 		"XpSsCq8HfjNtkH7Lv"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -121245,7 +121245,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "974.00",
+	"price": 974.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -121274,7 +121274,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "691.00",
+	"price": 691.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -121303,7 +121303,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "699.00",
+	"price": 699.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -121332,7 +121332,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "907.00",
+	"price": 907.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -121365,8 +121365,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -121392,7 +121392,7 @@
 	"ancestors": [
 		"bXvaJBF8poE5tcGQJ"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -121429,7 +121429,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "537.00",
+	"price": 537.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -121458,7 +121458,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "468.00",
+	"price": 468.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -121487,7 +121487,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "256.00",
+	"price": 256.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -121520,8 +121520,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -121547,7 +121547,7 @@
 	"ancestors": [
 		"mMgfRCAR9rcWA7SoA"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -121584,7 +121584,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "946.00",
+	"price": 946.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -121613,7 +121613,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "615.00",
+	"price": 615.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -121642,7 +121642,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "951.00",
+	"price": 951.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -121671,7 +121671,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "815.00",
+	"price": 815.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -121704,8 +121704,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -121731,7 +121731,7 @@
 	"ancestors": [
 		"F5t3C5KY4tadXsfEv"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -121768,7 +121768,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "490.00",
+	"price": 490.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -121797,7 +121797,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "550.00",
+	"price": 550.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -121826,7 +121826,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "674.00",
+	"price": 674.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -121859,8 +121859,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -121886,7 +121886,7 @@
 	"ancestors": [
 		"xeCCvh8PMriweCb8J"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -121923,7 +121923,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "298.00",
+	"price": 298.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -121956,8 +121956,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -121983,7 +121983,7 @@
 	"ancestors": [
 		"BabtdXELkcfWMv9LE"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -122020,7 +122020,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "282.00",
+	"price": 282.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -122049,7 +122049,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "391.00",
+	"price": 391.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -122078,7 +122078,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "488.00",
+	"price": 488.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -122111,8 +122111,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -122138,7 +122138,7 @@
 	"ancestors": [
 		"XTWmxunP7Tm9LRCuD"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -122175,7 +122175,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "827.00",
+	"price": 827.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -122204,7 +122204,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "964.00",
+	"price": 964.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -122233,7 +122233,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "732.00",
+	"price": 732.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -122262,7 +122262,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "280.00",
+	"price": 280.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -122295,8 +122295,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -122322,7 +122322,7 @@
 	"ancestors": [
 		"5WWvfNZAyAXJQwbJ9"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -122359,7 +122359,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "816.00",
+	"price": 816.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -122388,7 +122388,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "92.00",
+	"price": 92.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -122421,8 +122421,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -122448,7 +122448,7 @@
 	"ancestors": [
 		"PCCSoi4fur4Ko5uJu"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -122485,7 +122485,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "131.00",
+	"price": 131.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -122518,8 +122518,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -122545,7 +122545,7 @@
 	"ancestors": [
 		"QQHvCmn4KEimvbAr6"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -122582,7 +122582,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "261.00",
+	"price": 261.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -122615,8 +122615,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -122642,7 +122642,7 @@
 	"ancestors": [
 		"Ym6B3qqCT3BxmwZuR"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -122679,7 +122679,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "527.00",
+	"price": 527.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -122708,7 +122708,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "636.00",
+	"price": 636.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -122737,7 +122737,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "17.00",
+	"price": 17.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -122766,7 +122766,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "779.00",
+	"price": 779.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -122799,8 +122799,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -122826,7 +122826,7 @@
 	"ancestors": [
 		"iWP9SDjAZWiiiFMGq"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -122863,7 +122863,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "445.00",
+	"price": 445.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -122892,7 +122892,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "227.00",
+	"price": 227.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -122925,8 +122925,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -122952,7 +122952,7 @@
 	"ancestors": [
 		"oCQu6qrKQ6n5nXJHm"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -122989,7 +122989,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "453.00",
+	"price": 453.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -123018,7 +123018,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "404.00",
+	"price": 404.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -123047,7 +123047,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "769.00",
+	"price": 769.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -123076,7 +123076,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "562.00",
+	"price": 562.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -123109,8 +123109,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -123136,7 +123136,7 @@
 	"ancestors": [
 		"xNiWNgaWxzdNDLrzH"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -123173,7 +123173,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "564.00",
+	"price": 564.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -123202,7 +123202,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "891.00",
+	"price": 891.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -123231,7 +123231,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "397.00",
+	"price": 397.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -123264,8 +123264,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -123291,7 +123291,7 @@
 	"ancestors": [
 		"5GwRR63KNrGwbTYTN"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -123328,7 +123328,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "616.00",
+	"price": 616.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -123357,7 +123357,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "325.00",
+	"price": 325.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -123386,7 +123386,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "639.00",
+	"price": 639.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -123415,7 +123415,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "241.00",
+	"price": 241.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -123448,8 +123448,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -123475,7 +123475,7 @@
 	"ancestors": [
 		"2ccztApJ8MXXX3Z8T"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -123512,7 +123512,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "531.00",
+	"price": 531.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -123541,7 +123541,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "916.00",
+	"price": 916.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -123570,7 +123570,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "866.00",
+	"price": 866.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -123599,7 +123599,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "300.00",
+	"price": 300.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -123632,8 +123632,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -123659,7 +123659,7 @@
 	"ancestors": [
 		"8EaHr9czJ5kPXz26s"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -123696,7 +123696,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "322.00",
+	"price": 322.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -123725,7 +123725,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "352.00",
+	"price": 352.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -123758,8 +123758,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -123785,7 +123785,7 @@
 	"ancestors": [
 		"pA4MZDChQZxwFvaue"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -123822,7 +123822,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "972.00",
+	"price": 972.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -123851,7 +123851,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "665.00",
+	"price": 665.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -123880,7 +123880,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "749.00",
+	"price": 749.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -123913,8 +123913,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -123940,7 +123940,7 @@
 	"ancestors": [
 		"9MzizbxeNwtNDQGJk"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -123977,7 +123977,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "140.00",
+	"price": 140.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -124010,8 +124010,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -124037,7 +124037,7 @@
 	"ancestors": [
 		"PcFMq9kw4iXnMxkFi"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -124074,7 +124074,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "678.00",
+	"price": 678.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -124103,7 +124103,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "201.00",
+	"price": 201.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -124136,8 +124136,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -124163,7 +124163,7 @@
 	"ancestors": [
 		"bXbh6KPGgnkz9v4e9"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -124200,7 +124200,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "971.00",
+	"price": 971.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -124229,7 +124229,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "473.00",
+	"price": 473.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -124258,7 +124258,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "932.00",
+	"price": 932.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -124287,7 +124287,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "529.00",
+	"price": 529.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -124320,8 +124320,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -124347,7 +124347,7 @@
 	"ancestors": [
 		"5eQ3i6LSyasxqqkAY"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -124384,7 +124384,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "101.00",
+	"price": 101.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -124413,7 +124413,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "837.00",
+	"price": 837.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -124446,8 +124446,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -124473,7 +124473,7 @@
 	"ancestors": [
 		"yd4t2G4Xua4teAFzg"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -124510,7 +124510,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "957.00",
+	"price": 957.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -124539,7 +124539,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "751.00",
+	"price": 751.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -124572,8 +124572,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -124599,7 +124599,7 @@
 	"ancestors": [
 		"u8XCFn4QPJmFZq9e7"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -124636,7 +124636,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "59.00",
+	"price": 59.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -124669,8 +124669,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -124696,7 +124696,7 @@
 	"ancestors": [
 		"SKghpGi8RrKBBCJpi"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -124733,7 +124733,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "578.00",
+	"price": 578.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -124762,7 +124762,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "271.00",
+	"price": 271.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -124791,7 +124791,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "508.00",
+	"price": 508.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -124820,7 +124820,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "689.00",
+	"price": 689.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -124853,8 +124853,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -124880,7 +124880,7 @@
 	"ancestors": [
 		"DaHEJzEJ7ihJ3uWQn"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -124917,7 +124917,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "210.00",
+	"price": 210.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -124946,7 +124946,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "504.00",
+	"price": 504.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -124975,7 +124975,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "684.00",
+	"price": 684.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -125004,7 +125004,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "735.00",
+	"price": 735.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -125037,8 +125037,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -125064,7 +125064,7 @@
 	"ancestors": [
 		"hQjfgq6wJrNKvnCep"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -125101,7 +125101,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "464.00",
+	"price": 464.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -125130,7 +125130,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "498.00",
+	"price": 498.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -125159,7 +125159,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "258.00",
+	"price": 258.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -125192,8 +125192,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -125219,7 +125219,7 @@
 	"ancestors": [
 		"LpLDNgiWB3iZzADTR"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -125256,7 +125256,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "25.00",
+	"price": 25.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -125285,7 +125285,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "377.00",
+	"price": 377.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -125314,7 +125314,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "41.00",
+	"price": 41.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -125343,7 +125343,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "740.00",
+	"price": 740.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -125376,8 +125376,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -125403,7 +125403,7 @@
 	"ancestors": [
 		"YxifWoGc5kNWwzzj3"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -125440,7 +125440,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "174.00",
+	"price": 174.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -125469,7 +125469,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "275.00",
+	"price": 275.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -125498,7 +125498,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "481.00",
+	"price": 481.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -125531,8 +125531,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -125558,7 +125558,7 @@
 	"ancestors": [
 		"cRqC9Wa8LX2KLkDZ2"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -125595,7 +125595,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "917.00",
+	"price": 917.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -125624,7 +125624,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "354.00",
+	"price": 354.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -125657,8 +125657,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -125684,7 +125684,7 @@
 	"ancestors": [
 		"AL3fWMegisJ7xyEf9"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -125721,7 +125721,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "522.00",
+	"price": 522.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -125750,7 +125750,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "96.00",
+	"price": 96.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -125783,8 +125783,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -125810,7 +125810,7 @@
 	"ancestors": [
 		"x6nwpoHjgR9qxa2CL"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -125847,7 +125847,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "372.00",
+	"price": 372.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -125880,8 +125880,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -125907,7 +125907,7 @@
 	"ancestors": [
 		"PySgBunQJCZXq2FGj"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -125944,7 +125944,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "620.00",
+	"price": 620.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -125977,8 +125977,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -126004,7 +126004,7 @@
 	"ancestors": [
 		"JpkqQJs6djWcPmFrF"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -126041,7 +126041,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "265.00",
+	"price": 265.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -126070,7 +126070,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "966.00",
+	"price": 966.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -126099,7 +126099,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "539.00",
+	"price": 539.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -126132,8 +126132,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -126159,7 +126159,7 @@
 	"ancestors": [
 		"sxXwmetHWAZEHuRDe"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -126196,7 +126196,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "160.00",
+	"price": 160.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -126225,7 +126225,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "859.00",
+	"price": 859.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -126254,7 +126254,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "920.00",
+	"price": 920.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -126287,8 +126287,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -126314,7 +126314,7 @@
 	"ancestors": [
 		"85pvqcZCS6oSsASpD"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -126351,7 +126351,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "139.00",
+	"price": 139.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -126380,7 +126380,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "769.00",
+	"price": 769.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -126409,7 +126409,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "520.00",
+	"price": 520.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -126442,8 +126442,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -126469,7 +126469,7 @@
 	"ancestors": [
 		"icyrRu9eN3KhkvEf9"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -126506,7 +126506,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "330.00",
+	"price": 330.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -126539,8 +126539,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -126566,7 +126566,7 @@
 	"ancestors": [
 		"zvzWrJ5nH33Rgj5sL"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -126603,7 +126603,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "854.00",
+	"price": 854.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -126632,7 +126632,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "29.00",
+	"price": 29.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -126661,7 +126661,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "546.00",
+	"price": 546.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -126690,7 +126690,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "833.00",
+	"price": 833.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -126723,8 +126723,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -126750,7 +126750,7 @@
 	"ancestors": [
 		"EGiacBxqiyuDjPSf4"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -126787,7 +126787,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "213.00",
+	"price": 213.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -126820,8 +126820,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -126847,7 +126847,7 @@
 	"ancestors": [
 		"aoxKirb2wHsufnZmg"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -126884,7 +126884,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "770.00",
+	"price": 770.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -126917,8 +126917,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -126944,7 +126944,7 @@
 	"ancestors": [
 		"Kt3tr5skbK34GxYML"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -126981,7 +126981,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "711.00",
+	"price": 711.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -127010,7 +127010,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "772.00",
+	"price": 772.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -127043,8 +127043,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -127070,7 +127070,7 @@
 	"ancestors": [
 		"JzNTsp9GPiGazd6aT"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -127107,7 +127107,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "622.00",
+	"price": 622.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -127140,8 +127140,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -127167,7 +127167,7 @@
 	"ancestors": [
 		"FWn58XR6vK4YckdGb"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -127204,7 +127204,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "310.00",
+	"price": 310.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -127233,7 +127233,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "312.00",
+	"price": 312.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -127262,7 +127262,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "318.00",
+	"price": 318.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -127291,7 +127291,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "594.00",
+	"price": 594.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -127324,8 +127324,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -127351,7 +127351,7 @@
 	"ancestors": [
 		"tNsrzjynp4ADNZje9"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -127388,7 +127388,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "353.00",
+	"price": 353.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -127417,7 +127417,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "732.00",
+	"price": 732.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -127446,7 +127446,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "77.00",
+	"price": 77.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -127479,8 +127479,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -127506,7 +127506,7 @@
 	"ancestors": [
 		"nkLsYWR9jijkuzD3E"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -127543,7 +127543,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "595.00",
+	"price": 595.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -127572,7 +127572,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "371.00",
+	"price": 371.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -127601,7 +127601,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "775.00",
+	"price": 775.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -127634,8 +127634,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -127661,7 +127661,7 @@
 	"ancestors": [
 		"G3AbgHLjPv8wdwseE"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -127698,7 +127698,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "549.00",
+	"price": 549.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -127727,7 +127727,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "862.00",
+	"price": 862.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -127756,7 +127756,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "921.00",
+	"price": 921.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -127785,7 +127785,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "609.00",
+	"price": 609.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -127818,8 +127818,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -127845,7 +127845,7 @@
 	"ancestors": [
 		"YbTjsdAshpKthyAqv"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -127882,7 +127882,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "818.00",
+	"price": 818.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -127911,7 +127911,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "256.00",
+	"price": 256.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -127940,7 +127940,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "101.00",
+	"price": 101.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -127973,8 +127973,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -128000,7 +128000,7 @@
 	"ancestors": [
 		"eGeNceJ22djMucK8y"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -128037,7 +128037,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "529.00",
+	"price": 529.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -128066,7 +128066,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "918.00",
+	"price": 918.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -128095,7 +128095,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "850.00",
+	"price": 850.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -128124,7 +128124,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "986.00",
+	"price": 986.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -128157,8 +128157,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -128184,7 +128184,7 @@
 	"ancestors": [
 		"cpxuYAT2xbqBexMZC"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -128221,7 +128221,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "592.00",
+	"price": 592.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -128254,8 +128254,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -128281,7 +128281,7 @@
 	"ancestors": [
 		"4CFpxq9vtNrMtBf4R"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -128318,7 +128318,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "892.00",
+	"price": 892.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -128347,7 +128347,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "503.00",
+	"price": 503.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -128376,7 +128376,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "23.00",
+	"price": 23.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -128409,8 +128409,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -128436,7 +128436,7 @@
 	"ancestors": [
 		"9WzAEufeTkgCuQn5y"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -128473,7 +128473,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "742.00",
+	"price": 742.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -128506,8 +128506,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -128533,7 +128533,7 @@
 	"ancestors": [
 		"HfjSMnZ6QrXATvLpS"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -128570,7 +128570,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "740.00",
+	"price": 740.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -128599,7 +128599,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "115.00",
+	"price": 115.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -128628,7 +128628,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "843.00",
+	"price": 843.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -128661,8 +128661,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -128688,7 +128688,7 @@
 	"ancestors": [
 		"HNznJAGYbd3Lp8qvY"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -128725,7 +128725,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "219.00",
+	"price": 219.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -128754,7 +128754,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "961.00",
+	"price": 961.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -128783,7 +128783,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "982.00",
+	"price": 982.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -128812,7 +128812,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "433.00",
+	"price": 433.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -128845,8 +128845,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -128872,7 +128872,7 @@
 	"ancestors": [
 		"AbMbRnrR7JAkWsRc9"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -128909,7 +128909,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "553.00",
+	"price": 553.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -128942,8 +128942,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -128969,7 +128969,7 @@
 	"ancestors": [
 		"jRzBR4HBpgygKMmBc"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -129006,7 +129006,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "767.00",
+	"price": 767.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -129035,7 +129035,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "847.00",
+	"price": 847.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -129064,7 +129064,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "560.00",
+	"price": 560.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -129093,7 +129093,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "256.00",
+	"price": 256.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -129126,8 +129126,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -129153,7 +129153,7 @@
 	"ancestors": [
 		"GaMv4ksH926gWXmfa"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -129190,7 +129190,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "710.00",
+	"price": 710.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -129219,7 +129219,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "104.00",
+	"price": 104.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -129248,7 +129248,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "629.00",
+	"price": 629.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -129277,7 +129277,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "864.00",
+	"price": 864.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -129310,8 +129310,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -129337,7 +129337,7 @@
 	"ancestors": [
 		"QY2rtoZgyuRNiyrvz"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -129374,7 +129374,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "435.00",
+	"price": 435.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -129403,7 +129403,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "109.00",
+	"price": 109.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -129432,7 +129432,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "632.00",
+	"price": 632.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -129461,7 +129461,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "923.00",
+	"price": 923.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -129494,8 +129494,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -129521,7 +129521,7 @@
 	"ancestors": [
 		"KDXCJpeMnYc2A9prF"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -129558,7 +129558,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "467.00",
+	"price": 467.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -129587,7 +129587,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "110.00",
+	"price": 110.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -129616,7 +129616,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "655.00",
+	"price": 655.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -129645,7 +129645,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "544.00",
+	"price": 544.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -129678,8 +129678,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -129705,7 +129705,7 @@
 	"ancestors": [
 		"dvvRm5cTRmxoNWL4f"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -129742,7 +129742,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "234.00",
+	"price": 234.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -129775,8 +129775,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -129802,7 +129802,7 @@
 	"ancestors": [
 		"id2PEAHtcJqHuRQc4"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -129839,7 +129839,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "65.00",
+	"price": 65.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -129868,7 +129868,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "313.00",
+	"price": 313.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -129901,8 +129901,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -129928,7 +129928,7 @@
 	"ancestors": [
 		"BqCKqP4vQHyzRpCw8"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -129965,7 +129965,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "854.00",
+	"price": 854.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -129998,8 +129998,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -130025,7 +130025,7 @@
 	"ancestors": [
 		"MnkmGLYrwr5gxz6jN"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -130062,7 +130062,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "547.00",
+	"price": 547.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -130095,8 +130095,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -130122,7 +130122,7 @@
 	"ancestors": [
 		"oM6rPdA2kPgRhv6fi"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -130159,7 +130159,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "227.00",
+	"price": 227.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -130188,7 +130188,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "601.00",
+	"price": 601.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -130217,7 +130217,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "562.00",
+	"price": 562.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -130250,8 +130250,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -130277,7 +130277,7 @@
 	"ancestors": [
 		"cDb3QnuCohENYwrGi"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -130314,7 +130314,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "285.00",
+	"price": 285.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -130343,7 +130343,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "499.00",
+	"price": 499.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -130372,7 +130372,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "894.00",
+	"price": 894.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -130405,8 +130405,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -130432,7 +130432,7 @@
 	"ancestors": [
 		"iugF9HDknCSPiBmEA"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -130469,7 +130469,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "14.00",
+	"price": 14.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -130498,7 +130498,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "648.00",
+	"price": 648.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -130531,8 +130531,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -130558,7 +130558,7 @@
 	"ancestors": [
 		"T4fDsQ9x2xgpaRkJJ"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -130595,7 +130595,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "506.00",
+	"price": 506.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -130628,8 +130628,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -130655,7 +130655,7 @@
 	"ancestors": [
 		"ofrMMofwFPGrYaxPe"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -130692,7 +130692,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "605.00",
+	"price": 605.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -130725,8 +130725,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -130752,7 +130752,7 @@
 	"ancestors": [
 		"3imHQkDhabHvcqMqA"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -130789,7 +130789,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "238.00",
+	"price": 238.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -130818,7 +130818,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "261.00",
+	"price": 261.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -130851,8 +130851,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -130878,7 +130878,7 @@
 	"ancestors": [
 		"pzEtXx8TEqr5DwHPS"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -130915,7 +130915,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "663.00",
+	"price": 663.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -130948,8 +130948,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -130975,7 +130975,7 @@
 	"ancestors": [
 		"SoYxmBPhYvxRSi69u"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -131012,7 +131012,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "648.00",
+	"price": 648.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -131045,8 +131045,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -131072,7 +131072,7 @@
 	"ancestors": [
 		"84cyXAtDzvo73m7xg"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -131109,7 +131109,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "438.00",
+	"price": 438.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -131138,7 +131138,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "177.00",
+	"price": 177.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -131167,7 +131167,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "413.00",
+	"price": 413.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -131196,7 +131196,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "323.00",
+	"price": 323.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -131229,8 +131229,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -131256,7 +131256,7 @@
 	"ancestors": [
 		"YdSeFuCfSosd5s5BC"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -131293,7 +131293,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "9.00",
+	"price": 9.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -131322,7 +131322,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "113.00",
+	"price": 113.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -131351,7 +131351,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "644.00",
+	"price": 644.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -131384,8 +131384,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -131411,7 +131411,7 @@
 	"ancestors": [
 		"DyJmPur6RGZzWHgAa"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -131448,7 +131448,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "45.00",
+	"price": 45.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -131477,7 +131477,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "820.00",
+	"price": 820.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -131506,7 +131506,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "474.00",
+	"price": 474.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -131535,7 +131535,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "252.00",
+	"price": 252.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -131568,8 +131568,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -131595,7 +131595,7 @@
 	"ancestors": [
 		"gN659y4KyD5r97jqb"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -131632,7 +131632,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "785.00",
+	"price": 785.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -131661,7 +131661,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "978.00",
+	"price": 978.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -131690,7 +131690,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "532.00",
+	"price": 532.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -131723,8 +131723,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -131750,7 +131750,7 @@
 	"ancestors": [
 		"qL3taeNpYoDw6rNTS"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -131787,7 +131787,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "252.00",
+	"price": 252.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -131816,7 +131816,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "394.00",
+	"price": 394.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -131849,8 +131849,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -131876,7 +131876,7 @@
 	"ancestors": [
 		"awcpkfKevt5w7wHN8"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -131913,7 +131913,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "317.00",
+	"price": 317.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -131942,7 +131942,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "260.00",
+	"price": 260.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -131975,8 +131975,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -132002,7 +132002,7 @@
 	"ancestors": [
 		"TQpYY7gamPFfNwNTm"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -132039,7 +132039,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "915.00",
+	"price": 915.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -132068,7 +132068,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "519.00",
+	"price": 519.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -132101,8 +132101,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -132128,7 +132128,7 @@
 	"ancestors": [
 		"sqyCPjM9kZEe3oWdK"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -132165,7 +132165,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "147.00",
+	"price": 147.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -132198,8 +132198,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -132225,7 +132225,7 @@
 	"ancestors": [
 		"Rq84phZLpF6uj5Cai"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -132262,7 +132262,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "330.00",
+	"price": 330.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -132295,8 +132295,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -132322,7 +132322,7 @@
 	"ancestors": [
 		"K9ffdAm7StMvoohdr"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -132359,7 +132359,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "442.00",
+	"price": 442.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -132388,7 +132388,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "189.00",
+	"price": 189.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -132421,8 +132421,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -132448,7 +132448,7 @@
 	"ancestors": [
 		"G8RpjoRoPXa9KpTQp"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -132485,7 +132485,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "303.00",
+	"price": 303.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -132518,8 +132518,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -132545,7 +132545,7 @@
 	"ancestors": [
 		"qmaBEfxPa2QHR86MT"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -132582,7 +132582,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "357.00",
+	"price": 357.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -132611,7 +132611,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "199.00",
+	"price": 199.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -132640,7 +132640,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "955.00",
+	"price": 955.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -132673,8 +132673,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -132700,7 +132700,7 @@
 	"ancestors": [
 		"As6cyJ2ot55RJhKeN"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -132737,7 +132737,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "772.00",
+	"price": 772.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -132770,8 +132770,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -132797,7 +132797,7 @@
 	"ancestors": [
 		"HChpGfPpyMMzSmeae"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -132834,7 +132834,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "94.00",
+	"price": 94.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -132867,8 +132867,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -132894,7 +132894,7 @@
 	"ancestors": [
 		"nBBJ6QYgLrvWsp7FP"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -132931,7 +132931,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "679.00",
+	"price": 679.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -132964,8 +132964,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -132991,7 +132991,7 @@
 	"ancestors": [
 		"EdsE37n2dpxrEFp2a"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -133028,7 +133028,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "449.00",
+	"price": 449.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -133057,7 +133057,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "986.00",
+	"price": 986.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -133086,7 +133086,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "923.00",
+	"price": 923.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -133115,7 +133115,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "484.00",
+	"price": 484.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -133148,8 +133148,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -133175,7 +133175,7 @@
 	"ancestors": [
 		"rnAnjoLHp6grBPdBu"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -133212,7 +133212,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "696.00",
+	"price": 696.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -133241,7 +133241,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "814.00",
+	"price": 814.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -133270,7 +133270,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "569.00",
+	"price": 569.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -133299,7 +133299,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "792.00",
+	"price": 792.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -133332,8 +133332,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -133359,7 +133359,7 @@
 	"ancestors": [
 		"gdnD3kzWwYzHMmBk9"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -133396,7 +133396,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "77.00",
+	"price": 77.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -133425,7 +133425,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "972.00",
+	"price": 972.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -133454,7 +133454,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "933.00",
+	"price": 933.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -133483,7 +133483,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "362.00",
+	"price": 362.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -133516,8 +133516,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -133543,7 +133543,7 @@
 	"ancestors": [
 		"vRNDwcfqBhqTvjA3B"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -133580,7 +133580,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "567.00",
+	"price": 567.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -133609,7 +133609,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "89.00",
+	"price": 89.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -133638,7 +133638,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "688.00",
+	"price": 688.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -133667,7 +133667,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "551.00",
+	"price": 551.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -133700,8 +133700,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -133727,7 +133727,7 @@
 	"ancestors": [
 		"jSPZwqodqbJofCALn"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -133764,7 +133764,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "380.00",
+	"price": 380.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -133793,7 +133793,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "953.00",
+	"price": 953.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -133826,8 +133826,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -133853,7 +133853,7 @@
 	"ancestors": [
 		"TF9zX6P48AArQLGQu"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -133890,7 +133890,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "626.00",
+	"price": 626.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -133919,7 +133919,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "906.00",
+	"price": 906.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -133952,8 +133952,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -133979,7 +133979,7 @@
 	"ancestors": [
 		"EpCDfxo9qZnMuAQwa"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -134016,7 +134016,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "201.00",
+	"price": 201.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -134045,7 +134045,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "579.00",
+	"price": 579.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -134074,7 +134074,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "936.00",
+	"price": 936.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -134107,8 +134107,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -134134,7 +134134,7 @@
 	"ancestors": [
 		"G6kr9nCsKKjerKoud"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -134171,7 +134171,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "212.00",
+	"price": 212.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -134204,8 +134204,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -134231,7 +134231,7 @@
 	"ancestors": [
 		"66eWr9NmbjQL5L2Ak"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -134268,7 +134268,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "42.00",
+	"price": 42.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -134301,8 +134301,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -134328,7 +134328,7 @@
 	"ancestors": [
 		"R6apCsKJLmvWdhpHY"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -134365,7 +134365,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "892.00",
+	"price": 892.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -134398,8 +134398,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -134425,7 +134425,7 @@
 	"ancestors": [
 		"myfARqXsnKQ8Q7fbS"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -134462,7 +134462,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "28.00",
+	"price": 28.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -134495,8 +134495,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -134522,7 +134522,7 @@
 	"ancestors": [
 		"ZLEGFwBG75StquTy9"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -134559,7 +134559,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "621.00",
+	"price": 621.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -134588,7 +134588,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "999.00",
+	"price": 999.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -134621,8 +134621,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -134648,7 +134648,7 @@
 	"ancestors": [
 		"jEgrB57eRjcmevPgb"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -134685,7 +134685,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "305.00",
+	"price": 305.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -134718,8 +134718,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -134745,7 +134745,7 @@
 	"ancestors": [
 		"ijHmQCN9hjAHgC3ER"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -134782,7 +134782,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "653.00",
+	"price": 653.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -134811,7 +134811,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "325.00",
+	"price": 325.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -134844,8 +134844,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -134871,7 +134871,7 @@
 	"ancestors": [
 		"h4fjeMiHpTw8Roroc"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -134908,7 +134908,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "165.00",
+	"price": 165.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -134937,7 +134937,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "482.00",
+	"price": 482.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -134966,7 +134966,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "953.00",
+	"price": 953.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -134995,7 +134995,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "215.00",
+	"price": 215.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -135028,8 +135028,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -135055,7 +135055,7 @@
 	"ancestors": [
 		"yTmG3kfDfXX2acbnM"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -135092,7 +135092,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "804.00",
+	"price": 804.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -135121,7 +135121,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "647.00",
+	"price": 647.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -135150,7 +135150,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "305.00",
+	"price": 305.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -135179,7 +135179,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "694.00",
+	"price": 694.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -135212,8 +135212,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -135239,7 +135239,7 @@
 	"ancestors": [
 		"pJKa2rRkNop3toC7g"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -135276,7 +135276,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "102.00",
+	"price": 102.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -135309,8 +135309,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -135336,7 +135336,7 @@
 	"ancestors": [
 		"TAhoYQ8ZdXJ4HzEAM"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -135373,7 +135373,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "949.00",
+	"price": 949.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -135402,7 +135402,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "414.00",
+	"price": 414.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -135435,8 +135435,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -135462,7 +135462,7 @@
 	"ancestors": [
 		"3SnBDR64HkPmPzWCk"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -135499,7 +135499,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "912.00",
+	"price": 912.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -135528,7 +135528,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "531.00",
+	"price": 531.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -135557,7 +135557,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "856.00",
+	"price": 856.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -135590,8 +135590,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -135617,7 +135617,7 @@
 	"ancestors": [
 		"yZuGZoEoRALeCWWQy"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -135654,7 +135654,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "124.00",
+	"price": 124.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -135683,7 +135683,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "979.00",
+	"price": 979.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -135712,7 +135712,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "796.00",
+	"price": 796.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -135741,7 +135741,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "533.00",
+	"price": 533.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -135774,8 +135774,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -135801,7 +135801,7 @@
 	"ancestors": [
 		"hJ6FCtSCyYXZnoLRg"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -135838,7 +135838,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "942.00",
+	"price": 942.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -135867,7 +135867,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "515.00",
+	"price": 515.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -135900,8 +135900,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -135927,7 +135927,7 @@
 	"ancestors": [
 		"HoYEsvHzMoQ2kxfi3"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -135964,7 +135964,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "914.00",
+	"price": 914.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -135997,8 +135997,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -136024,7 +136024,7 @@
 	"ancestors": [
 		"4oZcJiKxP8Cd84csX"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -136061,7 +136061,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "297.00",
+	"price": 297.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -136090,7 +136090,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "951.00",
+	"price": 951.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -136119,7 +136119,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "966.00",
+	"price": 966.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -136152,8 +136152,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -136179,7 +136179,7 @@
 	"ancestors": [
 		"sHwkm4HJEnEWyNnvo"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -136216,7 +136216,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "50.00",
+	"price": 50.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -136245,7 +136245,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "248.00",
+	"price": 248.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -136274,7 +136274,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "889.00",
+	"price": 889.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -136303,7 +136303,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "735.00",
+	"price": 735.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -136336,8 +136336,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -136363,7 +136363,7 @@
 	"ancestors": [
 		"EoehzTJgsWw37nWkX"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -136400,7 +136400,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "539.00",
+	"price": 539.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -136429,7 +136429,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "532.00",
+	"price": 532.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -136458,7 +136458,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "686.00",
+	"price": 686.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -136491,8 +136491,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -136518,7 +136518,7 @@
 	"ancestors": [
 		"2mnadyMQunBWdgjL7"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -136555,7 +136555,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "590.00",
+	"price": 590.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -136584,7 +136584,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "38.00",
+	"price": 38.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -136613,7 +136613,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "505.00",
+	"price": 505.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -136642,7 +136642,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "489.00",
+	"price": 489.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -136675,8 +136675,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -136702,7 +136702,7 @@
 	"ancestors": [
 		"PFLg4YWJEdhAP64Xw"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -136739,7 +136739,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "684.00",
+	"price": 684.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -136772,8 +136772,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -136799,7 +136799,7 @@
 	"ancestors": [
 		"3YbqyeoH3iTLhRRAp"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -136836,7 +136836,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "219.00",
+	"price": 219.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -136865,7 +136865,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "280.00",
+	"price": 280.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -136894,7 +136894,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "762.00",
+	"price": 762.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -136923,7 +136923,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "256.00",
+	"price": 256.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -136956,8 +136956,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -136983,7 +136983,7 @@
 	"ancestors": [
 		"8s3JCEf6oEKXPAkPp"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -137020,7 +137020,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "488.00",
+	"price": 488.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -137049,7 +137049,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "376.00",
+	"price": 376.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -137078,7 +137078,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "375.00",
+	"price": 375.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -137111,8 +137111,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -137138,7 +137138,7 @@
 	"ancestors": [
 		"hBzHJNWvC5ituuXTm"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -137175,7 +137175,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "40.00",
+	"price": 40.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -137204,7 +137204,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "725.00",
+	"price": 725.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -137233,7 +137233,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "657.00",
+	"price": 657.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -137266,8 +137266,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -137293,7 +137293,7 @@
 	"ancestors": [
 		"ZRLshzs6Ni3qFFefP"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -137330,7 +137330,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "86.00",
+	"price": 86.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -137359,7 +137359,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "36.00",
+	"price": 36.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -137392,8 +137392,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -137419,7 +137419,7 @@
 	"ancestors": [
 		"xBu3uougcjFJX38u7"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -137456,7 +137456,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "846.00",
+	"price": 846.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -137485,7 +137485,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "841.00",
+	"price": 841.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -137518,8 +137518,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -137545,7 +137545,7 @@
 	"ancestors": [
 		"Jegetq3LFbFbiyktr"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -137582,7 +137582,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "723.00",
+	"price": 723.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -137611,7 +137611,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "324.00",
+	"price": 324.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -137640,7 +137640,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "817.00",
+	"price": 817.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -137669,7 +137669,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "119.00",
+	"price": 119.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -137702,8 +137702,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -137729,7 +137729,7 @@
 	"ancestors": [
 		"ErbWvcQmXNRarv2DF"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -137766,7 +137766,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "714.00",
+	"price": 714.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -137795,7 +137795,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "385.00",
+	"price": 385.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -137828,8 +137828,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -137855,7 +137855,7 @@
 	"ancestors": [
 		"rWz2ygAx8958oRdNv"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -137892,7 +137892,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "338.00",
+	"price": 338.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -137921,7 +137921,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "797.00",
+	"price": 797.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -137950,7 +137950,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "375.00",
+	"price": 375.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -137979,7 +137979,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "851.00",
+	"price": 851.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -138012,8 +138012,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -138039,7 +138039,7 @@
 	"ancestors": [
 		"mvZb5iGYAHbdAtfsP"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -138076,7 +138076,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "82.00",
+	"price": 82.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -138105,7 +138105,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "747.00",
+	"price": 747.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -138138,8 +138138,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -138165,7 +138165,7 @@
 	"ancestors": [
 		"vKh5yLZzAgRBGN87L"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -138202,7 +138202,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "141.00",
+	"price": 141.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -138235,8 +138235,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -138262,7 +138262,7 @@
 	"ancestors": [
 		"wM2ZktNT5kSN9uXoN"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -138299,7 +138299,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "557.00",
+	"price": 557.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -138328,7 +138328,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "304.00",
+	"price": 304.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -138357,7 +138357,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "883.00",
+	"price": 883.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -138386,7 +138386,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "118.00",
+	"price": 118.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -138419,8 +138419,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -138446,7 +138446,7 @@
 	"ancestors": [
 		"bZwAJ3ycT3dzBDn3f"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -138483,7 +138483,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "299.00",
+	"price": 299.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -138512,7 +138512,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "554.00",
+	"price": 554.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -138545,8 +138545,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -138572,7 +138572,7 @@
 	"ancestors": [
 		"zDNbaTiya56sY6Xap"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -138609,7 +138609,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "746.00",
+	"price": 746.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -138642,8 +138642,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -138669,7 +138669,7 @@
 	"ancestors": [
 		"scjYTggYGkbxp9BJQ"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -138706,7 +138706,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "55.00",
+	"price": 55.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -138735,7 +138735,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "702.00",
+	"price": 702.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -138764,7 +138764,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "506.00",
+	"price": 506.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -138797,8 +138797,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -138824,7 +138824,7 @@
 	"ancestors": [
 		"AeyMeaX8C5EEvMBB8"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -138861,7 +138861,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "353.00",
+	"price": 353.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -138890,7 +138890,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "802.00",
+	"price": 802.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -138919,7 +138919,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "767.00",
+	"price": 767.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -138948,7 +138948,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "891.00",
+	"price": 891.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -138981,8 +138981,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -139008,7 +139008,7 @@
 	"ancestors": [
 		"ZytqSkC6rBGPrjCaH"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -139045,7 +139045,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "30.00",
+	"price": 30.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -139074,7 +139074,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "267.00",
+	"price": 267.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -139107,8 +139107,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -139134,7 +139134,7 @@
 	"ancestors": [
 		"wZFaeubnjBYiyNwQ8"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -139171,7 +139171,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "550.00",
+	"price": 550.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -139200,7 +139200,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "17.00",
+	"price": 17.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -139229,7 +139229,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "406.00",
+	"price": 406.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -139262,8 +139262,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -139289,7 +139289,7 @@
 	"ancestors": [
 		"T8xAgfMAqyPwRKCF5"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -139326,7 +139326,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "740.00",
+	"price": 740.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -139355,7 +139355,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "913.00",
+	"price": 913.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -139384,7 +139384,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "440.00",
+	"price": 440.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -139413,7 +139413,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "953.00",
+	"price": 953.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -139446,8 +139446,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -139473,7 +139473,7 @@
 	"ancestors": [
 		"Mt3wF5h6z5c3QBMWS"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -139510,7 +139510,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "677.00",
+	"price": 677.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -139539,7 +139539,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "542.00",
+	"price": 542.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -139572,8 +139572,8 @@
 	"isVisible": true,
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"template": "productDetailSimple",
 	"workflow": {
@@ -139599,7 +139599,7 @@
 	"ancestors": [
 		"jDttCcoTyjLihzoLr"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -139636,7 +139636,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": "537.00",
+	"price": 537.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,

--- a/sample-data/data/medium/Products.json
+++ b/sample-data/data/medium/Products.json
@@ -19,11 +19,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Perferendis aliquid molestiae. Minima vero porro a. Et sed ullam et recusandae non quia sunt.",
 	"title": "Practical Cotton Tuna",
@@ -207,11 +202,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Quia pariatur deserunt. Perspiciatis dolores ut pariatur voluptatem asperiores. Sed est facilis minus voluptatem pariatur nesciunt hic omnis.",
 	"title": "Handcrafted Fresh Bacon",
@@ -308,11 +298,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Laboriosam et atque. Dolores autem voluptas eos praesentium neque est et aspernatur amet. Delectus voluptatem fugit laudantium assumenda. Velit rerum aut. Autem aut quo quas natus exercitationem et quo sapiente. Facilis adipisci quam quibusdam ad et.",
 	"title": "Small Frozen Table",
@@ -409,11 +394,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Magnam aut quod quod voluptatibus iusto voluptatibus qui. Dolor omnis magnam maxime. Autem et voluptate similique expedita at nam temporibus voluptas voluptates.",
 	"title": "Sleek Steel Car",
@@ -568,11 +548,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Ut non qui earum reiciendis labore nam enim aspernatur. Modi delectus blanditiis a eum rem exercitationem voluptas aperiam. Voluptas ut quia possimus a aliquid. Exercitationem libero inventore totam aperiam. Provident rerum modi commodi. Quidem non corrupti sequi.",
 	"title": "Licensed Plastic Pants",
@@ -669,11 +644,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Ea ducimus eos molestiae earum consequatur voluptate quia nesciunt nihil. Sint dolor laborum. Quod aspernatur ut officiis quo quis distinctio. Explicabo et et eum labore repudiandae. In enim ea sit ducimus nisi ipsa aut voluptatum.",
 	"title": "Unbranded Granite Towels",
@@ -828,11 +798,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Ea nisi sequi facere ea autem. Autem tempora voluptas. Quia minima consequatur et voluptatem est autem. Minima inventore deleniti laboriosam. Voluptatibus eaque dolores debitis dolor.",
 	"title": "Generic Rubber Salad",
@@ -958,11 +923,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Recusandae expedita placeat est facere nulla et ea officiis ut. Tempora doloremque ad odio quis. Repellat natus aut consequatur. Id nobis molestias labore inventore similique similique nesciunt natus et. Quidem aperiam est modi error voluptatem. Officiis odit earum et velit rem eum deleniti nemo ratione.",
 	"title": "Unbranded Steel Fish",
@@ -1088,11 +1048,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Odio iure maiores dolor nesciunt explicabo aut ut ipsam in. Vitae repellendus qui architecto voluptatem possimus qui. Ut omnis vitae corporis ab delectus. Qui ducimus commodi quia laudantium minus esse eum sed culpa. Error dolorem est enim.",
 	"title": "Ergonomic Cotton Chips",
@@ -1189,11 +1144,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Consequatur accusantium quisquam numquam. Dolores ut optio minus natus omnis nulla. Corrupti porro in qui quia provident ut. Esse sed aperiam quaerat harum commodi voluptates consectetur quidem quae.",
 	"title": "Gorgeous Rubber Tuna",
@@ -1319,11 +1269,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Minima fuga eum natus minima eum ut. Et ipsum ex cupiditate voluptas earum enim et. Recusandae ea minima. Facere ut eius minima ullam. Corporis praesentium natus quis.",
 	"title": "Practical Metal Towels",
@@ -1420,11 +1365,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Voluptate recusandae et. Beatae adipisci dolore qui itaque. Veniam maxime ut fugit eos quisquam sit. Voluptatem mollitia odio quasi dolor non voluptatibus blanditiis aspernatur.",
 	"title": "Tasty Concrete Shirt",
@@ -1521,11 +1461,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Nobis necessitatibus et consequatur magnam quia autem. Necessitatibus blanditiis dolore voluptatum. Et iure atque. Quaerat deleniti velit ut pariatur reprehenderit. Saepe repellat ad est eius velit voluptate sit.",
 	"title": "Gorgeous Cotton Shoes",
@@ -1680,11 +1615,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Doloribus saepe voluptas distinctio. Ut adipisci eligendi sapiente iusto expedita ea nesciunt laborum. Consequatur occaecati sint qui perspiciatis eaque ipsam ut aliquam. Qui itaque eveniet. Esse dolore similique quo libero dignissimos molestiae voluptas nobis.",
 	"title": "Unbranded Granite Sausages",
@@ -1810,11 +1740,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Voluptatem itaque velit. Accusamus molestiae iste sit eum et saepe sunt. Et corporis ab qui quibusdam animi nam praesentium doloribus.",
 	"title": "Ergonomic Concrete Cheese",
@@ -1998,11 +1923,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Eum sit asperiores quis nobis. Ut numquam qui fuga quibusdam expedita autem. Et facere iusto et accusantium. Aut maiores velit omnis non sed autem enim quod quo. Quibusdam modi officiis.",
 	"title": "Intelligent Rubber Salad",
@@ -2186,11 +2106,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Numquam non sit minus. Et minima nostrum corporis rerum a et quaerat vitae rerum. Magni illo nihil totam et eos id. Minima vel quidem magni facilis nobis eaque architecto voluptatem temporibus. Dignissimos a et.",
 	"title": "Gorgeous Soft Salad",
@@ -2287,11 +2202,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Repudiandae labore eum eius quo deleniti. Mollitia quasi et asperiores alias. Necessitatibus voluptatem velit dolores praesentium aut quam enim.",
 	"title": "Handmade Plastic Mouse",
@@ -2446,11 +2356,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Doloremque debitis eos repellat nisi eos omnis ipsam. Omnis suscipit laudantium a. Sed error quia omnis distinctio possimus illum ipsa. Sequi vero cupiditate aut doloremque ad aliquid iste eaque. Eveniet quibusdam soluta dolorem nihil occaecati hic sit quasi. Rerum excepturi quis aut.",
 	"title": "Small Fresh Shirt",
@@ -2576,11 +2481,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Officiis nihil consectetur quisquam aut. Quia laudantium qui amet quisquam sit. Quo sed aut. Sapiente repellat qui molestiae hic et sed. Molestias est voluptatem velit distinctio.",
 	"title": "Fantastic Granite Tuna",
@@ -2764,11 +2664,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Provident provident consectetur sequi. Et odit dolore eaque eum voluptatibus quia. Ea sunt sit ut. Totam consequuntur id eos alias. Doloribus fuga repudiandae numquam. Necessitatibus et impedit consectetur doloremque velit.",
 	"title": "Sleek Cotton Tuna",
@@ -2894,11 +2789,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Nihil eum consectetur laudantium ipsa. Quas voluptatem architecto. Occaecati qui nostrum eum libero mollitia aliquid pariatur fugit nihil. Recusandae id illum incidunt nobis ipsam aliquid eum perferendis. Aut modi reprehenderit ad mollitia similique voluptatem eos perferendis est.",
 	"title": "Fantastic Concrete Pizza",
@@ -3024,11 +2914,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Ut magnam quibusdam blanditiis. Eaque nobis ipsam quibusdam voluptas accusantium. Harum aut saepe voluptatem iure eaque. Mollitia sit qui.",
 	"title": "Intelligent Frozen Tuna",
@@ -3183,11 +3068,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Iste magni nesciunt earum est sint voluptatem. Molestiae sunt possimus omnis omnis. Maiores dolores odio quia quisquam debitis et. Aut qui aut similique error alias iste quasi praesentium id.",
 	"title": "Handmade Steel Car",
@@ -3313,11 +3193,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Quidem adipisci maxime reprehenderit sit voluptas voluptas. Consectetur sed quia officia quo et laborum. Ut saepe blanditiis consequuntur. Quia itaque vitae id numquam quisquam quam quisquam.",
 	"title": "Tasty Cotton Pants",
@@ -3472,11 +3347,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Nam perspiciatis iure quos optio amet doloremque totam. Nam distinctio quo voluptatibus. Id veniam beatae tenetur velit unde beatae. Voluptates est labore mollitia.",
 	"title": "Small Soft Chips",
@@ -3602,11 +3472,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Dolorem corrupti omnis eligendi nihil nihil expedita deleniti earum dolores. Ut qui odio maxime enim voluptatem temporibus odit quam. Rem ipsam et quia adipisci. Quia ipsa aliquid.",
 	"title": "Unbranded Wooden Computer",
@@ -3790,11 +3655,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Quae id voluptatem vitae ut ad est quis. Dicta et consequatur quidem accusantium id qui delectus aut. Voluptatem aut molestiae labore ipsam omnis quia. Totam numquam autem aut error ut inventore architecto. Sunt consequatur at cupiditate et quia veritatis sit. Voluptatem autem harum nulla quas corrupti sed quia sunt.",
 	"title": "Handcrafted Fresh Hat",
@@ -3920,11 +3780,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Provident minus sed consectetur et harum. Eligendi aperiam voluptatem labore laudantium corrupti voluptatem. Suscipit aut quis dolorem aut veritatis. Nihil magni velit aliquam natus omnis unde. Enim dolorem quidem tempore incidunt accusamus beatae mollitia similique eveniet. Est exercitationem ea.",
 	"title": "Handcrafted Granite Bacon",
@@ -4108,11 +3963,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Odit et odio incidunt magni nam ducimus eveniet. Nobis soluta hic quia. Aut provident odit sunt hic voluptas eos. Et totam libero. Amet cupiditate sed dolores possimus. Eius repudiandae rerum.",
 	"title": "Awesome Wooden Sausages",
@@ -4296,11 +4146,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Nihil labore consequatur molestiae et vel commodi modi. Laboriosam unde facere velit quidem nesciunt quis dolorem voluptas. Dolorem tenetur doloribus aut. Et quisquam dolorem. Praesentium voluptate iste ipsa natus necessitatibus id ut iste. Repellendus quia cum veniam necessitatibus ipsam debitis tempora.",
 	"title": "Handcrafted Plastic Chair",
@@ -4397,11 +4242,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Aut aut aliquam voluptatem ratione maxime. Voluptas qui velit inventore perspiciatis eligendi. Et aliquid quis enim ipsum sit cum illo qui. Esse omnis aut quos est deleniti eligendi laborum eos. Est labore distinctio soluta molestias soluta accusamus.",
 	"title": "Handcrafted Steel Salad",
@@ -4556,11 +4396,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Ut libero eum amet iure ut tenetur amet voluptatum. Quas inventore et aut deleniti vero quam quis dicta. Hic vitae non non.",
 	"title": "Rustic Cotton Bike",
@@ -4715,11 +4550,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Qui sed rerum ut maiores error ipsa. Nisi aut est nobis et illum et. Nihil consequatur asperiores in magni accusamus a.",
 	"title": "Rustic Rubber Towels",
@@ -4845,11 +4675,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Numquam in eum. Deserunt neque in reiciendis possimus pariatur laboriosam modi omnis. Dicta reiciendis et labore laborum ut molestiae. Est eligendi non eveniet ratione molestias cumque aliquam aut nobis.",
 	"title": "Intelligent Plastic Soap",
@@ -4946,11 +4771,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Delectus illo odit repudiandae et. Ut et facere quisquam tenetur cum. Quas praesentium earum eos voluptatibus non quam voluptates error illum. Quia aliquid autem natus doloremque in. Dolorum perspiciatis consequatur repudiandae perferendis. Aspernatur tempore beatae quibusdam consequatur cum quod.",
 	"title": "Generic Plastic Bacon",
@@ -5105,11 +4925,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Alias reiciendis consequatur sunt autem ipsum. Error qui est molestiae voluptas. Vel corrupti totam quis corrupti aut.",
 	"title": "Small Granite Ball",
@@ -5206,11 +5021,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Quos soluta rerum sapiente asperiores sequi et ut in voluptatum. Sit et voluptatum perferendis. Reprehenderit consequuntur quia omnis voluptatem id autem in optio. Quae laborum similique impedit neque quasi. Odio exercitationem soluta. Laudantium praesentium natus voluptatem ut explicabo animi.",
 	"title": "Ergonomic Granite Computer",
@@ -5307,11 +5117,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Et eius quia id quis. Velit delectus ut. Quos praesentium doloribus rem sint harum omnis ea. Et vero ut tempora. Voluptate voluptatibus dolore. Voluptatem corrupti exercitationem.",
 	"title": "Generic Metal Bike",
@@ -5437,11 +5242,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Quos et veniam. Ut earum et vero cupiditate. Tenetur quae pariatur incidunt natus libero repellendus repellat et. Quo qui expedita distinctio ut consequatur optio officiis voluptatem ut.",
 	"title": "Handcrafted Frozen Mouse",
@@ -5538,11 +5338,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Harum veniam excepturi voluptates est eum dolores. Dolorum quasi est a sint recusandae itaque. Error ex et. Ut a rerum.",
 	"title": "Sleek Frozen Car",
@@ -5639,11 +5434,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Nihil dolores qui. Minima molestiae nulla rerum dicta fugit. Optio totam debitis.",
 	"title": "Refined Concrete Fish",
@@ -5769,11 +5559,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Enim alias unde. Sit nostrum aliquam quasi eum et ducimus illum. Laboriosam eligendi id rem nobis quos et provident. Quia enim est ipsum alias. Et voluptas mollitia aperiam excepturi tenetur. Quisquam numquam est voluptatibus veritatis odit est.",
 	"title": "Small Frozen Computer",
@@ -5957,11 +5742,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Ut ducimus repudiandae laboriosam qui maiores dolor quam tempora totam. Quaerat nesciunt reprehenderit corrupti libero. Velit quo ex quae eveniet qui sapiente voluptates deserunt. Possimus incidunt voluptates voluptatum inventore suscipit. Ratione omnis aut est maxime voluptatum.",
 	"title": "Refined Granite Chair",
@@ -6087,11 +5867,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Nostrum qui ex consequatur optio enim cum veritatis id. Fugiat quod nesciunt quisquam ut cupiditate repellat. Culpa autem non nemo temporibus nulla cupiditate quas. Nobis voluptas dolores voluptatum est sint distinctio quae minus. Non pariatur voluptates ea est ipsam sapiente ratione dicta. Omnis consequuntur natus non recusandae quo laudantium.",
 	"title": "Handmade Granite Gloves",
@@ -6246,11 +6021,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Ipsum provident fuga et illo cumque sit fugit aspernatur. Nulla dolorum dolores dolor sunt atque eos quo ipsam. Voluptas quasi qui quod deserunt iusto vel.",
 	"title": "Handcrafted Concrete Hat",
@@ -6376,11 +6146,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Dolore unde vero et et soluta id. Reiciendis est ut repellat ut quasi illum quasi. Quia harum libero perspiciatis quia enim qui. Est occaecati non quos enim in quisquam.",
 	"title": "Incredible Metal Keyboard",
@@ -6564,11 +6329,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Dolorem et culpa. Dolorum tenetur magnam quasi delectus aut. Beatae nulla omnis quia non nihil deserunt occaecati magni non. Nihil et in expedita. Dolorem et error nihil cum soluta iste dolorem.",
 	"title": "Ergonomic Concrete Sausages",
@@ -6694,11 +6454,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Voluptatem rem voluptatum praesentium ipsum consequatur. Beatae illo eaque consequatur aut quasi assumenda provident ut praesentium. Iure ipsam ipsa. Soluta consequatur laudantium eos aspernatur.",
 	"title": "Gorgeous Granite Bike",
@@ -6824,11 +6579,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Aperiam ea quae. Fuga doloribus et provident consequatur at nobis eveniet laudantium. Aut commodi repellendus inventore autem aut non explicabo et rerum. Numquam voluptatum et ratione dolorum. Libero sint aut dolores nisi totam sequi quisquam.",
 	"title": "Sleek Concrete Bacon",
@@ -6925,11 +6675,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Perspiciatis quia amet provident similique error. Quia itaque ex numquam quidem soluta quis officia corrupti nobis. Aliquid aliquam accusantium. Libero quod molestiae. Ipsam odio qui asperiores veniam repellat sint odit quia. Ipsum laborum nihil corporis autem velit.",
 	"title": "Ergonomic Steel Chair",
@@ -7026,11 +6771,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Similique aliquid quia illum aperiam ut voluptatibus sed alias. Quod ut eaque. Assumenda possimus recusandae. Et natus nisi. Reiciendis quis labore numquam qui nisi aspernatur nam facilis ipsum. Quasi minima voluptatibus nemo doloribus.",
 	"title": "Handmade Cotton Pizza",
@@ -7127,11 +6867,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Vitae quaerat numquam saepe reprehenderit consequatur ut adipisci eos. Voluptatum molestiae sapiente nemo nobis consequatur facere consequatur dolorum eos. Et sequi quia assumenda debitis animi eos. Est dolorem et id ullam eos nisi.",
 	"title": "Handmade Cotton Shirt",
@@ -7228,11 +6963,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Reprehenderit consequatur repellat maiores. Consequatur aut vel excepturi eum numquam ratione. Velit et exercitationem eaque dolorum.",
 	"title": "Practical Granite Chips",
@@ -7387,11 +7117,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Quos dolores earum quas. Nulla quis placeat debitis praesentium aut perspiciatis et. Animi unde ducimus possimus. Ex eum autem.",
 	"title": "Handmade Rubber Bike",
@@ -7488,11 +7213,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Nihil aut omnis neque id dolorem. Facilis sint sequi. Placeat deleniti rem nemo. Maiores cum qui. Qui omnis fugiat. Sint dolor veniam rerum voluptates cum.",
 	"title": "Generic Metal Table",
@@ -7647,11 +7367,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Eveniet a voluptatibus beatae possimus nisi officiis explicabo. Numquam hic tenetur. Quis voluptas aut enim.",
 	"title": "Small Soft Table",
@@ -7748,11 +7463,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Accusantium architecto magni enim aut cupiditate similique asperiores. Mollitia nostrum ea ducimus. Aut rerum sunt esse ipsum. Dolore numquam atque. Consequatur voluptatem quis ducimus vel harum rerum ipsum. Minima placeat officiis quia quia illum in maiores.",
 	"title": "Awesome Granite Pizza",
@@ -7936,11 +7646,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Id et enim et quia minus quod. Cum quae magni deserunt dolore est. Dolorum animi aut magnam.",
 	"title": "Unbranded Wooden Mouse",
@@ -8066,11 +7771,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Dolorem voluptatum tempora quis deserunt doloremque minus. In pariatur officiis et reiciendis. Commodi consequatur rem voluptatibus maxime asperiores suscipit consectetur est labore. Accusantium est cum distinctio officiis. Placeat et non iste laboriosam aspernatur est numquam aut saepe.",
 	"title": "Generic Steel Mouse",
@@ -8196,11 +7896,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Repellat magni molestiae sunt nemo. Cupiditate sequi non. Nisi qui est ex. Aut unde quo qui. Ab vitae mollitia illum maiores eum nemo quibusdam enim. Voluptate sint voluptas unde aspernatur et.",
 	"title": "Unbranded Metal Cheese",
@@ -8384,11 +8079,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Aspernatur ab laudantium quibusdam voluptas non minima molestias rerum cumque. Id et ullam qui dolore odit ut vero nulla natus. Quas quos quas laudantium aut eveniet voluptatem similique. Quas ullam officiis. Quidem sit nemo deserunt molestiae neque error.",
 	"title": "Small Granite Car",
@@ -8572,11 +8262,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Dolorem asperiores repellendus natus officia est aut dicta accusantium accusantium. Magni provident fugiat ducimus atque. Et dicta reiciendis labore quis consectetur atque fuga vero. Minus voluptate ab aut eos hic totam.",
 	"title": "Handmade Fresh Tuna",
@@ -8673,11 +8358,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Voluptatem modi nisi voluptatum. Consequatur delectus molestiae quos non excepturi adipisci similique enim. Consequatur in voluptatem. Expedita officiis corrupti quam itaque.",
 	"title": "Awesome Soft Computer",
@@ -8861,11 +8541,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Voluptatem dolores accusamus nulla dolores esse. Voluptatem reprehenderit quas. Voluptatem nostrum culpa facere veniam esse eligendi.",
 	"title": "Practical Cotton Pizza",
@@ -9020,11 +8695,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Provident placeat fugit consequuntur suscipit quam non. Doloribus eaque debitis. Dolores sit et qui aut. Optio quasi praesentium voluptatem ipsam maiores tempora. Hic odit ipsum incidunt cum consequuntur.",
 	"title": "Handmade Frozen Pizza",
@@ -9150,11 +8820,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Voluptas inventore suscipit voluptas numquam et doloremque. Aspernatur ipsa aut. Commodi eveniet aut qui repudiandae dolorem molestiae distinctio nulla. Corporis sed laborum impedit nulla qui. Voluptatem dolorem libero.",
 	"title": "Handcrafted Cotton Shirt",
@@ -9338,11 +9003,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Asperiores totam dolor voluptas. Aut qui consequatur rerum in et. Dignissimos est doloremque aut cupiditate qui et harum.",
 	"title": "Handcrafted Steel Gloves",
@@ -9468,11 +9128,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Enim asperiores blanditiis aut ea eum nemo reprehenderit consequatur qui. Voluptate aut aut odio. Eligendi autem ut corrupti nobis rerum aut non est rerum. Et voluptatum dolorem qui et quo esse sit. Blanditiis tempore iure vero ab voluptatum sint reprehenderit. Accusantium est et ut aut fugiat recusandae minus architecto.",
 	"title": "Sleek Frozen Soap",
@@ -9569,11 +9224,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Soluta aliquid neque. Dolorem quia perspiciatis sit sapiente aut quae. Facilis eligendi ut. Aut quod odio ut animi pariatur totam sed odit. Quidem ducimus voluptas.",
 	"title": "Sleek Cotton Cheese",
@@ -9699,11 +9349,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Voluptas esse doloremque reprehenderit dolor possimus libero impedit veritatis. Adipisci ratione sunt dolores sapiente molestias illum. Quo culpa sed voluptatibus sapiente fugiat. Illo dolores perferendis. Omnis ut quidem accusamus. Quibusdam delectus non ut sit.",
 	"title": "Tasty Rubber Pizza",
@@ -9858,11 +9503,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Quod minus ducimus eum numquam. Veritatis praesentium explicabo cumque eligendi expedita exercitationem in qui. Autem dolore repellendus assumenda voluptate vel alias. Quod et neque quas. Et exercitationem quo deleniti amet ab quo. Eius eos ratione rerum quod impedit est vero et ullam.",
 	"title": "Unbranded Steel Hat",
@@ -9988,11 +9628,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Ea autem beatae voluptates quia omnis suscipit velit ut aut. Et vel id repudiandae impedit aut reprehenderit. Est sed saepe reiciendis autem exercitationem non fuga perspiciatis porro.",
 	"title": "Generic Soft Keyboard",
@@ -10147,11 +9782,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Voluptas veritatis ullam. Blanditiis inventore culpa porro occaecati recusandae. Vitae illo eveniet earum dicta sed. Vero excepturi repudiandae ea odio vel odio ducimus. Error perspiciatis recusandae vel iure. Officia et officia sunt quia vel ab.",
 	"title": "Handmade Concrete Mouse",
@@ -10277,11 +9907,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Pariatur odit dolore id assumenda dicta asperiores iste quia consequatur. Commodi officiis ea sit itaque temporibus voluptas suscipit corporis blanditiis. Incidunt odit dolore et. Nihil at hic quisquam id vero et et quia. Quia eaque qui assumenda quos voluptatem debitis ab.",
 	"title": "Incredible Metal Pants",
@@ -10378,11 +10003,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Incidunt qui impedit consequatur. Vero qui sequi cumque et non omnis deserunt. Ut facilis saepe at ea corporis fugiat. Est nobis quo nostrum commodi doloremque commodi dolore rerum id. Quo et ipsam qui dolore velit suscipit id enim voluptatem.",
 	"title": "Handmade Rubber Tuna",
@@ -10508,11 +10128,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Illo asperiores rerum harum iste dolores. Debitis excepturi provident aut eum animi doloribus. Maiores eos nisi facere. Eum ipsam sed voluptate dignissimos hic.",
 	"title": "Licensed Fresh Pants",
@@ -10696,11 +10311,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "A ea quos. Id dolore qui et. Quos consequatur quibusdam.",
 	"title": "Handcrafted Plastic Towels",
@@ -10855,11 +10465,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Eum quis at eligendi dignissimos quos. Ea neque quos laudantium cumque repellat. Qui iste enim eos rerum accusamus ad odit qui. Dolor est laboriosam alias quam est. Et ea sed ea et qui. Et ut rerum sed consequatur eveniet facere ut et.",
 	"title": "Licensed Rubber Chicken",
@@ -11014,11 +10619,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Omnis inventore porro reprehenderit expedita fuga accusantium. Aut adipisci at aut. Culpa eligendi dolores modi vel.",
 	"title": "Handmade Metal Bacon",
@@ -11202,11 +10802,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Ut soluta minus rerum. Veniam et dolores unde et quaerat nulla dolorum repellendus. Velit deserunt consequuntur atque cum dolorem voluptatibus adipisci.",
 	"title": "Handcrafted Frozen Soap",
@@ -11361,11 +10956,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Labore illum reiciendis earum harum distinctio quia. Laboriosam nemo aut eum quia esse natus maiores ut. Ipsa sequi deserunt reprehenderit perferendis quos sed tempore nostrum. Rerum ea beatae ut perspiciatis expedita non dignissimos.",
 	"title": "Refined Concrete Shirt",
@@ -11520,11 +11110,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Voluptas quae et delectus illo qui neque. Illo aperiam sed animi dignissimos soluta mollitia occaecati. Quam quibusdam eos ullam inventore.",
 	"title": "Tasty Rubber Chair",
@@ -11708,11 +11293,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Voluptatibus ratione aut. Occaecati et perspiciatis ut repellat et et omnis. Aut deleniti ut enim quam consequatur. Quidem iste et sed architecto porro. Dolor vitae nobis fugiat. Iure aliquid doloribus facilis nihil doloribus vel eveniet exercitationem numquam.",
 	"title": "Intelligent Fresh Chair",
@@ -11867,11 +11447,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Qui itaque deserunt quia. Ut non incidunt non. Hic tempore saepe perspiciatis maxime numquam et.",
 	"title": "Practical Granite Car",
@@ -11997,11 +11572,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Fugit iusto voluptas. Quas fugit veniam dignissimos. Nisi explicabo velit quia tempora. Qui explicabo maiores. Eos sint sit enim numquam. Dolores et quod ad dolorem.",
 	"title": "Licensed Steel Pizza",
@@ -12156,11 +11726,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Sed quia eos quae ducimus autem. Voluptas odit tenetur ea eligendi. Aut ut exercitationem sit quibusdam esse voluptas non. Facilis neque aut vel beatae distinctio ut vitae nulla. Tenetur iusto laudantium eos consequatur sunt numquam fuga eligendi.",
 	"title": "Practical Cotton Mouse",
@@ -12286,11 +11851,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Sunt maiores nihil est aperiam molestias iusto fugit atque maxime. Non ex provident qui tempore. Dolorem qui odio possimus corporis et sit aliquam. Rem consequatur enim cum in et aut repellat optio.",
 	"title": "Small Fresh Cheese",
@@ -12416,11 +11976,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Explicabo beatae iste rem aspernatur magni sapiente aspernatur est. Molestias ut quidem cum quo sunt quidem corrupti repellat minima. Aspernatur sed autem aut debitis et quis excepturi consectetur. Iusto quas rem eum cupiditate est. Autem blanditiis beatae qui iste possimus quos quo. Eius quibusdam eaque veritatis.",
 	"title": "Incredible Wooden Pizza",
@@ -12575,11 +12130,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Molestiae tempora aperiam esse et dignissimos dolor nulla. Hic suscipit incidunt pariatur nihil iste ut dolorem voluptatem perspiciatis. Repellendus vitae minima velit aut.",
 	"title": "Incredible Rubber Computer",
@@ -12705,11 +12255,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Aut dignissimos a dicta aut eveniet. Dolorum delectus non sit libero sequi. Fugit excepturi sit assumenda. Neque excepturi molestias a temporibus placeat voluptatum harum inventore.",
 	"title": "Generic Frozen Tuna",
@@ -12864,11 +12409,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Id ipsa nihil pariatur ut soluta repellendus repudiandae et magnam. Non neque sequi dicta qui. Ullam et cumque. In rerum sed. Ipsam consequatur veritatis voluptate at facilis eos sit omnis.",
 	"title": "Practical Soft Car",
@@ -13023,11 +12563,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Ipsum eaque ipsam beatae nemo rerum. Quis assumenda impedit repudiandae alias voluptate aut. Odit voluptas minima quae facere fugit ut doloribus odit dolorem. Ea voluptatem assumenda. Repellendus sint recusandae est.",
 	"title": "Incredible Metal Towels",
@@ -13124,11 +12659,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Est vitae qui voluptas quis. Possimus possimus consequatur sint vitae magni qui architecto. Et sequi dolores nulla dolorem non repudiandae accusamus eos. Accusantium nesciunt necessitatibus temporibus et corporis. Quos molestias ab pariatur aliquid culpa.",
 	"title": "Licensed Rubber Pizza",
@@ -13225,11 +12755,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Enim in quisquam. Beatae autem quia qui quam corporis accusamus temporibus qui recusandae. Nihil est nihil consectetur et culpa aut. Neque eos quos quam qui quia sapiente iure. Quia facilis quo ut sed hic.",
 	"title": "Small Concrete Pants",
@@ -13384,11 +12909,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Vel distinctio qui et est quo distinctio fugit fugit. Ipsum praesentium nobis ratione placeat reiciendis laborum repudiandae cupiditate. Numquam eum laudantium enim in error reiciendis mollitia optio. At fuga quae omnis minus sunt. Nemo ut sit ipsam.",
 	"title": "Generic Plastic Shirt",
@@ -13572,11 +13092,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Qui quia nobis aut. Reprehenderit est tenetur iusto nam ut ipsam. Voluptatum rem inventore tenetur voluptas veritatis ex eius. Rem ut dolor excepturi deserunt et rerum et maxime est.",
 	"title": "Incredible Granite Sausages",
@@ -13673,11 +13188,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Asperiores inventore laudantium nobis culpa quibusdam nesciunt est quo. Doloribus aliquid sunt sapiente consequatur culpa maxime deserunt doloremque sunt. Consequatur labore sapiente suscipit rerum velit velit tempore eos maxime.",
 	"title": "Gorgeous Concrete Sausages",
@@ -13774,11 +13284,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Assumenda velit blanditiis dolores cumque possimus sequi non. Ipsa quae adipisci magnam earum ut ab porro nesciunt est. Quisquam accusantium quae velit voluptatem amet magnam ut et. Ut voluptatibus recusandae quidem sed ullam debitis magni. Laudantium occaecati dolorum. Iste ut voluptas atque.",
 	"title": "Fantastic Granite Shirt",
@@ -13933,11 +13438,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Assumenda eos aut voluptas. Aut animi ut aut voluptates. Laudantium ad porro.",
 	"title": "Gorgeous Granite Bike",
@@ -14121,11 +13621,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Qui id aut voluptatibus deserunt cum qui odit repellat. Aperiam ea dolores quisquam quo atque pariatur explicabo aut. Saepe dolor et ullam id dolore qui. Asperiores culpa vero repudiandae. Nisi illo fuga ab molestias distinctio omnis alias illum rem. Sunt error deserunt ut veritatis totam iure.",
 	"title": "Licensed Frozen Towels",
@@ -14309,11 +13804,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Voluptas in at velit aliquid. Voluptates non molestiae temporibus. Sint odit facilis a.",
 	"title": "Small Frozen Bike",
@@ -14497,11 +13987,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Dolores omnis architecto corporis iste mollitia hic. Natus qui illo sequi doloribus et sapiente non perspiciatis. Assumenda similique dolorum dicta vel consequuntur dolor officia dolores. Incidunt molestias atque. Fugit et repellendus molestiae illo laudantium aut dolore reprehenderit.",
 	"title": "Unbranded Plastic Car",
@@ -14656,11 +14141,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Pariatur et assumenda vel sed. Sint dolor quia nesciunt ab suscipit dolores. Quis eum a vel dolorum sed molestiae magnam. Architecto pariatur esse exercitationem aut placeat.",
 	"title": "Tasty Granite Chips",
@@ -14815,11 +14295,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Est id aut porro velit voluptatibus. Facilis et est nesciunt quia necessitatibus dicta adipisci. Vero odio quia omnis et est dolorem et. Expedita voluptatum quis explicabo aut hic molestiae. Praesentium quisquam omnis soluta dolores architecto. Et at ratione incidunt eos sint est odio.",
 	"title": "Unbranded Soft Sausages",
@@ -15003,11 +14478,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Maxime repudiandae beatae quia reiciendis. Nihil consequatur ut nulla sit repellat nostrum quos ducimus. Aut rem aspernatur et ipsa culpa expedita omnis.",
 	"title": "Incredible Frozen Car",
@@ -15133,11 +14603,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Qui est ut sit laborum ad repellendus molestiae eos. Tempora et accusantium assumenda omnis impedit quam quia velit maxime. Beatae et voluptas incidunt. Quis sint aperiam officia earum. Sint debitis dolor hic et repudiandae. Deserunt et natus expedita accusamus atque repellendus ut repellat.",
 	"title": "Intelligent Metal Ball",
@@ -15321,11 +14786,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Impedit assumenda ut voluptas sit ut consequuntur voluptatem quam. Commodi occaecati doloribus illo. Eius dolores sequi enim totam corporis at.",
 	"title": "Licensed Rubber Soap",
@@ -15480,11 +14940,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Itaque nisi aliquid velit ullam reprehenderit qui molestias odit. Animi explicabo blanditiis deleniti sit sequi libero consequatur qui. Quia nesciunt quibusdam possimus corporis aut et dolor tempora amet. Magni hic omnis voluptatem.",
 	"title": "Small Soft Bacon",
@@ -15639,11 +15094,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Veritatis qui facilis dolorum blanditiis voluptatem. Recusandae quam rerum ut exercitationem aperiam tempora excepturi. Officia et ea non vel modi accusantium. Accusantium dolorem non tempore iste quia et voluptates esse. Repellat qui ratione dolorem tempora laudantium aut dolorem. Molestiae facere minus voluptatem est labore voluptate aliquam.",
 	"title": "Ergonomic Rubber Chips",
@@ -15798,11 +15248,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Minus esse sit dolorum. Est aliquid amet omnis est repudiandae similique natus eveniet. Quia est facilis eius ab sit iusto unde. Voluptatem non qui provident deleniti temporibus libero.",
 	"title": "Incredible Concrete Bike",
@@ -15957,11 +15402,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Quidem aut et nisi et est omnis itaque est reprehenderit. Eum perferendis repudiandae magnam aut incidunt quasi rerum. Omnis quia aut illum maiores repellendus suscipit quia. Illo expedita et qui tempora sit. Saepe illum quo dolorum a fuga cum ea.",
 	"title": "Small Frozen Ball",
@@ -16087,11 +15527,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Ullam id inventore provident praesentium fuga esse. Vitae amet molestiae et. Voluptas similique beatae. Est quidem sed rerum unde quo vel.",
 	"title": "Intelligent Metal Chips",
@@ -16188,11 +15623,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Quia ut dolore incidunt alias ipsa. Similique dolor odio eligendi esse et voluptatem. Vel sit voluptate assumenda laborum officia voluptas corporis. Aut hic amet. Fuga sit officiis.",
 	"title": "Incredible Plastic Table",
@@ -16318,11 +15748,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Voluptatibus neque corporis est placeat itaque sed non doloremque facilis. Aliquid laborum id error minus qui ex deleniti labore. Autem nulla et suscipit est cumque. Sequi non nihil suscipit. Deserunt est voluptates et sapiente non odit.",
 	"title": "Intelligent Rubber Mouse",
@@ -16419,11 +15844,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Omnis hic aperiam qui voluptatum. Qui provident consequatur. Voluptatem repudiandae sit dolor.",
 	"title": "Ergonomic Wooden Gloves",
@@ -16549,11 +15969,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Doloribus error distinctio. Ex non voluptate cupiditate ullam eius ad nihil. Velit aut reiciendis sed velit officiis explicabo unde provident. Illum quae assumenda dolore impedit qui veniam architecto architecto.",
 	"title": "Sleek Concrete Shoes",
@@ -16737,11 +16152,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "In voluptas iste minima. Eos autem illo a aut. Doloribus eos accusantium distinctio possimus vel deserunt. Sapiente iusto inventore.",
 	"title": "Intelligent Wooden Keyboard",
@@ -16867,11 +16277,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Repellat quo ut iusto quia est aut consequatur sint aut. In ipsa nam possimus et sit aut voluptas molestiae illo. Ut ea at numquam reprehenderit reiciendis eum corporis.",
 	"title": "Handmade Plastic Chair",
@@ -17055,11 +16460,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Optio quasi quos expedita accusantium tempore minima. Animi non voluptatem velit repudiandae necessitatibus. Blanditiis velit quasi sed modi accusantium dolor blanditiis sapiente porro. Omnis quasi ipsam blanditiis eum.",
 	"title": "Gorgeous Frozen Towels",
@@ -17185,11 +16585,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Eos qui et sunt ea nobis tempore dolorem qui unde. Iure atque reiciendis nobis tempore illo illo. Et at ut quas cupiditate ut. Laborum necessitatibus nihil ut et hic cumque ea sunt. Illo ut provident qui dignissimos.",
 	"title": "Handcrafted Frozen Pizza",
@@ -17315,11 +16710,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Numquam voluptatum porro doloribus voluptatum blanditiis amet quos laboriosam quidem. Consequatur ab esse dolorem ut nemo quas. Porro est impedit cupiditate ut. Inventore ad nisi et atque debitis necessitatibus sit.",
 	"title": "Handmade Frozen Chicken",
@@ -17445,11 +16835,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Ea vel repudiandae maiores architecto labore totam. Perferendis non ut ut et rem non eligendi maiores. Consequatur unde beatae et ut. Et dolore et amet non dolorem eveniet eaque. Et nesciunt eveniet veniam et totam.",
 	"title": "Gorgeous Granite Chair",
@@ -17604,11 +16989,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Sapiente nesciunt placeat odio non quibusdam laborum sed velit id. Blanditiis magnam quia. Earum officiis qui quis cumque ducimus earum excepturi ea explicabo.",
 	"title": "Licensed Steel Gloves",
@@ -17734,11 +17114,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Qui distinctio reprehenderit nulla quae aut quaerat ex vero. Eos aut enim iusto rem quo amet impedit. Saepe culpa non quia quia laboriosam officiis tempore a ut. Minus modi amet dolores. Ea ducimus et et. Et hic facere veritatis error eveniet praesentium quam iusto ipsum.",
 	"title": "Refined Metal Keyboard",
@@ -17835,11 +17210,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Nisi hic in eum eos maxime veritatis. Voluptas adipisci qui eum quae voluptatem ut possimus quas et. Consequuntur beatae iure alias facilis quo libero sit et. Porro quis aut porro nesciunt consequatur.",
 	"title": "Incredible Plastic Tuna",
@@ -18023,11 +17393,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Consequatur dolor nihil. Sunt omnis quam ipsa facere voluptas. Mollitia perspiciatis maxime aspernatur. Distinctio ut ut sint molestiae dolorum recusandae voluptatem ut.",
 	"title": "Fantastic Frozen Computer",
@@ -18182,11 +17547,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Dolorum et quia. Sint dolore et commodi voluptatem. Molestiae enim impedit quis dolorem asperiores veritatis aut.",
 	"title": "Ergonomic Plastic Shoes",
@@ -18312,11 +17672,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Assumenda odio sit. Delectus cumque cumque modi eos fugit ut. Perspiciatis qui quas perspiciatis ut ea provident eaque.",
 	"title": "Unbranded Frozen Sausages",
@@ -18471,11 +17826,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Quia temporibus aliquid possimus sit suscipit quia voluptate fugit ea. Voluptate velit quo atque quos ea cumque. Dicta eum molestiae vero sed consequatur suscipit saepe dignissimos omnis.",
 	"title": "Incredible Granite Tuna",
@@ -18659,11 +18009,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Soluta enim alias eos eum maxime est dolore. Sunt velit eum reiciendis magnam numquam itaque. Et aspernatur repellendus nesciunt earum quas esse eligendi. Id occaecati qui corrupti iste temporibus consectetur inventore. Ut maxime repellat et est neque voluptatum. Eos totam autem et consectetur deserunt laudantium.",
 	"title": "Generic Steel Salad",
@@ -18760,11 +18105,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Magnam qui nobis hic neque nihil velit non totam incidunt. Voluptates quod quam perferendis at facilis cum. Consequatur nobis amet id at. Est cumque omnis necessitatibus adipisci natus numquam similique. Nihil molestiae rerum molestiae veniam dolorem est nulla autem voluptas. Occaecati voluptatibus nemo deleniti accusantium nam neque ex quibusdam.",
 	"title": "Incredible Soft Hat",
@@ -18890,11 +18230,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Quo aspernatur placeat esse perferendis beatae eveniet omnis. Quia eos voluptatum ipsam sed sint. Voluptas nulla dolore. Saepe culpa qui qui pariatur laudantium maiores ducimus. Aliquam tempore maxime ab rerum. Necessitatibus id laboriosam delectus aut a ab eaque inventore sit.",
 	"title": "Gorgeous Concrete Pizza",
@@ -19078,11 +18413,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Aliquid in cumque ab dolorem suscipit perspiciatis dolores. Nihil vitae consequatur eum optio quo. Fugit rerum consequatur quo et corporis est. Est et enim consequatur tenetur rem natus. Dolore et cum rerum molestiae.",
 	"title": "Gorgeous Wooden Bacon",
@@ -19208,11 +18538,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Vel illo rerum aut tempore sequi molestiae repellat eaque ut. Minima asperiores et ullam qui. Laborum voluptatem dolore nostrum qui. Molestiae reiciendis ea est aut ipsum repudiandae. Et et iusto. Ut minus quasi facilis at sit accusamus harum.",
 	"title": "Tasty Steel Fish",
@@ -19367,11 +18692,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Rerum asperiores fuga a cumque. Vel et nemo voluptatem natus ut. Atque magni quo cum dolores officiis sunt eum soluta unde. Aliquam voluptatem voluptate dolores repellat. Odio fugiat iste et eum deleniti et nobis itaque. Placeat maxime fuga.",
 	"title": "Practical Fresh Towels",
@@ -19468,11 +18788,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Impedit et pariatur maxime magni mollitia quis sapiente ad voluptatem. Adipisci error sit sint nesciunt velit omnis quis amet sint. Repellat sit qui in tempora. Incidunt architecto incidunt.",
 	"title": "Handmade Steel Car",
@@ -19627,11 +18942,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Quasi quos qui facilis cum dolorum architecto laboriosam ea. Ex voluptates architecto ad nobis voluptas at autem et. Quibusdam officia rem exercitationem totam. Impedit quibusdam nihil laudantium nihil ut est aut facilis. Assumenda similique eius incidunt molestiae non. Ut eos repudiandae ut aut.",
 	"title": "Sleek Concrete Mouse",
@@ -19757,11 +19067,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Aspernatur adipisci quia eius commodi id amet blanditiis. Ea architecto placeat possimus aut blanditiis hic architecto. Aut iure ut.",
 	"title": "Rustic Granite Shoes",
@@ -19887,11 +19192,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Voluptatibus impedit tenetur quo. Distinctio quis similique. Eligendi consectetur suscipit magnam molestiae voluptatum corrupti sed voluptatem. Minima nostrum et.",
 	"title": "Licensed Concrete Bike",
@@ -19988,11 +19288,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Possimus et omnis nihil ut voluptate ducimus iste tempore excepturi. Praesentium aut deserunt. Occaecati recusandae aut dolores corporis aut impedit. Dolorem aut possimus.",
 	"title": "Tasty Wooden Tuna",
@@ -20118,11 +19413,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Accusantium dolorem enim omnis tempore minima id atque consequatur sit. Et neque aut sed voluptatem fugit. Nihil rem sit accusantium.",
 	"title": "Licensed Granite Shoes",
@@ -20277,11 +19567,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Omnis sint autem ea accusamus impedit. Fuga sed et nam repudiandae voluptatum. Impedit sint repellat id nemo soluta vel incidunt. Molestiae dolor ipsam nostrum nulla voluptatem. Cumque cum sit qui officiis placeat recusandae deserunt in ducimus. Eaque fuga porro unde et amet rem et dicta.",
 	"title": "Licensed Wooden Soap",
@@ -20465,11 +19750,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Dicta fuga soluta quasi ipsum reiciendis. Assumenda et deleniti consequuntur et porro cum et rerum in. Quam eius dolor.",
 	"title": "Incredible Metal Bacon",
@@ -20595,11 +19875,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Aut vero doloremque quibusdam cumque repellendus. Voluptatibus ea ut quia rerum blanditiis eos natus ullam pariatur. Eaque aut id quis occaecati. Dolorum aut provident rerum.",
 	"title": "Unbranded Steel Keyboard",
@@ -20725,11 +20000,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Sed reprehenderit dolor voluptate impedit natus. Voluptatem rerum placeat. Ut quos repellendus sint numquam sed ut impedit non. Est inventore quos.",
 	"title": "Incredible Fresh Ball",
@@ -20884,11 +20154,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Quis perspiciatis delectus sed corporis rerum. Sunt ut molestiae dolorum est facere id sapiente eius reprehenderit. Inventore distinctio blanditiis magnam molestias ut enim veniam similique. Aperiam in hic ad dolor architecto nostrum molestiae omnis.",
 	"title": "Awesome Steel Towels",
@@ -21014,11 +20279,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Ea eum ut deserunt omnis sint quia perferendis. Fugit aut quasi quas dolorem quod. Aut et doloribus voluptas illum incidunt et. Eveniet culpa modi et laborum omnis animi error commodi.",
 	"title": "Small Wooden Keyboard",
@@ -21202,11 +20462,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Libero aut et dolor. Sit quibusdam unde esse dolor dolorem necessitatibus quod. Deserunt totam fugiat labore aut amet omnis non. Quisquam omnis rerum placeat. Iure molestiae explicabo doloremque delectus.",
 	"title": "Sleek Fresh Sausages",
@@ -21390,11 +20645,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Eveniet sapiente atque aut totam saepe quam eius error a. Deleniti eius necessitatibus. Adipisci optio fugit fuga accusamus eos aut dolorum.",
 	"title": "Rustic Fresh Chair",
@@ -21520,11 +20770,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Quia veniam temporibus ducimus quis eveniet nulla ipsum ut quas. Pariatur distinctio itaque ut tenetur. Vel esse ipsa cumque quo cum repudiandae sunt cupiditate.",
 	"title": "Licensed Wooden Soap",
@@ -21621,11 +20866,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Sit numquam fugit sit voluptatum quia. Quia nisi et autem tenetur. Est commodi veritatis ipsam ut animi. Non suscipit occaecati fugiat consequatur. Fuga repellendus tenetur nihil perspiciatis nihil laborum consequatur quam aperiam.",
 	"title": "Tasty Cotton Towels",
@@ -21780,11 +21020,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Et quia et. Sunt provident vel illum quidem quidem sit id ad eum. Magni dolor dolore et quisquam occaecati sint similique. Id illo corporis. Officiis et ratione. Rerum mollitia labore earum.",
 	"title": "Unbranded Soft Chips",
@@ -21910,11 +21145,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Ut beatae temporibus et quisquam eligendi quaerat. At quia repellat iure sunt animi eaque. Recusandae non accusamus eum autem eveniet pariatur. Eum minima non iusto. Eos in reprehenderit facere impedit.",
 	"title": "Handmade Fresh Fish",
@@ -22098,11 +21328,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Vel aut dolor voluptatem perferendis. Et praesentium quo officiis et quas beatae. Sint et labore quia esse. Non consequatur nostrum rerum mollitia sint.",
 	"title": "Rustic Frozen Chips",
@@ -22199,11 +21424,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Quia odio dolorem non velit nihil similique amet. At aut quis molestiae molestias voluptas provident dolores non. Provident exercitationem nam et molestias veritatis quasi qui. Veritatis veritatis adipisci enim sed.",
 	"title": "Gorgeous Cotton Bacon",
@@ -22358,11 +21578,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Reiciendis sed omnis veritatis et voluptas quia corrupti aut. Aperiam saepe qui minima aut qui illum consequatur earum. Hic neque totam vel. Incidunt enim est rerum sequi. Sint qui atque qui rem sit aperiam voluptatem quo eius.",
 	"title": "Handmade Plastic Ball",
@@ -22517,11 +21732,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Error deserunt et eos. Tempora quo voluptates sed voluptates eum maiores sint illo aspernatur. Maxime sint et id est sapiente. Ipsam dolor est sed rerum asperiores consequatur placeat mollitia omnis.",
 	"title": "Small Plastic Chicken",
@@ -22618,11 +21828,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Quia voluptatem perferendis omnis incidunt. Quia voluptatem soluta sint ut enim. Id placeat deleniti est. Laborum quod sed asperiores. Ipsa ad aut numquam voluptatem dignissimos quia.",
 	"title": "Licensed Concrete Tuna",
@@ -22777,11 +21982,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Placeat dolorem hic porro laborum sit sint. Vel modi vel dolorum ut libero voluptatem. Et nostrum veniam. Assumenda eum aut necessitatibus earum dicta fugit.",
 	"title": "Incredible Wooden Fish",
@@ -22907,11 +22107,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Praesentium explicabo rerum. Impedit dolor rerum et voluptas pariatur voluptatem quisquam. Voluptatum corporis et.",
 	"title": "Generic Rubber Tuna",
@@ -23008,11 +22203,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Qui ut fuga ducimus aperiam repellat unde accusantium voluptas aliquid. Odio distinctio modi voluptatum qui voluptatem voluptates. Quo culpa perspiciatis quis. Dicta aut tempore aspernatur voluptatum omnis nam officiis. Mollitia est dolorem incidunt eius magnam.",
 	"title": "Incredible Steel Bacon",
@@ -23167,11 +22357,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Voluptas minus dolore eveniet cupiditate ratione. Rerum impedit eius mollitia dicta beatae. Rem laudantium cumque dolor. Doloribus nemo omnis. Voluptatibus et odit non delectus nihil repellat animi consectetur.",
 	"title": "Fantastic Rubber Bike",
@@ -23268,11 +22453,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Quibusdam harum aspernatur. Aut ipsa pariatur quod et consequatur minus totam exercitationem. Nihil unde minus rem dolorem. Dolore alias ab et minima sed voluptatibus veritatis. Minus vel in provident eos harum et minus.",
 	"title": "Intelligent Fresh Soap",
@@ -23369,11 +22549,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Voluptatibus hic incidunt. Nobis vel est id totam rerum amet dignissimos. Aut facilis et necessitatibus eius voluptatem qui eos enim. Ullam vel sed et.",
 	"title": "Rustic Plastic Fish",
@@ -23557,11 +22732,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Aliquid quia necessitatibus architecto. Et animi nobis veritatis inventore corrupti accusamus. Quia et ipsum. Omnis et soluta. Quam eum itaque porro. Ab dolorem in.",
 	"title": "Tasty Steel Sausages",
@@ -23687,11 +22857,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Sunt enim veniam quisquam aut blanditiis nihil in neque. Doloribus ullam eum est sequi. Ea ad dolor cupiditate et ut tempore quisquam.",
 	"title": "Sleek Cotton Fish",
@@ -23788,11 +22953,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Veniam et inventore tempora occaecati debitis debitis consequatur architecto. Voluptate aut sunt qui et. Corporis totam dignissimos voluptate fuga at et. Dolore qui aliquid alias. Facere provident et unde soluta harum autem.",
 	"title": "Gorgeous Steel Pants",
@@ -23947,11 +23107,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Sequi corrupti nobis quos deserunt eligendi omnis. Qui similique qui ducimus. Optio ullam aut nesciunt. Incidunt corporis quo. Ipsam quasi iure qui omnis et eveniet rerum exercitationem. Et est facilis.",
 	"title": "Awesome Rubber Computer",
@@ -24135,11 +23290,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Totam ut quo sint et voluptatem rem quos. Laboriosam quis nemo ut enim autem facilis aut. Unde libero cupiditate et aut praesentium id voluptas aut. Facilis perferendis culpa temporibus. Magnam sunt ad.",
 	"title": "Fantastic Fresh Fish",
@@ -24265,11 +23415,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Ea exercitationem consequuntur accusamus laborum incidunt quia enim. Rem quia eos pariatur corporis omnis. Consequatur omnis beatae aspernatur sunt.",
 	"title": "Practical Wooden Chips",
@@ -24424,11 +23569,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Amet temporibus eaque ut alias ut adipisci. Voluptates sit libero quo praesentium unde odio. Quas praesentium pariatur est animi illum quis aut sint aut. Quae laboriosam minus non et. Totam rerum delectus voluptatem repellendus aperiam quia a a sit. Nihil qui sed ipsum fugit dolorem ea tempora dolorem voluptatem.",
 	"title": "Tasty Plastic Fish",
@@ -24583,11 +23723,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Commodi aut odio earum eligendi odit iste. Voluptas molestiae sit suscipit eum aut sit sint. Et sit amet sit adipisci delectus eum. Perspiciatis omnis aut voluptatem reprehenderit accusamus totam neque dolore magnam. Omnis magni sit eius animi ex magnam unde.",
 	"title": "Licensed Granite Shirt",
@@ -24742,11 +23877,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Vitae est nulla asperiores consectetur sint. Ipsum quibusdam saepe ea eum totam nesciunt possimus velit accusantium. Praesentium ipsum quos voluptatem consequatur et qui ducimus. Fugit sed tenetur consequuntur dolor facere voluptatem deserunt delectus. Enim beatae et est illo atque.",
 	"title": "Refined Plastic Keyboard",
@@ -24930,11 +24060,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Reiciendis fugit rerum. Cumque ut et. Sed ut tempore aut dolores fugit aut dolores praesentium. Quibusdam error sit. Voluptas sunt id velit explicabo sit est sed possimus.",
 	"title": "Handmade Metal Pizza",
@@ -25089,11 +24214,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Nesciunt eaque eos. Occaecati aut quia qui. Laboriosam dolores facilis et.",
 	"title": "Practical Cotton Computer",
@@ -25277,11 +24397,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Dicta quas corporis rerum. Veritatis numquam alias dolores ut assumenda minima. Harum animi similique ipsam quia dolor quod nostrum. Et possimus placeat corporis. Labore iusto accusantium sint et beatae eaque. Quidem eum delectus et.",
 	"title": "Sleek Soft Computer",
@@ -25465,11 +24580,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Doloribus ullam autem quaerat ut dolores aspernatur. Exercitationem aut voluptas quis nostrum est aliquam dicta vitae. Et dolores voluptatem ipsum repellendus saepe asperiores non. Accusamus eum quo perspiciatis saepe. Consequuntur sequi et aliquid.",
 	"title": "Tasty Soft Cheese",
@@ -25566,11 +24676,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Incidunt nisi quaerat illum. Facere qui commodi nihil consequatur inventore quis. Atque fugiat consequatur omnis consequatur quia natus vitae magni.",
 	"title": "Practical Concrete Pants",
@@ -25754,11 +24859,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Maiores et unde sed reiciendis odit. Officiis qui maxime a. Suscipit optio voluptatem impedit ducimus mollitia expedita aut ea veniam. Inventore ut eos et inventore quasi et et.",
 	"title": "Unbranded Soft Cheese",
@@ -25855,11 +24955,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Ratione ullam itaque quam sit. Illum ex minima. Quam est libero sit magnam autem. Beatae eos sunt consectetur et cum. Perferendis aut necessitatibus aut enim expedita et illo dolor. Odio minus et id iusto sunt optio quasi.",
 	"title": "Refined Wooden Mouse",
@@ -26043,11 +25138,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Dolor cum repellat. Harum neque eaque nesciunt sint corporis beatae eveniet provident reprehenderit. Qui aspernatur corporis nulla quia ducimus est rem. Atque autem consequatur labore et dolor enim. Quis nesciunt nobis iure ex consequatur qui sit enim. Voluptate iusto sit ullam nulla odit.",
 	"title": "Unbranded Frozen Chair",
@@ -26231,11 +25321,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "At recusandae sapiente sed. Similique possimus distinctio dolorum facere. Aut maxime perspiciatis et quas illo omnis reprehenderit voluptatum.",
 	"title": "Rustic Wooden Chair",
@@ -26361,11 +25446,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Quibusdam sint voluptas pariatur maxime sit ipsum. Blanditiis qui at minus aperiam sapiente et. Eaque quia temporibus beatae.",
 	"title": "Gorgeous Granite Shirt",
@@ -26549,11 +25629,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Ut officia molestiae reprehenderit aliquid possimus consequatur similique vitae fugiat. Unde neque facilis quidem aut. Saepe vitae pariatur minus velit quia.",
 	"title": "Unbranded Soft Ball",
@@ -26679,11 +25754,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Saepe earum omnis laborum soluta quaerat dolores et. Ut consequatur temporibus quo ipsam ut praesentium quidem. Nesciunt ab alias voluptatum aut enim repudiandae aut suscipit sed. Ducimus enim sed aut aut.",
 	"title": "Awesome Steel Hat",
@@ -26867,11 +25937,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Ullam ut impedit quod quia odit. Magnam debitis aut corrupti dignissimos laboriosam. Et suscipit totam.",
 	"title": "Sleek Wooden Chicken",
@@ -26968,11 +26033,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Labore neque dolores quas tempore dolor officia. Rerum natus vel et tempore blanditiis aliquid animi. Non laboriosam unde. Voluptatem consequatur fugiat ut nostrum dignissimos.",
 	"title": "Generic Granite Pizza",
@@ -27127,11 +26187,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Est esse cupiditate hic illum quia facilis neque. Consequuntur est enim. Maiores omnis excepturi repellendus nihil et cum vero velit.",
 	"title": "Fantastic Plastic Towels",
@@ -27286,11 +26341,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Totam blanditiis quae alias cupiditate tenetur omnis hic. Non architecto porro. Quia quas et aut ut facere assumenda. Quod voluptatibus iste quo.",
 	"title": "Fantastic Soft Car",
@@ -27474,11 +26524,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Molestiae eos eos corrupti sint saepe. Dolorem aut nostrum repudiandae dolor impedit qui et officiis provident. Amet dicta sed non unde. Porro dolores vitae et quia. Voluptas et quia dolor expedita adipisci dolore unde.",
 	"title": "Ergonomic Fresh Ball",
@@ -27575,11 +26620,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Voluptatem assumenda dignissimos cum fugit deleniti. Eos ipsam minima. Debitis temporibus assumenda facere nemo odio molestiae sit. Illum praesentium sunt aliquid illo blanditiis ad in nostrum molestiae.",
 	"title": "Sleek Metal Pizza",
@@ -27705,11 +26745,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Optio eaque ab quod ea doloremque eos ex. Saepe non voluptatem enim voluptas facilis. Quo incidunt dolores ut perspiciatis quo fuga. Ipsa atque sunt eveniet magnam sequi quas vel. Facere voluptatem mollitia molestias sequi maiores sed aperiam fugiat praesentium.",
 	"title": "Gorgeous Metal Fish",
@@ -27806,11 +26841,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Voluptas aut iure fuga voluptate numquam aut. Vel deleniti aliquam. Cupiditate officia maxime libero culpa eum. Reiciendis ad quaerat accusantium. Et magnam enim nobis distinctio fuga nesciunt. Molestiae quisquam ratione debitis impedit iusto fuga veritatis.",
 	"title": "Small Frozen Bacon",
@@ -27936,11 +26966,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Sed voluptas a ipsam unde assumenda. Voluptatem voluptatem enim in nihil. Sequi quia consequatur. Voluptate ipsam eaque aliquam et sunt et.",
 	"title": "Rustic Wooden Ball",
@@ -28124,11 +27149,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Quod sunt provident ut ut. Officiis enim id enim fugiat aut libero. Eos ut quibusdam nobis qui sunt vero. Quam eos quis delectus earum pariatur quis fugiat rerum. Illo beatae numquam maiores in voluptas libero exercitationem non. Consequatur animi quaerat et molestias.",
 	"title": "Sleek Plastic Chicken",
@@ -28225,11 +27245,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Sunt consequatur odit. Odit ipsum ipsum repellat aspernatur est. Ullam amet magni ipsa sunt est quia. Nam rerum quo recusandae voluptatem quibusdam et ipsa ab nesciunt. Unde sed quam optio voluptatibus laboriosam sed placeat esse nostrum.",
 	"title": "Handcrafted Fresh Shirt",
@@ -28413,11 +27428,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "In vitae est excepturi ipsum et sequi accusamus. Veritatis officiis commodi. Illo id perferendis odio eius accusantium. Nulla et nostrum assumenda velit debitis molestiae eligendi quia.",
 	"title": "Ergonomic Plastic Fish",
@@ -28601,11 +27611,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Illo aut dolor earum. Sit non et deserunt. Saepe harum qui ratione voluptatum et eius repudiandae rerum cumque. Provident velit soluta mollitia rerum. Perspiciatis corporis sit veritatis minima architecto magni maxime.",
 	"title": "Fantastic Steel Ball",
@@ -28702,11 +27707,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Natus enim repudiandae animi beatae dolorem. Voluptatum adipisci perferendis ut numquam voluptatum qui. Eveniet mollitia vel aut. Maxime hic occaecati. Est perferendis earum veritatis velit.",
 	"title": "Handcrafted Soft Bike",
@@ -28861,11 +27861,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Ut voluptatibus dolorem quia et fugiat sit similique aut. Modi illo voluptate sapiente id omnis enim est. Deserunt reprehenderit ea.",
 	"title": "Licensed Cotton Ball",
@@ -28991,11 +27986,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Nam voluptas facilis est unde ut deleniti aliquam tenetur. Fugit quia vero assumenda aliquid eos aspernatur nam. Repellendus consectetur vitae nihil ratione dolore officia. Occaecati ea nobis asperiores laboriosam laboriosam quia. Cupiditate explicabo dicta officiis adipisci aut ea nam est.",
 	"title": "Fantastic Metal Sausages",
@@ -29121,11 +28111,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Expedita quae reprehenderit suscipit minima porro exercitationem. Non sed eaque repellendus praesentium voluptas et et sed. Culpa eos modi similique et quia enim. Beatae quidem cupiditate amet mollitia.",
 	"title": "Tasty Metal Chips",
@@ -29280,11 +28265,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Nulla numquam et ut blanditiis. Ut nostrum nihil facere veritatis qui numquam. Vel quo saepe iste tenetur tenetur est consequatur est. Iusto quaerat qui. Modi voluptatibus incidunt qui minima quaerat quas. Quaerat necessitatibus alias nulla optio nulla.",
 	"title": "Unbranded Rubber Keyboard",
@@ -29468,11 +28448,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Ipsa pariatur nemo at vel consequatur cumque quo fuga. Beatae quibusdam voluptatum et et maxime consequatur. Tenetur veniam dolor laudantium vel architecto ducimus.",
 	"title": "Incredible Wooden Chair",
@@ -29598,11 +28573,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Nostrum quisquam explicabo aut voluptates odio. Dolores commodi quisquam vitae et. Dolore atque magni nisi sint omnis.",
 	"title": "Fantastic Rubber Shirt",
@@ -29757,11 +28727,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Perferendis possimus et minus nostrum. Recusandae sed voluptas sed ab odio. Consequuntur vitae est dolore consectetur officiis sed voluptatem.",
 	"title": "Fantastic Cotton Pants",
@@ -29916,11 +28881,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Quam rerum est quidem quas sunt eos temporibus explicabo. Id qui consectetur quia est eaque omnis voluptatem quos voluptas. Odit sit numquam. Qui debitis ea ducimus quaerat occaecati voluptatem cumque adipisci. Velit autem tempora molestiae nisi quidem. Omnis quam quisquam praesentium aut quo quibusdam aliquid ut.",
 	"title": "Generic Plastic Gloves",
@@ -30075,11 +29035,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Itaque quis sunt nemo voluptatem ducimus quia omnis. Aliquid ducimus sunt accusantium dolorem. Necessitatibus sequi libero laboriosam consequatur. Dolores error voluptatem qui minima aut exercitationem et fuga.",
 	"title": "Licensed Wooden Table",
@@ -30263,11 +29218,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Voluptas aut aut officiis earum alias consequuntur nemo. Deserunt sed aspernatur rerum exercitationem ad. Incidunt eveniet nihil in nam quaerat vel suscipit.",
 	"title": "Refined Soft Towels",
@@ -30393,11 +29343,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Consequatur ea ipsa laudantium ab id nulla. Esse id culpa maxime ullam delectus qui consequuntur. Odit nam modi rerum quia.",
 	"title": "Awesome Fresh Cheese",
@@ -30523,11 +29468,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Optio est eum inventore cupiditate deserunt. Sit perspiciatis ab et ea. Est reprehenderit iusto provident eum quia quisquam enim consequatur. Vel accusamus ducimus. Qui rem dolores sunt vel doloribus.",
 	"title": "Handcrafted Steel Soap",
@@ -30653,11 +29593,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Illum vitae rerum alias qui repellat praesentium. Voluptatibus ut sed fugiat quis voluptates enim. Aspernatur et voluptate voluptatem mollitia quos. Et ullam quia reprehenderit neque qui est voluptatem qui. Quo consequuntur qui molestiae velit corrupti.",
 	"title": "Rustic Granite Car",
@@ -30812,11 +29747,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Similique ut qui hic et. Vel quae possimus eum. Sunt sint quasi neque.",
 	"title": "Rustic Wooden Chair",
@@ -30913,11 +29843,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Qui magni tempora esse placeat. Sed exercitationem voluptas aperiam dolorem ut enim ut ea exercitationem. Aut veritatis enim eos voluptates dolores commodi explicabo cum nobis. Ut ullam velit enim itaque ullam perspiciatis quisquam.",
 	"title": "Handmade Cotton Bike",
@@ -31101,11 +30026,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Dicta nostrum optio. Ducimus animi vero aliquid rerum vero amet qui ratione ducimus. Veniam magni quo ex aut quia. Excepturi suscipit ullam perferendis. Et ut rem neque repudiandae dolore dolore quia veniam. Ad aliquid voluptas cum nobis omnis.",
 	"title": "Generic Frozen Pizza",
@@ -31231,11 +30151,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Dignissimos veritatis fuga velit distinctio magni nisi quo. Dolorem amet ipsam eos deserunt sapiente architecto enim dicta cumque. Fugit neque distinctio et ut quo. Est quibusdam tempore ea hic delectus officiis laudantium incidunt.",
 	"title": "Practical Frozen Chair",
@@ -31361,11 +30276,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Et libero nobis sit ut dolor perspiciatis. Ipsam quod magni molestias sit qui molestiae enim illo aut. Qui consequatur repellendus ea. Recusandae non inventore quaerat et iusto. Quod dolor atque. Laudantium quo et.",
 	"title": "Incredible Wooden Fish",
@@ -31549,11 +30459,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Saepe a quae explicabo quas ipsam laudantium vel nesciunt. Et voluptate et odio dolores iure deleniti repudiandae officia dolorem. Quisquam est at dolor odit voluptatem. Rerum necessitatibus quia et quibusdam impedit voluptas velit. Occaecati laborum consequatur similique quam.",
 	"title": "Generic Plastic Gloves",
@@ -31708,11 +30613,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Ut vel sed. Ea delectus voluptates. Autem iusto rerum doloremque. Et impedit et consequatur. Voluptas fuga accusantium incidunt id at. Aut officia deserunt accusantium qui voluptates dignissimos.",
 	"title": "Ergonomic Concrete Keyboard",
@@ -31867,11 +30767,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Eos odio dolores sint sit non quo cum tempore et. Voluptatum error delectus est in. Consequuntur maiores voluptatum vel aliquid est dolores. Eos vero voluptas officia et eveniet reiciendis sit odit. Rerum quia non mollitia quos ipsa dolorem non nam maiores. Sint dolor molestias alias occaecati illo.",
 	"title": "Rustic Frozen Chair",
@@ -31968,11 +30863,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Ut sunt veritatis voluptas. Sit et odio et distinctio. Ad fugiat ipsum culpa adipisci.",
 	"title": "Small Plastic Gloves",
@@ -32156,11 +31046,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Cupiditate atque pariatur error nihil quos iusto aperiam eos minus. Cumque dolores perspiciatis. Cumque ab ut hic quidem enim aspernatur incidunt tempora. Beatae inventore quia ipsum ipsum et. Animi esse pariatur rerum eveniet aut inventore incidunt. Et vitae exercitationem temporibus incidunt.",
 	"title": "Awesome Cotton Pants",
@@ -32286,11 +31171,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Pariatur minus ducimus iure esse rerum consequuntur blanditiis ut. Vitae vitae sit modi porro autem non corporis consequatur quisquam. Dolores quaerat animi doloribus dolore.",
 	"title": "Handmade Granite Towels",
@@ -32387,11 +31267,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Et et voluptate ratione ullam dolores laboriosam officia cupiditate. Quia voluptatibus omnis vitae iure vel ad nam ratione autem. Accusamus sed sit perferendis accusamus et. Voluptatem unde cupiditate doloribus. Porro aut cumque unde cupiditate quas modi deleniti cumque rerum. Molestias enim deleniti molestias.",
 	"title": "Handcrafted Wooden Salad",
@@ -32488,11 +31363,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Vel iusto maiores officiis rerum eum distinctio ex. Qui commodi voluptatem neque. Nulla ipsam libero. Quis dolore est voluptatem tempore aliquid voluptatem nulla pariatur.",
 	"title": "Tasty Cotton Salad",
@@ -32676,11 +31546,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Id rerum natus commodi sequi quos et error accusamus. Ut quasi mollitia sunt voluptatem. Deserunt enim voluptas sit fugit. Nemo voluptatem aliquam repellat recusandae molestiae accusamus ut doloremque. Fuga enim velit.",
 	"title": "Sleek Concrete Bike",
@@ -32806,11 +31671,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Illum soluta tempora magni nulla quas. Magni et earum aut molestiae delectus eius velit. Sit nostrum at in maxime non nobis rerum. Sapiente reiciendis molestias blanditiis error aut et beatae laudantium.",
 	"title": "Unbranded Frozen Ball",
@@ -32965,11 +31825,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Non aut sit. Voluptatem cum perspiciatis. Enim ea quod.",
 	"title": "Small Cotton Pizza",
@@ -33066,11 +31921,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Tempora consequatur sapiente blanditiis totam. Nam ab delectus dolores sit at. Fugit deserunt est rerum. Rerum optio occaecati non.",
 	"title": "Licensed Metal Chips",
@@ -33225,11 +32075,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Optio dolor cum sequi itaque modi quia architecto eos. Rerum alias pariatur tempora consequatur repellat maxime laboriosam quidem voluptatem. Nostrum aut in voluptate vitae et illum. Exercitationem totam perferendis cumque ipsam tempora eligendi omnis ipsa. Mollitia quis explicabo occaecati.",
 	"title": "Sleek Rubber Cheese",
@@ -33413,11 +32258,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Aut magni est. Consequatur sed in totam magnam alias quibusdam ex vel numquam. Voluptatibus et dolorem error et. Hic et quae ea nihil enim omnis nemo officiis. Amet officia sit. Unde molestiae facilis sint est cupiditate dicta iure.",
 	"title": "Practical Concrete Sausages",
@@ -33601,11 +32441,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Vel occaecati corporis consectetur harum laborum fugit vel. Dolores praesentium ipsum. Fugiat pariatur ducimus ut debitis autem id qui aut. Culpa nihil qui quo delectus ipsa consequatur ea cum in.",
 	"title": "Refined Frozen Mouse",
@@ -33789,11 +32624,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Nihil quia assumenda ad possimus ut similique placeat. Velit in quo. Quisquam corrupti non perferendis. Nostrum qui suscipit delectus quidem.",
 	"title": "Rustic Granite Car",
@@ -33948,11 +32778,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Dolorem quasi omnis laudantium necessitatibus. Voluptatem aut aut aliquid dolores sit commodi numquam enim natus. Praesentium iste quam. Earum qui blanditiis dicta magnam sit quaerat ad. Est quia blanditiis et voluptas vero. Nemo odit voluptatum provident voluptate voluptatem et.",
 	"title": "Licensed Fresh Chicken",
@@ -34078,11 +32903,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Reiciendis soluta est magnam recusandae dolore iusto necessitatibus molestiae ut. Sapiente aperiam dicta quibusdam magnam aut. Nemo saepe cum. Libero aut tempora iste enim tempora dolor. Cumque voluptatibus tempore aut repellat est nihil.",
 	"title": "Tasty Fresh Hat",
@@ -34179,11 +32999,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Id dolore quisquam repellat amet sapiente repellat. Praesentium totam eum aut. Nesciunt consequatur voluptates sint. Autem qui nihil unde aut nisi. Numquam quos sint dignissimos. Aspernatur laudantium corrupti.",
 	"title": "Handcrafted Fresh Bacon",
@@ -34280,11 +33095,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Omnis asperiores quia nobis amet voluptatem sed. Ab quas est maiores. Non est repudiandae tempore et iste architecto est aut sed.",
 	"title": "Sleek Rubber Tuna",
@@ -34410,11 +33220,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Minus est occaecati dolorem officia nesciunt iste doloribus neque quia. Non sint qui tenetur voluptatibus tempora laboriosam enim reprehenderit fuga. Voluptas incidunt natus explicabo repellendus odit id amet nam. Aut est consequatur sed modi omnis debitis sint quia.",
 	"title": "Rustic Concrete Chair",
@@ -34511,11 +33316,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Aliquam ipsam et aperiam molestias. Delectus quidem non optio nemo et dicta et facere necessitatibus. Consequatur delectus nihil. Sed iure fugiat similique qui iste sit.",
 	"title": "Handcrafted Soft Towels",
@@ -34612,11 +33412,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Harum dolor ipsum corporis eum nam. Aperiam sunt autem expedita sequi illum saepe placeat. Enim corrupti et omnis omnis enim tenetur. Iusto eum eos aspernatur voluptates. Et unde repudiandae nihil libero aut aliquid ut facere doloremque. Et eos eum.",
 	"title": "Unbranded Fresh Salad",
@@ -34742,11 +33537,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Molestiae occaecati aspernatur. Dolorem recusandae illo est. Ea itaque sapiente sapiente minus. Pariatur eum et. Nisi doloribus ut maxime.",
 	"title": "Intelligent Cotton Chair",
@@ -34901,11 +33691,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Omnis voluptate illo iure iure dolorum velit qui ullam. Repellendus dolore maxime odio corporis. Aut voluptas pariatur assumenda ea. Commodi nulla voluptatem omnis maiores saepe et expedita aliquid ducimus. Dignissimos qui et. Dolores alias magnam error tempora illo.",
 	"title": "Sleek Concrete Bike",
@@ -35002,11 +33787,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Corporis vero mollitia fugit et. Sed dignissimos iure non qui. Velit ut quae. Iste voluptas dolorem aut est alias eius ad asperiores. Nesciunt sint nobis corrupti ut et odit aspernatur autem et.",
 	"title": "Generic Wooden Tuna",
@@ -35161,11 +33941,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Vitae optio earum est suscipit distinctio unde. Ea et ea. Ut rerum aliquam aut. Est mollitia accusantium ea.",
 	"title": "Tasty Rubber Mouse",
@@ -35320,11 +34095,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Quam qui ullam voluptatibus doloremque et in et. Voluptatibus in possimus tempora omnis. Exercitationem architecto at culpa dolor. Et est quas pariatur labore. Voluptas distinctio et quasi nihil ea. Unde voluptas in ut blanditiis est sed qui repellendus recusandae.",
 	"title": "Intelligent Steel Bacon",
@@ -35479,11 +34249,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Dolores dicta veritatis nemo rerum. Incidunt vitae sed voluptates cupiditate. Pariatur qui totam ut reiciendis.",
 	"title": "Rustic Cotton Pants",
@@ -35667,11 +34432,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Nemo eum maxime voluptatum a repudiandae et nesciunt. Voluptas fugiat tempore qui sed ad sunt quasi. Ipsa ut eos rerum maxime aut. Ullam quia ipsum et dolores cumque corporis non cum.",
 	"title": "Handmade Metal Ball",
@@ -35797,11 +34557,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Illo est cum voluptas. Commodi aut dolorum est ut repellat autem. Non aperiam voluptates. Mollitia rerum eum sed iure blanditiis doloremque voluptas ullam.",
 	"title": "Unbranded Soft Bacon",
@@ -35956,11 +34711,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Voluptatem temporibus non explicabo sed velit animi sapiente facilis. Voluptatem quibusdam similique sit nesciunt. Provident illum labore. Dicta nobis ex voluptatem animi. Nobis enim aut.",
 	"title": "Refined Steel Ball",
@@ -36086,11 +34836,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Veritatis et labore id. Voluptatem sunt ut cumque exercitationem harum consectetur a quas. Rem in ea cumque dolores. Illum vel totam necessitatibus nulla tempora molestiae. Odit dicta aut ut laudantium voluptatum deserunt. Blanditiis ipsum veritatis nihil qui soluta sapiente debitis.",
 	"title": "Practical Wooden Shoes",
@@ -36187,11 +34932,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "At corrupti quos voluptate cumque qui deleniti nostrum alias blanditiis. Laborum sed hic quos quidem. Ut quo et voluptas dolor incidunt non rerum assumenda vel. Et sunt libero voluptatem aut facilis. Ullam non doloremque fugit quia inventore sed repellendus in nam.",
 	"title": "Tasty Plastic Towels",
@@ -36288,11 +35028,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Et quaerat ullam ex omnis qui commodi. Nihil iusto nobis aut id corporis tempore necessitatibus. Commodi neque vel est et sint. Delectus et et nihil error perferendis. Et atque ut. Ut delectus doloribus fuga deserunt.",
 	"title": "Handmade Cotton Shirt",
@@ -36418,11 +35153,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Vitae sit possimus voluptas corrupti laudantium facere doloribus quo. Exercitationem magni ea totam vero aliquid. Optio ipsa sequi deserunt beatae eaque voluptas ut. Est ipsum blanditiis facilis nihil ut. Distinctio repellat eaque a quia voluptatem et quia veniam.",
 	"title": "Incredible Concrete Soap",
@@ -36606,11 +35336,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Et voluptates aut. Explicabo ut temporibus dolores quod labore est quisquam. Veniam eaque velit sed perspiciatis necessitatibus.",
 	"title": "Rustic Rubber Chicken",
@@ -36794,11 +35519,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Et laborum eius voluptatem accusantium culpa quod rem eum. Atque velit nemo dicta qui et asperiores illo. Neque doloribus aliquid reiciendis est quas nobis. Quia deserunt sunt quisquam aut qui quia blanditiis soluta minus. Magni at dolorem optio ex iste sunt.",
 	"title": "Intelligent Granite Shoes",
@@ -36895,11 +35615,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Autem sint magnam rerum odit consequatur perspiciatis. Aut quisquam reprehenderit at eos sequi id libero dolorem velit. Molestias sunt ipsa nostrum. Ab nobis atque quod corporis. Quod rerum aut. Dolorem accusamus est commodi iure.",
 	"title": "Generic Wooden Tuna",
@@ -37054,11 +35769,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "A ut aperiam. Qui velit fugit. Corrupti quis et sequi labore et vel ipsum tenetur enim. Velit quaerat et omnis quis repellat reiciendis perferendis quas. Ducimus similique non quis odit. Voluptatem velit accusamus ipsum sit sint.",
 	"title": "Licensed Metal Cheese",
@@ -37184,11 +35894,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Dolorem ab est expedita dolorem soluta et et. Distinctio molestiae cupiditate nihil reprehenderit recusandae provident omnis aperiam dolore. Velit dolores nisi maxime consequatur perspiciatis neque vel. Quia pariatur accusamus modi dolorem quis est minus. Sed alias necessitatibus aspernatur repellat porro sequi aut.",
 	"title": "Awesome Cotton Salad",
@@ -37372,11 +36077,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Consequatur corrupti laboriosam assumenda odio quae earum expedita. Dolor modi repudiandae aut. Commodi assumenda tempora occaecati et nesciunt qui corporis dolorem.",
 	"title": "Refined Granite Mouse",
@@ -37473,11 +36173,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Autem nobis officiis voluptatem. Sapiente voluptatum cupiditate enim minus est quod minus hic corrupti. Doloremque in quis rerum aut similique facilis soluta animi. Placeat saepe tempore molestiae ea voluptatem quibusdam. Dolore sint et. Nam repudiandae rerum voluptatum.",
 	"title": "Generic Fresh Gloves",
@@ -37574,11 +36269,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Tenetur doloremque dolore cupiditate itaque quia sed. Provident ex et error eligendi vel aut modi tempora fugiat. Et ut voluptatibus aut veritatis et ut vero nam. Quod temporibus quis est quaerat voluptatibus odio nisi quos quaerat. Eum officia et delectus placeat voluptatem est amet eos architecto.",
 	"title": "Sleek Rubber Table",
@@ -37762,11 +36452,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Numquam laudantium perspiciatis aut ipsa occaecati in et voluptatem. Qui ut earum illo a maiores. Repellendus quis labore omnis nulla a voluptatem. Consequuntur exercitationem rerum et.",
 	"title": "Intelligent Concrete Shirt",
@@ -37863,11 +36548,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Eum ab doloremque debitis. Consequatur cupiditate aut ea culpa ea et repudiandae laborum corrupti. Aut rerum assumenda voluptas pariatur. Est praesentium vitae.",
 	"title": "Handcrafted Concrete Chicken",
@@ -38051,11 +36731,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Minima reprehenderit beatae aut et facere et quia laborum velit. Soluta ad explicabo quis mollitia corporis repellat quos veniam. Et sunt consequatur rerum. Ratione aut ipsam quis delectus est fuga. Suscipit et et. Recusandae esse tempora odio facere aperiam et rerum.",
 	"title": "Handmade Cotton Mouse",
@@ -38210,11 +36885,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Et velit libero assumenda alias enim debitis quos beatae. Aliquid exercitationem consequatur id veritatis corporis aut reiciendis. Unde quae iusto earum illo sit ipsum id.",
 	"title": "Ergonomic Wooden Pants",
@@ -38311,11 +36981,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Aliquid ullam illum. Deleniti nulla saepe dolorem ducimus assumenda. Repellendus dolores alias expedita dolor. Aliquam et ex labore cum. Doloremque nesciunt voluptatibus nihil hic quod qui illum. Sint quia ipsam voluptatem incidunt autem corrupti aperiam maxime exercitationem.",
 	"title": "Licensed Steel Keyboard",
@@ -38470,11 +37135,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Dolores et et. Consectetur odio consequatur nihil accusamus aliquam minus at aut placeat. Esse nihil voluptatem ut nostrum magnam ad qui reprehenderit.",
 	"title": "Generic Cotton Bacon",
@@ -38600,11 +37260,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Maxime enim excepturi unde laudantium sint voluptatibus qui veritatis sint. Illum quia consectetur impedit aut sint a sed. Omnis qui rerum.",
 	"title": "Generic Wooden Chips",
@@ -38759,11 +37414,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Libero velit est omnis quaerat voluptas. Corrupti impedit et. Laborum vero sit. Repellat vel expedita in. Similique velit non quo molestiae voluptates. Dolores illum dolore rerum similique sed.",
 	"title": "Small Rubber Keyboard",
@@ -38947,11 +37597,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Nisi qui nihil maxime et ut omnis. Vel velit non dolores non et qui dolores. Fuga quisquam rerum qui. Incidunt est eius quidem veniam voluptas voluptatem. Maxime dolorum ratione eaque sit a et. Sit quasi aut autem omnis magnam doloremque.",
 	"title": "Handmade Rubber Bacon",
@@ -39048,11 +37693,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Qui natus omnis et rerum ratione necessitatibus veniam consequatur. Aut voluptatum non unde id. Cum distinctio adipisci saepe est ipsa. Sit vel quo debitis dolores qui quaerat et.",
 	"title": "Ergonomic Wooden Salad",
@@ -39178,11 +37818,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Dolorem et in velit provident nemo molestiae. Qui omnis animi quae aliquam delectus. Modi sed cupiditate minus reprehenderit dolores incidunt aut deserunt. Illo necessitatibus officia doloremque. Expedita dolor aliquam.",
 	"title": "Practical Concrete Tuna",
@@ -39308,11 +37943,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Aliquid dolor qui. Tempore sint error magni natus quia ex magnam consequatur commodi. Fugiat sunt voluptatem cupiditate est accusantium praesentium asperiores voluptatem. Quia dolor ipsa autem dolorem.",
 	"title": "Practical Frozen Chips",
@@ -39467,11 +38097,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Sit et repellendus dolorem. Magni tenetur sequi. Voluptatem autem eius. Ipsam eos quam tempora qui. Libero voluptatem dolorum qui. Officia velit adipisci odio.",
 	"title": "Rustic Metal Pizza",
@@ -39568,11 +38193,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Voluptatem ex optio nihil quia dolorem qui veritatis cumque aperiam. Quis laudantium animi sed natus numquam eligendi ut cupiditate. Voluptas neque officia atque sed excepturi. Ea a reprehenderit praesentium excepturi. Quis aut autem placeat.",
 	"title": "Practical Metal Chips",
@@ -39727,11 +38347,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Perferendis est expedita modi reiciendis soluta. Explicabo tenetur illum vitae ducimus aut beatae ut labore perspiciatis. Animi sit ut molestias officia. Nisi ducimus expedita omnis optio ut beatae.",
 	"title": "Small Fresh Chicken",
@@ -39886,11 +38501,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Eius beatae hic veritatis eaque et. Sed et distinctio delectus ea quia sunt voluptatibus. Perspiciatis at eaque aperiam deserunt commodi rerum. Eveniet sapiente quidem exercitationem ut ad sit.",
 	"title": "Practical Metal Salad",
@@ -40016,11 +38626,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Ut deserunt sit aspernatur quia distinctio et provident ducimus. Laborum consequatur necessitatibus tenetur voluptatem occaecati dolorum. Repellendus non tempore iste omnis in et reiciendis.",
 	"title": "Fantastic Frozen Shoes",
@@ -40146,11 +38751,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Rem ut eos quia non occaecati repellendus quis explicabo expedita. Aut suscipit dolorum explicabo hic. Tenetur rerum itaque exercitationem asperiores. Non placeat ipsam eveniet. Est in eum aut sequi dolor ipsum totam. Ut laboriosam porro quia.",
 	"title": "Practical Frozen Cheese",
@@ -40334,11 +38934,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Praesentium quidem qui ut cupiditate magnam dolores. Aliquid voluptatem ullam occaecati ab quam ut sapiente. Ex eum animi ut quaerat ipsa alias earum non. Sit libero expedita voluptatem dolorum porro adipisci voluptas quis nobis.",
 	"title": "Generic Fresh Bike",
@@ -40435,11 +39030,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Sit voluptas quod mollitia sit autem quisquam et consequuntur ea. Eveniet ipsa vel optio sunt. Voluptas velit et ut sunt temporibus tempora voluptatibus saepe et. Quae sit nesciunt vitae dolore. Est tempora qui minus rerum. Aut qui debitis.",
 	"title": "Practical Cotton Table",
@@ -40623,11 +39213,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Velit illo voluptatem sequi impedit architecto. Provident enim quas enim repellat ducimus soluta. Qui amet sunt. Aut molestias inventore eos odit ut explicabo perferendis voluptate. Ut quo incidunt nostrum in praesentium rerum voluptate magnam. Voluptatem inventore delectus sunt dicta iste fuga.",
 	"title": "Gorgeous Cotton Pizza",
@@ -40753,11 +39338,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Repudiandae quos voluptatem. Qui quia veritatis provident ut laborum quia harum explicabo aut. Sint corporis harum. Eaque in dicta tempora consequatur deserunt natus voluptas laborum illum.",
 	"title": "Rustic Concrete Hat",
@@ -40941,11 +39521,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Sapiente nam omnis sit et occaecati ducimus consequatur voluptas. Unde assumenda beatae et. Accusamus asperiores maxime error expedita est facilis nam. Tempora necessitatibus cupiditate qui. Rerum ut molestiae nam rerum.",
 	"title": "Generic Cotton Fish",
@@ -41042,11 +39617,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Iste enim cumque ducimus rerum repellendus iste et officiis. Nam dolore quia natus et et quo. Debitis qui sapiente est ipsa sunt. Dolorem inventore quo aut quia.",
 	"title": "Gorgeous Frozen Fish",
@@ -41201,11 +39771,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Perferendis optio officiis reprehenderit id odit tempora. Optio rerum vitae rerum omnis architecto. Facere ut unde ipsam assumenda in eligendi sed accusantium cupiditate. Saepe et reprehenderit dignissimos nam cupiditate cum at debitis alias. Non similique et fuga eum eum velit animi quod reiciendis.",
 	"title": "Incredible Metal Hat",
@@ -41331,11 +39896,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Quos quia facilis ipsum itaque aliquid qui porro vel neque. Sequi dolores animi quo. Voluptas a omnis ipsum cumque officiis.",
 	"title": "Fantastic Fresh Pants",
@@ -41432,11 +39992,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Voluptas culpa minus laudantium. Ab nemo ut sunt ut fugit magni consequatur. Quaerat voluptatum cumque quidem excepturi. A sit aut quis voluptate. Qui error ad ab molestias ullam.",
 	"title": "Small Fresh Shoes",
@@ -41620,11 +40175,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Aut et quos et cumque. Esse quis nihil dicta eum voluptates facere. Totam magni dolore magni nobis nihil veniam ea sint optio. Porro odio voluptatem numquam cum quasi asperiores. Architecto accusamus quasi dolorem fugit.",
 	"title": "Tasty Fresh Bacon",
@@ -41779,11 +40329,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Molestias illum et et et magni numquam minima numquam. Omnis molestiae quisquam eum unde ipsum provident. Eum enim reprehenderit itaque quod voluptas dolores quas qui natus. Ad est quis et.",
 	"title": "Intelligent Concrete Car",
@@ -41967,11 +40512,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Error enim sint laborum quibusdam. Illo ullam voluptas ut magnam praesentium. Distinctio consequatur et sed ut excepturi culpa aut labore et. Veritatis quia deserunt rerum necessitatibus natus eaque eos ratione. Et aut voluptatem.",
 	"title": "Small Concrete Shoes",
@@ -42155,11 +40695,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Est minima vel dicta temporibus ipsa autem consequuntur et. Aut consequatur dolores qui omnis. Eligendi sapiente voluptatem cupiditate ea similique nostrum ut provident.",
 	"title": "Licensed Metal Salad",
@@ -42256,11 +40791,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Consequatur dicta nisi praesentium. Rerum consequatur odio. Voluptatem voluptates exercitationem placeat sit.",
 	"title": "Fantastic Granite Tuna",
@@ -42444,11 +40974,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Aliquid delectus neque autem dolorem. Quod velit ut labore eum omnis. Rem est fugit. Porro omnis ut.",
 	"title": "Practical Fresh Table",
@@ -42545,11 +41070,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Veritatis praesentium recusandae porro quo id tempore quos quis. Culpa id error velit sint voluptates molestiae ipsam placeat. Omnis aut vel molestias aliquid nihil porro consequatur. Facere illo nisi nostrum id et at quam dolorem illo. Illum voluptates tempore consequatur quisquam explicabo. Optio cum cumque voluptatem natus minus.",
 	"title": "Practical Steel Ball",
@@ -42646,11 +41166,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Odit qui nihil iure eos dicta amet placeat. Reiciendis eligendi harum et non quibusdam molestias autem soluta quisquam. Sunt amet pariatur et.",
 	"title": "Practical Metal Chips",
@@ -42805,11 +41320,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Voluptate id voluptas distinctio voluptates quo repudiandae voluptas. Explicabo ipsa expedita distinctio quas fuga excepturi animi quas. Repellat omnis iure cumque. Eveniet facere officia accusamus soluta quae.",
 	"title": "Fantastic Concrete Hat",
@@ -42993,11 +41503,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Itaque quo optio sint. Consequatur dolore ea velit sunt autem. Quo corporis illo hic et quod.",
 	"title": "Fantastic Soft Chair",
@@ -43094,11 +41599,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Reprehenderit iusto dolor laudantium. Aut temporibus laborum. Quo esse totam maxime incidunt velit et veniam.",
 	"title": "Small Soft Towels",
@@ -43195,11 +41695,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Adipisci consequatur veritatis praesentium natus aut quod consectetur voluptatum. Minus nihil magni. Et cumque rerum. Ut omnis qui voluptatum qui dolores eos sit porro. Architecto consequatur voluptas ea ut atque eos necessitatibus nemo. Sed suscipit pariatur voluptatem blanditiis architecto.",
 	"title": "Handcrafted Steel Chicken",
@@ -43383,11 +41878,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Quisquam consequatur atque. Nostrum laboriosam molestiae delectus maxime et occaecati velit voluptatibus fugiat. Reiciendis sed cum dolorem cupiditate ut voluptatem aut vel quis. Debitis qui rerum unde sapiente pariatur.",
 	"title": "Awesome Frozen Bacon",
@@ -43484,11 +41974,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Inventore ut amet itaque dolorem expedita praesentium. Sapiente architecto voluptate deserunt ullam repellendus aut aut tempore. Fuga laudantium aut quae est laborum. Ea repellendus voluptas porro placeat id labore corporis odit. Maiores qui eligendi. Nesciunt sed accusantium.",
 	"title": "Tasty Frozen Sausages",
@@ -43585,11 +42070,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Non ad eum officiis. Voluptate voluptatum nisi. Quis sed quam ut quasi doloribus aliquid amet.",
 	"title": "Fantastic Soft Pizza",
@@ -43686,11 +42166,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Qui unde dolores harum dolores qui corporis dolorum doloribus praesentium. Aut quasi alias et sit doloribus et cupiditate voluptatem temporibus. Aut occaecati sint ab ut dolorum id omnis veritatis incidunt.",
 	"title": "Handmade Fresh Pizza",
@@ -43816,11 +42291,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Magni id similique mollitia tempore consequatur. Distinctio a natus non et veniam eum sint quibusdam quidem. Atque et quia ullam aliquid voluptatem eligendi. Fugiat et culpa reiciendis. Omnis deleniti aliquam architecto. Iure excepturi ipsa fuga facere.",
 	"title": "Small Concrete Computer",
@@ -43975,11 +42445,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Et ut unde eius recusandae. Fuga et minima omnis eos delectus possimus. Vitae quos praesentium voluptates in voluptas ab aut temporibus quidem. Quis sunt quo eos minima quae adipisci repudiandae.",
 	"title": "Practical Plastic Pizza",
@@ -44163,11 +42628,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Maxime repellat quia odio tenetur pariatur. Reprehenderit sunt est delectus officia aut ab velit. Quasi sequi explicabo quisquam fugit sapiente debitis officia sunt. Quo omnis qui sunt alias. Quam ut quis ullam nemo unde qui veniam.",
 	"title": "Handmade Frozen Chicken",
@@ -44293,11 +42753,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Ab voluptatem libero nemo et repudiandae optio. Et molestiae ut officiis sed consequuntur totam qui sint et. Non voluptatem odit corporis tempore debitis quos eaque beatae est.",
 	"title": "Ergonomic Plastic Tuna",
@@ -44452,11 +42907,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Deserunt ut alias nam perferendis nam. Unde et nemo inventore unde. Hic mollitia rerum est quia voluptate maiores et reiciendis. Mollitia deleniti architecto maxime rerum fugit.",
 	"title": "Rustic Plastic Gloves",
@@ -44553,11 +43003,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Perferendis in vel et magnam debitis maxime esse illo. Cupiditate et odit animi doloribus fuga minima totam deleniti. Beatae enim aut dolor excepturi. Et eveniet quae. In non sit dignissimos nam voluptates et omnis impedit enim.",
 	"title": "Tasty Plastic Table",
@@ -44712,11 +43157,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Quis et possimus occaecati nihil vero laboriosam. Eaque eligendi est placeat in consequuntur dolore. Et sit nisi odit placeat deleniti at et.",
 	"title": "Small Granite Shoes",
@@ -44842,11 +43282,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Numquam laborum ex veniam. Ut quibusdam omnis quae facilis facilis doloribus quisquam vel. Dolorum dolor quo distinctio et velit iusto asperiores repudiandae nobis. Ad culpa ea quis dicta doloribus quas et consectetur quod. Voluptas odio ut debitis minus rerum porro aperiam beatae.",
 	"title": "Licensed Frozen Car",
@@ -44943,11 +43378,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Distinctio repellat beatae vel et aperiam ut quam. Repellat enim doloremque eaque quod consequatur dicta. Est placeat nobis facere sed. Natus qui debitis cum eos quo deserunt illo quod. Quis quam laudantium qui corrupti asperiores voluptate facere.",
 	"title": "Intelligent Metal Shoes",
@@ -45073,11 +43503,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Est necessitatibus nisi autem aperiam ut expedita eos. Aut voluptas beatae dignissimos quia et aliquid aliquid consequatur exercitationem. Est ut quia consequatur.",
 	"title": "Ergonomic Rubber Pants",
@@ -45203,11 +43628,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Possimus sapiente accusantium. Odio modi in eveniet voluptatem. Rem odio velit in.",
 	"title": "Unbranded Metal Mouse",
@@ -45391,11 +43811,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Vero voluptates ducimus. Qui est ex exercitationem. Culpa dolores harum provident. Quia adipisci quibusdam aut ex aliquam dolorem enim. Repellendus architecto dicta voluptates praesentium nostrum dolores non ducimus.",
 	"title": "Fantastic Wooden Fish",
@@ -45492,11 +43907,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Explicabo culpa aut sint sit corrupti id possimus. Iure pariatur corrupti sapiente laboriosam numquam culpa quis. Odio quisquam voluptatibus dolores.",
 	"title": "Awesome Steel Keyboard",
@@ -45622,11 +44032,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Quas pariatur sed enim. Voluptas impedit harum eveniet a quas. Repudiandae quis sed eum nihil sint architecto amet quibusdam. Iste sit quis eius occaecati maxime nostrum architecto. Numquam aut dolore nostrum iste dicta possimus laudantium et.",
 	"title": "Practical Plastic Shoes",
@@ -45723,11 +44128,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Impedit odit quis et voluptates cum quisquam. Nesciunt praesentium qui debitis et. Commodi velit aperiam molestiae soluta aliquid esse ut est.",
 	"title": "Practical Cotton Soap",
@@ -45911,11 +44311,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Eum qui corporis molestias qui. Sed sint fuga deleniti. Non quo cumque minima earum. Quo perspiciatis porro reprehenderit hic incidunt cum. Nobis sint incidunt libero dolor ut est rerum at quos.",
 	"title": "Practical Rubber Bacon",
@@ -46012,11 +44407,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Ea ipsum beatae asperiores deserunt perspiciatis provident. Numquam et ipsa corporis sint. Facere quibusdam corrupti non aut qui. Voluptatem ut voluptas eius sunt quos labore ea saepe. Dolore soluta hic ipsum quis eveniet vero aliquid. Voluptas eos ipsum provident ratione labore.",
 	"title": "Ergonomic Wooden Chips",
@@ -46200,11 +44590,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Voluptatem dolorem cum pariatur nobis inventore voluptatem vel placeat. Dignissimos deleniti temporibus cum ut quod voluptatem. Voluptatem reprehenderit modi iusto odio est iure consequatur nostrum odit.",
 	"title": "Intelligent Granite Chicken",
@@ -46301,11 +44686,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Repellendus accusantium qui enim est placeat aspernatur dolores eos est. Et cum magni dolorem similique et sint deserunt aut ad. Quia facilis vitae non itaque. In assumenda similique sequi tempore et perferendis eaque consectetur. Commodi inventore beatae veritatis delectus id debitis sint.",
 	"title": "Refined Rubber Gloves",
@@ -46489,11 +44869,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Aut vitae incidunt inventore in vero consequatur similique eius. Sed qui doloremque atque ut omnis et. Odit facere ullam in quo omnis est autem quasi. Explicabo sapiente iste saepe ad illo iste et qui. Sapiente libero sit dolore maiores necessitatibus officiis maxime eos.",
 	"title": "Fantastic Frozen Pants",
@@ -46590,11 +44965,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Error quis neque harum eos sed suscipit. Commodi natus dolorem maxime. Ab explicabo nemo animi molestias non. Modi consequatur ut omnis nihil consequatur esse enim.",
 	"title": "Fantastic Frozen Tuna",
@@ -46778,11 +45148,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Aut ex voluptatibus architecto dignissimos nostrum pariatur voluptatem. Adipisci est eius sapiente. A adipisci id quia ducimus. Assumenda deleniti ut eligendi beatae earum porro. Provident est quos ab. Eos libero totam vel qui nemo qui et.",
 	"title": "Refined Rubber Salad",
@@ -46879,11 +45244,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Consequuntur velit et neque saepe. Qui officiis aut repudiandae in eveniet provident ea et. Velit velit doloremque illo qui minima fugiat. Deserunt omnis nam laborum ipsam necessitatibus sunt accusamus. Consectetur ad et voluptas maxime.",
 	"title": "Refined Frozen Keyboard",
@@ -47067,11 +45427,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Vitae accusantium non. Voluptatibus quisquam explicabo mollitia et. Exercitationem soluta voluptas dolore cumque ex saepe quisquam rem id. Nesciunt in sunt repudiandae suscipit possimus ipsam officiis quam. Veniam rerum dignissimos voluptas nemo commodi. Accusamus consequatur aperiam accusamus et voluptas qui ut.",
 	"title": "Refined Cotton Computer",
@@ -47168,11 +45523,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Qui repellendus quae minus perspiciatis numquam velit. Dolorem molestiae et voluptate est. Eligendi debitis in excepturi tempore ex. Animi facilis quas provident sit aliquid sunt quia asperiores quis. Dolores culpa rerum eligendi nihil ut aut autem facere enim.",
 	"title": "Ergonomic Plastic Hat",
@@ -47298,11 +45648,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Et cupiditate sint molestiae porro voluptatem veritatis provident corporis aut. Praesentium corrupti omnis error blanditiis. Sit rerum consequuntur odio ab at quae. Et placeat nulla non. Et quis nesciunt quod quisquam occaecati quo. Est sint sint.",
 	"title": "Licensed Cotton Shirt",
@@ -47457,11 +45802,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Distinctio labore non vel qui ipsum quisquam nihil maiores aliquid. Sapiente aperiam rerum minus. Voluptatem vitae consequatur voluptas esse quisquam.",
 	"title": "Handcrafted Plastic Bike",
@@ -47645,11 +45985,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Repellat et quis odio non odio ipsa. Voluptatibus minus autem qui fugiat asperiores nulla laboriosam velit beatae. Qui accusantium voluptatem doloribus rerum quae. Nobis accusantium impedit adipisci quisquam beatae.",
 	"title": "Handcrafted Rubber Mouse",
@@ -47746,11 +46081,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Enim rerum nostrum cupiditate eveniet voluptate at ut nobis. Ut dolorem est. Cupiditate qui eaque rem vel accusamus ut corrupti quis. Quia voluptatum adipisci aliquid aut odit. Voluptatibus et eius expedita nulla in impedit et earum. Mollitia sed repellendus odio ut maiores a.",
 	"title": "Practical Plastic Pants",
@@ -47934,11 +46264,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Ad soluta et sint. Odio cupiditate explicabo in non id ut iste dicta. Voluptate necessitatibus quaerat dolorum et labore nesciunt praesentium vitae odit. Ullam excepturi sit. Velit corporis voluptatem.",
 	"title": "Ergonomic Soft Chicken",
@@ -48093,11 +46418,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Sed id cumque commodi. Deleniti ut saepe tempora. Totam occaecati tempora dolores corrupti beatae sunt esse aut. Ea tempora explicabo sed consectetur eligendi temporibus.",
 	"title": "Small Rubber Keyboard",
@@ -48223,11 +46543,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Iste provident quis. Maiores debitis voluptatum. Cupiditate rem maxime explicabo aut dolore eum mollitia.",
 	"title": "Handmade Concrete Keyboard",
@@ -48324,11 +46639,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Dolor provident animi qui repellat praesentium ea molestias error quis. Sapiente aut ut laborum vel. Hic asperiores eum qui esse aspernatur voluptates tempore.",
 	"title": "Ergonomic Soft Keyboard",
@@ -48483,11 +46793,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Nobis sequi exercitationem delectus maxime ullam consequatur asperiores. Harum totam fuga id ex id nisi. Quia molestiae molestias est molestiae. Mollitia ipsum est inventore occaecati accusamus enim. Qui dolore impedit voluptatibus voluptas temporibus minima voluptatem.",
 	"title": "Awesome Metal Chips",
@@ -48613,11 +46918,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Voluptatem nisi quos rerum et voluptatum cupiditate aut. Magni aut nulla similique aut voluptas rerum officia amet. Pariatur quas velit. Molestias sapiente officia odio. Et vero labore et.",
 	"title": "Licensed Concrete Mouse",
@@ -48772,11 +47072,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Qui iste itaque rerum dicta. Et harum qui libero sunt est modi sed dignissimos ratione. Sint a aut facere nihil culpa quasi dolorem eum. Repudiandae dolor quis dolores alias. Incidunt deleniti quod ut ut et error et. Voluptate voluptatibus quasi omnis incidunt consequatur ea ipsum consequuntur.",
 	"title": "Intelligent Plastic Mouse",
@@ -48902,11 +47197,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Exercitationem et quisquam dolor natus saepe dolore quis incidunt et. Nam dolor perferendis qui ea. Nihil cumque in et aut voluptates ea. Sed qui itaque id officia possimus et porro et quo. Necessitatibus ea voluptas velit ut officiis.",
 	"title": "Handcrafted Wooden Shoes",
@@ -49061,11 +47351,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Ex et quisquam perspiciatis. Ea at voluptatem id omnis earum nulla qui inventore. Voluptas voluptas cum. Voluptas dolorum minima maxime non amet. Dolor animi nisi dolores iure id fugit rerum. Iste et ut nisi distinctio.",
 	"title": "Rustic Plastic Cheese",
@@ -49249,11 +47534,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Sed et ea suscipit. Molestiae id rerum voluptates deserunt ea excepturi voluptatibus. Veniam rerum est. Eveniet a asperiores. Et in quas. Quia esse quis amet repellat vel.",
 	"title": "Intelligent Steel Mouse",
@@ -49350,11 +47630,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Voluptas omnis sequi. Nisi ullam velit magni iure ut reiciendis qui qui enim. Error sed doloremque expedita pariatur sint sunt quo. Suscipit numquam culpa voluptatem quidem tenetur.",
 	"title": "Practical Metal Soap",
@@ -49509,11 +47784,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Assumenda est at corrupti quod delectus facilis incidunt totam nemo. Magnam sint nobis. Rerum ut optio commodi. Quo incidunt et architecto vero reprehenderit iusto excepturi in.",
 	"title": "Licensed Fresh Hat",
@@ -49668,11 +47938,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Nobis eum tempora. Qui sed eveniet consequuntur consectetur facere in sapiente ut voluptatem. Qui id provident. Ut in dolores expedita.",
 	"title": "Fantastic Fresh Towels",
@@ -49798,11 +48063,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Illo adipisci et autem minima harum. Delectus voluptatem aut. Voluptas fugit minima omnis voluptates sit quaerat qui. Placeat molestiae aliquid impedit suscipit. Qui quos ratione non esse eum.",
 	"title": "Incredible Concrete Fish",
@@ -49986,11 +48246,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Et et quam pariatur. Repellendus molestiae nulla praesentium. Numquam odit quae modi nemo est asperiores aperiam quaerat aperiam. Ab consectetur adipisci quaerat. Sed illum asperiores. Ducimus non temporibus pariatur quos.",
 	"title": "Handcrafted Granite Hat",
@@ -50116,11 +48371,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Quis sint nesciunt. Quo et et officiis laborum quia. Illo repellat voluptates. Est quidem quam molestias autem incidunt. Inventore blanditiis minima dolores cumque quis. Provident nemo quo dolor et expedita quidem quis enim ipsa.",
 	"title": "Refined Frozen Chair",
@@ -50246,11 +48496,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Voluptate ut et ut autem. Officia nesciunt itaque ea tempore aliquam quia occaecati consequuntur. Rerum molestiae iste aliquid ut quia amet vel sint. Ut amet temporibus cum soluta aut vero esse. Laborum sit sunt facere molestiae unde in occaecati vero tempore. Et at necessitatibus rerum in ab libero dolor minus.",
 	"title": "Practical Fresh Soap",
@@ -50434,11 +48679,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Mollitia quidem possimus. Quibusdam minima perferendis incidunt delectus possimus quis dignissimos sit. Asperiores vel quam eaque impedit omnis mollitia.",
 	"title": "Fantastic Granite Salad",
@@ -50564,11 +48804,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "In error nemo. Repellendus reprehenderit natus at. Laborum eius sit.",
 	"title": "Unbranded Concrete Pants",
@@ -50665,11 +48900,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Dolorem libero alias ipsum atque sapiente itaque non reprehenderit quo. Distinctio debitis aspernatur ab. Voluptates et fugiat deleniti unde quis molestiae qui eos. Optio facere ipsam fuga vel non quo. Ipsam tempore nobis. Voluptas alias quidem quod minus adipisci.",
 	"title": "Sleek Metal Hat",
@@ -50853,11 +49083,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Aut et labore. Aut voluptatem culpa molestias qui modi similique qui. Magni natus cumque. Non inventore dolorem inventore aut dolorum qui velit sed et.",
 	"title": "Ergonomic Steel Table",
@@ -51041,11 +49266,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Molestias officiis possimus qui id sit odio voluptatem perferendis. Modi maxime fugit dicta non eos quod aut. Autem aut itaque. Molestias sed et. Libero quae est.",
 	"title": "Tasty Wooden Car",
@@ -51171,11 +49391,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Excepturi necessitatibus repellendus nulla ut consequatur culpa velit. Optio sint molestiae nihil error et consectetur ut. Sequi fugit sint.",
 	"title": "Handmade Metal Keyboard",
@@ -51272,11 +49487,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Sit tempora at illo ratione eligendi ut. Hic cumque saepe sint autem quo et qui unde modi. Numquam et aut non. Praesentium qui sit aut et quod ea consequatur quia. Ipsam et voluptas.",
 	"title": "Handcrafted Rubber Ball",
@@ -51402,11 +49612,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Neque consectetur officiis officiis quia sunt officiis explicabo nihil nesciunt. Molestiae magni sint. Aut illo error amet qui provident. Exercitationem voluptatibus expedita doloremque aut necessitatibus quia inventore qui. Qui nemo totam libero.",
 	"title": "Ergonomic Rubber Salad",
@@ -51561,11 +49766,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Qui aut est. Et est vitae nihil ullam. Enim similique aperiam ratione. Eum et ipsam.",
 	"title": "Fantastic Metal Shirt",
@@ -51749,11 +49949,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Suscipit quia labore dolores. Assumenda voluptatibus nisi quo a ratione aut. Sint doloremque omnis rerum doloribus quaerat excepturi. Vero fugit nesciunt quaerat vel nesciunt sapiente doloribus.",
 	"title": "Unbranded Frozen Chicken",
@@ -51879,11 +50074,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Consectetur quis totam. Quibusdam id voluptatibus quis rerum praesentium. Sunt provident asperiores tempora quae beatae exercitationem ut. Quas aut voluptatibus. Tenetur illum et consequatur dolore ut. Rerum officiis iusto.",
 	"title": "Gorgeous Frozen Ball",
@@ -51980,11 +50170,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Possimus dolore nisi totam illum sed. Enim quia minima fugiat. Quia unde quod cupiditate doloribus animi unde eius.",
 	"title": "Handcrafted Frozen Salad",
@@ -52168,11 +50353,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Sit aut recusandae exercitationem dolores dolorem. In molestiae velit quo unde delectus magnam magnam quasi. Corrupti architecto occaecati perspiciatis quos ea quae sed quaerat expedita. Veritatis voluptatem vel sit corrupti repudiandae qui nisi. Quo consequatur est quis.",
 	"title": "Intelligent Fresh Keyboard",
@@ -52298,11 +50478,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Nostrum neque non dolorum adipisci minus. Incidunt dolore sapiente quisquam eveniet ut odit sit. Earum sunt harum labore quo harum ea laborum neque deleniti. Dolorum reprehenderit explicabo doloribus hic aperiam.",
 	"title": "Rustic Steel Salad",
@@ -52457,11 +50632,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Porro quo perferendis hic ipsum quibusdam sapiente accusantium et. Cupiditate dicta sequi labore recusandae occaecati fugit. Adipisci culpa magnam autem molestias.",
 	"title": "Awesome Cotton Shoes",
@@ -52616,11 +50786,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Dicta deleniti quo sequi unde aut quis suscipit veniam laudantium. Est quis expedita et saepe aperiam eius consequuntur voluptas. Iusto consectetur quo voluptatibus omnis quaerat eos. Laudantium quas repudiandae ut. Eum unde sit est culpa asperiores.",
 	"title": "Intelligent Plastic Gloves",
@@ -52746,11 +50911,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Repudiandae iusto fuga sit consequatur. Nemo delectus omnis aut repellendus possimus optio dolor explicabo esse. Dolor doloremque qui alias consequatur labore et.",
 	"title": "Gorgeous Metal Towels",
@@ -52847,11 +51007,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Ut consequatur sapiente numquam et in veniam maxime aliquam voluptatem. Laborum dolore vitae ut. Cumque dolor officiis non explicabo rerum velit repellendus perspiciatis eos. Distinctio eligendi voluptas commodi rerum. Ipsum a voluptatibus sint nemo ut. Deserunt a inventore laboriosam cum quia ex.",
 	"title": "Fantastic Plastic Soap",
@@ -52948,11 +51103,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Veniam modi ut enim. Voluptas explicabo aliquid aperiam nihil omnis in sit facere ut. Ipsam rem ullam similique.",
 	"title": "Fantastic Steel Keyboard",
@@ -53078,11 +51228,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Consectetur accusantium consequuntur ut laudantium nostrum enim officiis corrupti. Rerum quisquam voluptas doloremque aperiam rerum quasi sed. Consectetur exercitationem illum ea inventore corporis quasi eius recusandae est. Voluptatem facere molestiae quas sint.",
 	"title": "Unbranded Steel Fish",
@@ -53179,11 +51324,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Reprehenderit error ut placeat quo consequatur aperiam deleniti sint. Sit debitis aspernatur ut aut alias rem quo et. Voluptate fuga unde quo id dignissimos excepturi et aperiam enim. Et eligendi pariatur quo.",
 	"title": "Rustic Concrete Bacon",
@@ -53280,11 +51420,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Velit odit possimus architecto provident laboriosam. Velit quam a nesciunt temporibus facere. Minus amet delectus.",
 	"title": "Unbranded Plastic Pizza",
@@ -53439,11 +51574,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Quis velit magni veniam id. Aspernatur error laborum autem voluptas voluptatem ipsa et. Dignissimos ea omnis. Eum ad neque minima et numquam provident.",
 	"title": "Awesome Frozen Tuna",
@@ -53598,11 +51728,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Deleniti quo eos. Quisquam distinctio voluptatem quia eligendi necessitatibus quam ipsa. Eos repellat suscipit.",
 	"title": "Tasty Fresh Salad",
@@ -53757,11 +51882,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Quo omnis accusamus ut provident totam labore nisi dolorem repellat. Eligendi et odio rerum rerum aperiam in velit. Perferendis porro ab earum nam quis ut tempora at recusandae.",
 	"title": "Generic Steel Sausages",
@@ -53916,11 +52036,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Consectetur eveniet quia magnam excepturi numquam doloremque officiis culpa. Animi sunt similique accusantium incidunt aut ullam consequatur veritatis. Fuga assumenda placeat sequi cupiditate. Reprehenderit velit hic ut tenetur omnis rerum voluptatem.",
 	"title": "Awesome Steel Tuna",
@@ -54104,11 +52219,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Officiis rerum praesentium labore perspiciatis et ipsam maxime et molestiae. Rerum assumenda animi aut debitis. Nemo aliquid iusto et et praesentium ea ducimus ut. Iste facilis repellendus totam ea. Nemo autem ducimus ratione quia et.",
 	"title": "Ergonomic Granite Pizza",
@@ -54234,11 +52344,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Natus quia sed aut. Nostrum illum minima fuga possimus quod. Corrupti voluptas veniam ipsam repellendus hic aliquid eum consequatur. Sapiente voluptatem deleniti quaerat in quia repellendus illo at. Ullam veritatis et aut aut quidem. Quis qui ea optio est.",
 	"title": "Generic Fresh Keyboard",
@@ -54335,11 +52440,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Iste ea officiis quis illum id quia eaque. Rerum itaque nesciunt vero culpa iure quo odit error. Quidem a inventore sit libero ut. In totam fuga rerum tenetur qui.",
 	"title": "Awesome Wooden Shirt",
@@ -54436,11 +52536,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Ut omnis omnis pariatur temporibus quas non. Et voluptatum recusandae minus. Consequatur ut labore at atque error in in velit iste. Ut fugiat occaecati deleniti quia perferendis. Nulla sed consequuntur odio accusantium voluptatum omnis maxime nostrum mollitia.",
 	"title": "Practical Soft Tuna",
@@ -54624,11 +52719,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Odit magnam dolore mollitia ut. Tempora quod ullam a delectus explicabo eveniet qui eaque. Ut sunt saepe qui. Aut qui labore consectetur neque rerum eligendi eligendi omnis. Et voluptatibus enim est. Omnis repudiandae soluta.",
 	"title": "Incredible Soft Gloves",
@@ -54754,11 +52844,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Provident aut quia sit ea aliquam aperiam aut voluptatem doloribus. Exercitationem atque quia et in enim beatae blanditiis tempore magnam. Autem placeat earum qui nobis quasi exercitationem ex.",
 	"title": "Rustic Concrete Soap",
@@ -54855,11 +52940,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Similique facilis ab praesentium ut et neque. Eos voluptate sint dolor fugit. Voluptas quas harum vel maxime exercitationem recusandae.",
 	"title": "Tasty Steel Computer",
@@ -55043,11 +53123,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Consequuntur rerum eaque vel repudiandae suscipit ut enim accusamus. Blanditiis mollitia at aut incidunt non maxime expedita magnam. Mollitia ut sit a sint hic consequuntur. Voluptas eos inventore. Accusantium voluptas in qui.",
 	"title": "Ergonomic Metal Chair",
@@ -55144,11 +53219,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Facere laboriosam harum quia. Libero reiciendis nihil nam. Sequi a atque velit aut exercitationem sint quia necessitatibus. Placeat recusandae fuga harum quisquam cupiditate quo aperiam. Mollitia tempora architecto accusantium dolor nulla et expedita eum nisi.",
 	"title": "Licensed Wooden Computer",
@@ -55245,11 +53315,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Qui asperiores non minima rerum adipisci iusto voluptatem velit. Accusantium architecto labore. Ad voluptas delectus aliquid laborum qui.",
 	"title": "Unbranded Fresh Cheese",
@@ -55375,11 +53440,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Tenetur laborum et expedita qui quis nesciunt aliquam sint incidunt. Laboriosam quia reiciendis cumque et nihil et sed ipsa. Natus officia dolor est dolor praesentium tempora quisquam saepe et. Est repellat distinctio et ipsa. Quibusdam voluptas tempore. Incidunt exercitationem veritatis modi laboriosam.",
 	"title": "Incredible Fresh Shirt",
@@ -55476,11 +53536,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Omnis consequatur sed sit ullam beatae est. Quos eos omnis reprehenderit. Deserunt nesciunt sunt ipsam et officia aut quo aut minus. Nihil unde provident delectus magni.",
 	"title": "Small Metal Pizza",
@@ -55577,11 +53632,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Vero neque rerum. Cumque qui dolor. Incidunt architecto pariatur perspiciatis assumenda rerum eius velit. Possimus enim aliquam inventore aut. Aut nihil magni quos rem possimus non temporibus. Impedit rerum molestias porro.",
 	"title": "Intelligent Steel Hat",
@@ -55707,11 +53757,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Natus qui illo similique soluta sunt eum molestiae autem. Et suscipit quos et. Ut et et nostrum saepe autem. Occaecati repellendus ex. Neque voluptate dicta qui voluptas ipsum et. Voluptatem libero voluptate provident debitis ea.",
 	"title": "Rustic Soft Chicken",
@@ -55808,11 +53853,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Libero occaecati alias. Non officiis quos quia. Molestiae officiis voluptatum. Quibusdam voluptatum voluptatem quis ad consequuntur. Nostrum mollitia corporis voluptatem numquam corrupti unde.",
 	"title": "Unbranded Plastic Soap",
@@ -55938,11 +53978,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Consequatur ea quis. Ea et odio ex voluptatem nemo quaerat pariatur consequatur rerum. Velit ut sit. Earum itaque ea neque nobis ratione pariatur sed. Molestiae molestias suscipit sit odio voluptate beatae officiis.",
 	"title": "Ergonomic Soft Chips",
@@ -56126,11 +54161,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Distinctio at consequatur. Laboriosam eveniet et culpa. Ab quo culpa natus iure omnis incidunt placeat.",
 	"title": "Sleek Fresh Salad",
@@ -56314,11 +54344,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Labore quo est quos earum fugiat doloribus nostrum omnis accusamus. Modi placeat laudantium optio id aliquam reprehenderit ut. Numquam sunt fuga aut. Numquam sint quas.",
 	"title": "Incredible Plastic Gloves",
@@ -56444,11 +54469,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Quasi tempora atque enim natus eveniet explicabo. Distinctio minima pariatur nisi aut odit magnam dolore voluptate. Est corporis incidunt enim voluptas iusto doloremque nam ut. Architecto nobis quod.",
 	"title": "Fantastic Plastic Soap",
@@ -56574,11 +54594,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Consequatur officia dolorum laboriosam. Repellat ipsa illo cumque. Ipsa autem ipsa vero incidunt qui odio ipsa dignissimos eius. Est quia deleniti architecto molestiae voluptas impedit ipsa voluptas.",
 	"title": "Gorgeous Rubber Gloves",
@@ -56675,11 +54690,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Et aperiam qui perspiciatis voluptatibus perferendis cupiditate dicta et. Perferendis fugiat hic repellendus fugiat nihil odio ut. Voluptatum consectetur sit quo veniam laborum atque omnis occaecati.",
 	"title": "Gorgeous Granite Chair",
@@ -56863,11 +54873,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Odit qui quia nihil culpa est. Sint corrupti ipsum perferendis cum expedita. Dolor aperiam illo dolores debitis sit ipsam non voluptatem. Excepturi impedit et. Minima cumque corrupti.",
 	"title": "Rustic Soft Car",
@@ -56964,11 +54969,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Dolores accusantium consequatur magni. Quaerat praesentium enim rerum iste tempore omnis nulla vel iusto. Rerum laudantium qui debitis repellat.",
 	"title": "Handcrafted Concrete Ball",
@@ -57094,11 +55094,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Eos quia tempora officia repellat ipsa ipsa tenetur inventore. Quia perferendis alias vitae facere occaecati voluptate. Provident impedit omnis culpa velit dolor inventore. Culpa soluta dolorum repudiandae corrupti ullam quis illo quis vero. Quod cum debitis et rerum amet ullam officiis at expedita. Officia eos aut est dolorem sapiente enim.",
 	"title": "Generic Metal Hat",
@@ -57224,11 +55219,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Perferendis mollitia eos quas occaecati deleniti et animi eum sed. Ratione labore qui aperiam aut in ea placeat. Quisquam aliquid nostrum quia velit aliquam vel amet minima est. Consequuntur et magni omnis quidem.",
 	"title": "Incredible Frozen Soap",
@@ -57354,11 +55344,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Dolor optio impedit nulla dolorum eius neque. Voluptatem quae sint et eveniet. Autem quam ducimus pariatur.",
 	"title": "Intelligent Fresh Ball",
@@ -57542,11 +55527,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Et nobis sint qui doloremque aut. Reprehenderit ea ratione. Sequi sed recusandae fuga aut. Magni voluptates at optio ut nostrum molestiae. Rem dolor sit. Et sit quis et.",
 	"title": "Sleek Granite Chips",
@@ -57701,11 +55681,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Dolor deserunt iure rerum. Similique harum quis ut et explicabo recusandae quasi cumque. Laborum reprehenderit ad dolore qui voluptate recusandae. Atque omnis neque sunt unde aut ea. Esse quas quia quia voluptas et quo et. Sapiente assumenda enim.",
 	"title": "Generic Cotton Bacon",
@@ -57802,11 +55777,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Dolorem corporis dicta qui velit nostrum aut voluptatem qui. Ut qui mollitia sunt omnis sunt voluptatem quasi. Asperiores et repudiandae dolores autem aut natus. Odit mollitia nesciunt et rerum eius quae ea.",
 	"title": "Gorgeous Fresh Bacon",
@@ -57932,11 +55902,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Tempora sit dolorem voluptatem blanditiis fugit. Aut consequatur corrupti voluptatum et. Corrupti quia ipsum eaque ut illum eius praesentium et. Dolor odio molestiae aut asperiores voluptatum et velit et. Nemo nisi ad velit provident maxime quia libero.",
 	"title": "Tasty Cotton Pizza",
@@ -58062,11 +56027,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Ipsa ipsa voluptatem voluptatem. Aut doloribus omnis dolor. Provident nihil harum fugiat voluptatibus. Sint aut neque eos facilis quisquam animi.",
 	"title": "Unbranded Concrete Ball",
@@ -58192,11 +56152,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Occaecati quis hic voluptatem et harum nemo suscipit corrupti. Possimus tempora soluta deserunt itaque possimus et. Doloremque sit ullam unde aut unde error magnam commodi iure.",
 	"title": "Refined Frozen Mouse",
@@ -58380,11 +56335,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Doloremque inventore dolor a. Suscipit officiis quis est non est qui molestiae natus quidem. Voluptas odio et unde quia consequatur eos occaecati quae.",
 	"title": "Incredible Soft Ball",
@@ -58510,11 +56460,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Non recusandae harum reiciendis quo amet. Officia voluptatem iusto. Error libero vel doloribus vero rem ut et. Et optio porro ab quisquam impedit distinctio quia iure. Et eos sit. Rerum est mollitia est eos.",
 	"title": "Handcrafted Concrete Shirt",
@@ -58640,11 +56585,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Velit delectus et voluptatum nam dolore nesciunt ex placeat. Similique minus qui quisquam. Error accusamus aperiam unde hic inventore expedita.",
 	"title": "Small Soft Gloves",
@@ -58799,11 +56739,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Est rerum vitae corporis autem quidem deserunt suscipit nisi. Aut cupiditate cum ut aspernatur. Molestiae magni ipsum assumenda a. Officia accusantium repellat velit ut voluptate voluptate in. Est ducimus fuga qui nam qui omnis ut. Quibusdam ea aut est unde incidunt praesentium laudantium qui.",
 	"title": "Rustic Granite Mouse",
@@ -58929,11 +56864,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Rem excepturi dolores. Voluptate aut nemo et saepe facere delectus molestiae iste asperiores. Amet exercitationem at eligendi eos. Error eos consequatur cumque vero atque et vero. Nostrum qui beatae tenetur delectus. Repellat maxime numquam tempore reiciendis cumque error.",
 	"title": "Incredible Plastic Bike",
@@ -59117,11 +57047,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "At ex expedita magnam debitis incidunt illum qui. Et tempore a suscipit eum debitis ratione et exercitationem. Voluptas incidunt harum aut aut dolores aspernatur mollitia omnis. Nobis sit fugit nemo et et.",
 	"title": "Refined Frozen Shoes",
@@ -59305,11 +57230,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Id ducimus porro voluptatem. Et delectus maiores et animi minima ipsum facilis illo molestiae. Aut et aspernatur corrupti non cum sed corrupti ea. Saepe debitis autem officia qui rerum illum dignissimos.",
 	"title": "Unbranded Soft Fish",
@@ -59493,11 +57413,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Soluta id unde ipsa. Et sit ea. Atque sequi sunt quos hic voluptas. Vero animi et. Magni dolor minus asperiores aut voluptatem quidem.",
 	"title": "Awesome Granite Fish",
@@ -59652,11 +57567,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Labore quo quos ipsum omnis necessitatibus voluptatem quibusdam ad. Et ut esse necessitatibus dolor dignissimos et. Ut non reiciendis dolorem a. Voluptas quo impedit cumque consequatur rerum quo pariatur fuga maiores.",
 	"title": "Gorgeous Metal Bacon",
@@ -59782,11 +57692,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Possimus vel voluptas fugiat nulla natus totam aliquam. Vitae cumque ipsum omnis id blanditiis illo tenetur deleniti ipsa. Vel molestiae ducimus et consectetur molestiae dolorum esse vero et.",
 	"title": "Handcrafted Fresh Pants",
@@ -59970,11 +57875,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Consequatur qui dolore nam atque velit et dicta ut harum. Est itaque consequuntur deleniti delectus sunt qui molestiae doloribus. Repudiandae quidem pariatur amet ea culpa neque. Veniam corrupti pariatur sint illo vitae dicta quod. Labore qui illo quisquam corrupti porro tempore aut aut.",
 	"title": "Rustic Granite Chair",
@@ -60071,11 +57971,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Illum sequi pariatur. Rerum culpa eos voluptas iusto dolor sit. Sequi nobis vitae repudiandae nihil qui ipsum animi quaerat et. Tempore repellat laboriosam. Sit est quia fugit repudiandae. Hic id sint rerum sint laboriosam adipisci quo.",
 	"title": "Ergonomic Rubber Pants",
@@ -60172,11 +58067,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Sed est ut at ut eum. Sed aut similique rerum. Voluptatem rerum sunt omnis quo laudantium in optio beatae voluptas. Ipsam rem optio ut eum ducimus quasi animi ut rerum. Vitae repudiandae est.",
 	"title": "Tasty Steel Fish",
@@ -60273,11 +58163,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Voluptatibus porro sed numquam explicabo eligendi. Commodi consequatur nulla et eum eius ullam esse amet nostrum. Mollitia excepturi non totam deleniti vero. Sit consequatur corrupti corrupti ratione est consequatur consequatur. Suscipit fugiat sit beatae omnis similique non nulla.",
 	"title": "Gorgeous Cotton Car",
@@ -60374,11 +58259,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Consequuntur non quibusdam unde sed. Sed et voluptas molestiae et. Qui illo ab excepturi nostrum magni aut. In non neque laudantium soluta eos quia.",
 	"title": "Practical Metal Pants",
@@ -60562,11 +58442,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Sed commodi dolor tempore aut vel ab. Fugiat amet dolores minus. Amet harum distinctio minus repellat iste sit consequatur dolor. Repellendus minima a et consequatur iure quia vitae nihil quia. In nihil iusto cumque est quis.",
 	"title": "Ergonomic Wooden Pizza",
@@ -60750,11 +58625,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Eos qui architecto temporibus. Voluptatibus placeat commodi sed et ratione repellat voluptatibus et soluta. Tempora dolorem in. Nihil distinctio sint omnis et saepe quia modi. Eos doloribus laboriosam minima alias est laborum soluta est. Aut beatae eum molestiae aut doloremque est adipisci excepturi.",
 	"title": "Incredible Wooden Keyboard",
@@ -60938,11 +58808,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Ducimus placeat iste illum hic hic iusto doloribus repellendus iusto. Consequuntur quaerat vero impedit. Maiores voluptatibus quas quia cumque ea omnis.",
 	"title": "Awesome Frozen Fish",
@@ -61126,11 +58991,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Mollitia aliquam et aut. Adipisci voluptatibus odio voluptatem blanditiis aliquid repudiandae suscipit. Autem in iure consequatur consequuntur et quia sequi eos et. At vero occaecati officia ipsam. Nobis incidunt veritatis numquam.",
 	"title": "Gorgeous Metal Sausages",
@@ -61227,11 +59087,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Incidunt eligendi quod rerum qui omnis dolore. Consequatur dolore optio laboriosam accusantium eaque. Suscipit labore repellat minima.",
 	"title": "Licensed Metal Pants",
@@ -61328,11 +59183,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Mollitia quasi voluptatem dolores qui. Iusto maiores molestiae. In perferendis corporis. Totam quo doloribus ut quam. Ea minima natus neque eius reprehenderit maiores. Sint hic reiciendis qui neque ad ratione.",
 	"title": "Refined Concrete Tuna",
@@ -61516,11 +59366,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Tempora aperiam cum voluptatibus atque cumque blanditiis eum sequi quasi. Non at provident quod dolor necessitatibus non. In velit iusto. Voluptatem rem quae illum pariatur voluptas a consectetur debitis.",
 	"title": "Small Soft Bacon",
@@ -61646,11 +59491,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Asperiores rem et ut mollitia autem. Sint ea dignissimos quo nulla nihil. Nihil rerum error. Et quia ipsam nisi. Dolore et in voluptatem quod qui. Fuga earum consectetur saepe autem voluptas consequatur fugiat reprehenderit rerum.",
 	"title": "Licensed Frozen Fish",
@@ -61776,11 +59616,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Enim ex quia sed consequatur. Aut repudiandae ut molestiae. Aut et molestiae provident voluptatem.",
 	"title": "Awesome Cotton Gloves",
@@ -61877,11 +59712,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Odit quia possimus inventore magnam non. Labore odit praesentium eveniet quisquam vero illo ut vero. Qui quia recusandae enim iure qui culpa enim. Veniam totam cupiditate magnam. Natus dolores aut nostrum earum et corrupti enim.",
 	"title": "Incredible Wooden Towels",
@@ -62065,11 +59895,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Molestiae eos accusamus libero vitae ullam. Eum saepe consequatur minima id est sed. Ut cum nobis voluptas tempora sint dolorem sapiente. Et a velit necessitatibus. Fuga ea eligendi omnis eveniet error ut illum beatae nihil.",
 	"title": "Small Rubber Ball",
@@ -62166,11 +59991,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Aut officia enim quos repellat explicabo. Explicabo at eum aut veniam qui quasi qui. Earum sit quas at dignissimos amet.",
 	"title": "Ergonomic Frozen Pants",
@@ -62267,11 +60087,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Pariatur facilis et. Odit deserunt voluptas. Dicta qui dignissimos. Suscipit similique non dolores ipsa animi aspernatur ut.",
 	"title": "Rustic Plastic Car",
@@ -62368,11 +60183,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Placeat velit laboriosam quo et soluta. Eos qui commodi error natus architecto. Fugiat qui esse provident corporis assumenda excepturi in. Non quia voluptatum temporibus tempore fuga voluptatum soluta.",
 	"title": "Tasty Wooden Table",
@@ -62498,11 +60308,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Reiciendis et assumenda ut. Et eveniet officia vel rem cumque quo aut ipsa ducimus. Totam sunt et vel voluptas sint deleniti ab vel harum. Suscipit veritatis fugiat fuga voluptas esse quasi iste minus. Quia qui aliquid consequatur culpa ea incidunt recusandae quos quaerat.",
 	"title": "Handcrafted Frozen Soap",
@@ -62686,11 +60491,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Maxime cum tenetur illum. Dolor et omnis est necessitatibus sint consequatur. Velit aspernatur ea officia laborum sequi sed laborum. Ut id molestias recusandae et ipsa quia sunt incidunt distinctio. Aliquam natus et repudiandae totam veritatis ducimus et quos et.",
 	"title": "Handmade Granite Hat",
@@ -62874,11 +60674,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Suscipit et dicta architecto maxime ut rerum rerum ullam minima. Provident sint ut aut praesentium. Voluptatem impedit facere officia et totam beatae officiis. Facilis quo temporibus rerum similique. Veniam quas rerum id. Quae sed eligendi sunt temporibus.",
 	"title": "Intelligent Wooden Shoes",
@@ -63033,11 +60828,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Tempora asperiores magni ut aut possimus ea accusantium ducimus id. Id ipsam consequuntur maxime incidunt tenetur perferendis. Omnis enim eligendi autem itaque rerum nobis sunt sint. Cumque vero provident sint veritatis distinctio sequi sit.",
 	"title": "Ergonomic Granite Salad",
@@ -63163,11 +60953,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Sit quia exercitationem ut. Iste cum iste laboriosam soluta id. Sed quaerat porro repudiandae sed.",
 	"title": "Licensed Rubber Fish",
@@ -63293,11 +61078,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "In ea cupiditate. Eos mollitia ut veritatis. Quis mollitia et necessitatibus temporibus ut omnis quaerat aut dignissimos. Nihil eveniet eius voluptatem.",
 	"title": "Refined Wooden Shoes",
@@ -63423,11 +61203,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Sed non non voluptatum perferendis est nulla. Assumenda voluptatem est neque minus placeat maxime ut aut exercitationem. Nostrum odit est deleniti consequatur non occaecati vel. Officiis rem et accusamus quam voluptatibus. Consequatur eaque quibusdam quia blanditiis.",
 	"title": "Handcrafted Granite Tuna",
@@ -63582,11 +61357,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Veniam aliquid quisquam quas ut. Tenetur dignissimos explicabo ea. Iusto ducimus dolore quae est veritatis ut. Voluptatem quae laudantium.",
 	"title": "Ergonomic Soft Cheese",
@@ -63770,11 +61540,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Autem possimus praesentium dolor harum aut ad corrupti ea. Officiis et sit occaecati saepe nulla dicta consequatur nostrum ut. Ipsam et veniam tempora hic veritatis sit repudiandae.",
 	"title": "Ergonomic Cotton Gloves",
@@ -63929,11 +61694,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Et sit sint quo ipsa. Maiores deleniti cum reprehenderit neque soluta et. Est quos eveniet. Atque ipsum aut error dolorem magni ut. Rerum maxime quia accusantium.",
 	"title": "Tasty Granite Bike",
@@ -64030,11 +61790,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Doloremque vel et labore non dolorum voluptas quas velit. Alias molestias non excepturi. Ut saepe incidunt aliquid velit saepe veritatis aut. Libero consequatur est enim et.",
 	"title": "Rustic Plastic Soap",
@@ -64189,11 +61944,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Consequatur facere quasi et. Nam tempora quia at fugit. Neque ab culpa quo. Sit molestiae quo et corporis natus nobis. Et minima earum consequatur provident nihil. Neque quam dolor molestias eum ipsum hic maxime asperiores.",
 	"title": "Gorgeous Frozen Hat",
@@ -64377,11 +62127,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Illo odit cupiditate quibusdam sed et cumque dolorum dolores. Harum ut rem architecto omnis aut nobis occaecati dolorum voluptas. Impedit et consequatur ut. Sunt minima dolorem ut porro dolorum illum quae. Libero aut tempore consectetur debitis suscipit est pariatur consequuntur.",
 	"title": "Fantastic Steel Keyboard",
@@ -64507,11 +62252,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Eos doloremque a voluptatum. Ipsam eos saepe accusamus molestias reiciendis. Esse molestiae sequi id tenetur accusantium. Dolorum rerum pariatur eum sint quaerat.",
 	"title": "Tasty Fresh Fish",
@@ -64695,11 +62435,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Qui hic necessitatibus beatae. Dolor rem tempore eos aut hic cum nisi deleniti. Cum omnis quia voluptatibus ullam corrupti aut iure est. Fugit perferendis vero iusto voluptate ea.",
 	"title": "Handcrafted Rubber Chicken",
@@ -64854,11 +62589,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Voluptas sint voluptatem excepturi vero eius enim. Quia laboriosam modi qui mollitia voluptatem deserunt debitis non. Neque saepe non occaecati odio dolores inventore. Neque in officiis amet voluptatum in.",
 	"title": "Tasty Plastic Pizza",
@@ -64955,11 +62685,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Labore neque ipsa in et facere omnis. Vel reiciendis maiores optio sed aut aut illum. Enim fugiat quaerat ut nam tempora ut. Qui aut reprehenderit eum corporis consequatur perspiciatis voluptatibus dolores vitae. Est accusantium corrupti illo fugit et est possimus est temporibus.",
 	"title": "Small Plastic Chair",
@@ -65085,11 +62810,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Atque sequi est assumenda. Id a molestias et quia eligendi laboriosam voluptas sed et. Nihil illum eveniet beatae. Ad eos fugit in consectetur iste velit est doloremque ad.",
 	"title": "Small Rubber Computer",
@@ -65215,11 +62935,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Omnis voluptatem cum vel autem repellendus qui numquam commodi esse. Et odio magni. Vel cum enim et. Voluptas at ut quos sunt distinctio qui error nulla aliquid. Nobis et quaerat et autem itaque aliquam illo. Sit ea fugit et id ut veritatis quisquam sunt.",
 	"title": "Fantastic Granite Salad",
@@ -65374,11 +63089,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Aliquid reiciendis et qui sit aspernatur sed facilis. Qui est consequatur perspiciatis aut possimus maiores voluptas. Amet quas et qui totam ut officia labore. Velit expedita nam. Deleniti hic vitae voluptatem sed sunt quia.",
 	"title": "Intelligent Plastic Bacon",
@@ -65562,11 +63272,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Voluptas ea dicta itaque. Tempora quia sit id perspiciatis vitae. Et laboriosam voluptate iste. Non et voluptatibus eum officiis doloribus neque quisquam. Deserunt enim id temporibus ipsam neque fugit. Mollitia vero repudiandae placeat ducimus ipsa voluptatem et.",
 	"title": "Refined Plastic Ball",
@@ -65750,11 +63455,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Tempora ab magni magni eos velit ad possimus magnam eos. Nobis a eum excepturi quis velit atque saepe doloremque id. Dolorem tenetur vitae sunt nemo est. Nihil unde excepturi.",
 	"title": "Licensed Steel Chair",
@@ -65938,11 +63638,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Ipsum est commodi. Culpa perferendis molestias. Architecto ut voluptas sunt natus ut qui. Est dolorem doloribus ad qui et.",
 	"title": "Licensed Frozen Keyboard",
@@ -66068,11 +63763,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Dolor eaque aut aut dolorum qui. Eius maiores dolore dolorem voluptatem nam. Perspiciatis non minus officia laudantium ut autem adipisci voluptatibus eveniet. Iure unde est ut quod quas temporibus est reiciendis. Magni labore accusamus et. Est quo repellendus excepturi labore dolorem pariatur.",
 	"title": "Licensed Fresh Shoes",
@@ -66256,11 +63946,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Doloribus dolorem inventore aut possimus aut tempora ipsam et fugiat. Distinctio quidem sequi et corporis vel nihil rerum quis itaque. Et aut laborum sed sapiente sapiente corporis.",
 	"title": "Practical Wooden Mouse",
@@ -66357,11 +64042,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Iure qui optio dolor dolorem rerum tenetur est ea. Omnis quasi illum earum corporis non autem et accusamus. Quis quidem sit voluptatum harum explicabo aut aut.",
 	"title": "Ergonomic Cotton Salad",
@@ -66487,11 +64167,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Et eum illum quia. Facere omnis hic. Qui quo consequatur excepturi quo a enim accusantium. Et delectus quia veniam est hic consequatur doloremque soluta. Dolorum ratione dolorem earum doloribus libero culpa est esse voluptas. Nobis quis tempore veniam facere quod ipsum enim.",
 	"title": "Handcrafted Steel Tuna",
@@ -66617,11 +64292,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Rerum ut laboriosam pariatur et. Omnis quidem pariatur quasi sed. Omnis voluptatem eos optio et dicta tenetur et. Dolores et alias cum nemo in minus consequatur asperiores. Dolorem libero quia quaerat et. Et vitae qui.",
 	"title": "Tasty Wooden Mouse",
@@ -66776,11 +64446,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Architecto eos voluptatem adipisci quis eius. Nostrum eos quia praesentium. Iste quis reiciendis ut dignissimos. Nesciunt amet vel et ipsa explicabo sunt fugit sit quia. Ratione repudiandae maxime. Similique quia assumenda eveniet saepe rerum ut non.",
 	"title": "Licensed Steel Hat",
@@ -66935,11 +64600,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Laboriosam eum quo quia quas sint. Ab ex nesciunt ut exercitationem voluptas aut quo blanditiis. Reprehenderit veritatis at.",
 	"title": "Unbranded Fresh Chicken",
@@ -67065,11 +64725,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Esse ipsam inventore tempora porro voluptatem temporibus tenetur ut tempora. Velit aut ea voluptatum labore accusamus voluptate ea. Quod sapiente est quasi et voluptas iusto non perspiciatis. Similique error velit tempore ut. Doloremque assumenda aut unde eveniet. Maxime ad voluptatibus sint labore.",
 	"title": "Practical Frozen Chicken",
@@ -67253,11 +64908,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Excepturi nam eum est fugit. Dicta et tempore iusto labore sit soluta. Dolores ullam et optio distinctio ea quia dolorem in dolorem.",
 	"title": "Tasty Frozen Keyboard",
@@ -67441,11 +65091,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Voluptates nemo aut quaerat harum ut quos esse unde. Vitae laboriosam hic corporis ducimus autem sit ut. Est repellat dolores quis quis ut aut quo.",
 	"title": "Incredible Metal Pizza",
@@ -67571,11 +65216,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Qui ratione eos totam quo consequuntur recusandae. Amet alias quidem ipsum modi doloribus. Aliquam adipisci voluptatum asperiores odio eligendi ipsum consequatur architecto. Aut rerum nesciunt.",
 	"title": "Handcrafted Concrete Computer",
@@ -67672,11 +65312,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Ut vel minus laudantium qui et repellendus aut minima consectetur. Voluptatum ab et. Rem architecto esse quo accusamus magnam voluptatem deleniti.",
 	"title": "Unbranded Frozen Chicken",
@@ -67802,11 +65437,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Natus amet enim nobis dolores et est distinctio aut. Iure voluptatem officiis ipsum quod illo explicabo laudantium voluptatem quas. Aut similique voluptatum rerum dolorem aut placeat quam quas.",
 	"title": "Intelligent Concrete Chips",
@@ -67932,11 +65562,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Expedita velit blanditiis repellendus sit rerum odit numquam. Non qui odio quia et est eaque et. Omnis nemo est dolorem aliquid aut aut nemo. Qui explicabo reprehenderit eaque ipsam.",
 	"title": "Licensed Metal Tuna",
@@ -68091,11 +65716,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Quasi molestias quia pariatur aut. Rem ad voluptas corporis laboriosam temporibus non autem dolorem tempore. Dicta necessitatibus id libero dolor eum illum natus quia eos.",
 	"title": "Unbranded Rubber Chips",
@@ -68221,11 +65841,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Voluptatem molestiae aut ut consectetur. Sint ducimus tempore adipisci velit et error harum ipsa labore. Aliquid vitae placeat neque praesentium. Voluptas dolores laboriosam et inventore debitis et dolores et. Nostrum a praesentium sint quasi dolores quae id et quas. At natus aperiam dolorem.",
 	"title": "Intelligent Soft Chicken",
@@ -68351,11 +65966,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Cum est voluptas. Placeat delectus cumque nostrum alias cupiditate explicabo dignissimos. Veniam quam eum adipisci sunt blanditiis quae voluptas. Impedit quia sint et pariatur corrupti. Quasi aut autem. Nihil quod totam nemo sapiente.",
 	"title": "Awesome Fresh Shirt",
@@ -68539,11 +66149,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Veritatis repellat labore. Iure enim impedit asperiores ullam quia consequatur ut. Ut esse molestiae. Assumenda vero et saepe consequatur earum labore non nulla. Quis minima hic et. Quod eaque soluta sed et.",
 	"title": "Handmade Wooden Hat",
@@ -68698,11 +66303,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Sit accusamus aperiam quis eos doloribus pariatur beatae omnis quo. Reprehenderit labore nesciunt. Ipsa esse laborum excepturi expedita rerum.",
 	"title": "Awesome Granite Keyboard",
@@ -68857,11 +66457,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Non placeat voluptatum aliquid ea et tenetur. Similique aut nostrum aut harum recusandae fugiat. Ullam alias quia. Praesentium quos repellendus dignissimos cupiditate nisi dignissimos nihil voluptatem.",
 	"title": "Unbranded Frozen Cheese",
@@ -69016,11 +66611,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Nemo dignissimos accusamus error corrupti consequatur autem est eveniet. Vel vero est nisi nihil repellendus. Accusantium veniam eos. Enim animi soluta.",
 	"title": "Generic Rubber Tuna",
@@ -69117,11 +66707,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Nobis ratione soluta ut autem quaerat modi dolorum. Voluptatem ullam aliquam. Harum nesciunt aut. Quis ab et veniam commodi. Itaque perspiciatis enim non accusantium odit voluptas. Qui magni omnis aut molestias qui iste voluptas natus.",
 	"title": "Gorgeous Concrete Mouse",
@@ -69247,11 +66832,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Est eos nihil rerum ipsa soluta. Voluptate labore aliquid quia assumenda. Quos voluptatem minus et impedit consequatur inventore. Impedit dolorum quae ad animi laboriosam aspernatur quo maiores.",
 	"title": "Unbranded Soft Fish",
@@ -69406,11 +66986,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Quas dolores iusto optio reiciendis aperiam officiis velit velit similique. Quo ullam culpa culpa aspernatur est eos aut assumenda. Atque est libero quibusdam asperiores provident. Atque labore magni ut dolores dolores. Vitae est quia mollitia delectus reiciendis recusandae repudiandae et. Debitis illo blanditiis.",
 	"title": "Generic Metal Tuna",
@@ -69594,11 +67169,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Neque nesciunt ut eum pariatur at libero. Aut corrupti nobis eligendi unde eum adipisci ipsum placeat facere. Suscipit nam earum enim qui vel quisquam consequatur eos molestias. Eius consequatur repellat aspernatur et voluptas id beatae suscipit.",
 	"title": "Generic Steel Cheese",
@@ -69724,11 +67294,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Eveniet explicabo ab ipsum fuga. Sit quidem consequatur accusamus aut est voluptas nostrum. Esse architecto architecto minima voluptatem blanditiis. Similique error consectetur molestiae voluptas delectus asperiores. Ut velit nemo. Dolores in et voluptas cupiditate aut eos.",
 	"title": "Refined Rubber Ball",
@@ -69883,11 +67448,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Aut saepe enim dicta quia suscipit iure nobis animi omnis. Est ut non et ut. Nobis omnis omnis sed nulla laboriosam placeat. Fuga doloremque in dolorum vero dolor fuga.",
 	"title": "Sleek Granite Cheese",
@@ -70042,11 +67602,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Hic dolor earum. Id voluptate quasi. Aut laborum expedita distinctio nulla iure modi autem. Occaecati tempore totam blanditiis ipsam. Iste velit sit voluptates consequuntur aut dignissimos nesciunt ratione. Architecto et vel ratione in laudantium tenetur ut rerum.",
 	"title": "Handcrafted Concrete Towels",
@@ -70172,11 +67727,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Atque aspernatur eos incidunt porro et vitae eum. Dolores ad aut sint quo temporibus neque quos. Sequi reprehenderit quo sed expedita qui nesciunt corporis. Quis et similique id debitis consequatur dignissimos architecto laboriosam assumenda. Sed aspernatur recusandae maxime laudantium dolorum deleniti et commodi. Dolorem magnam quis vitae laudantium sed eius quasi.",
 	"title": "Practical Steel Pants",
@@ -70302,11 +67852,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Molestiae qui molestiae quos. Et aliquid explicabo. Voluptatem dignissimos aut modi aliquid ut a officiis.",
 	"title": "Generic Plastic Chicken",
@@ -70432,11 +67977,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Ratione ab error explicabo. Labore dolore corporis est quia. Assumenda occaecati tempore ab et eos minima quia. Placeat incidunt asperiores beatae et quidem explicabo sed nobis. Aut magni sed. Quasi ut aut et facere omnis quibusdam repudiandae.",
 	"title": "Incredible Granite Salad",
@@ -70591,11 +68131,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Fuga accusantium sequi sit. Minus adipisci labore eius ullam ullam tenetur ad omnis et. Corrupti omnis quis sed sunt facere ea.",
 	"title": "Unbranded Frozen Table",
@@ -70692,11 +68227,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Tempora nam ex natus eos aut aut. Et quod aspernatur commodi ut quia quidem sunt. Fugit voluptas blanditiis exercitationem error dolorum. Odio qui voluptas reprehenderit et ut nemo molestias voluptatum. Officiis velit distinctio voluptatibus nesciunt totam ducimus voluptate. Sit repellendus quam sint quis officiis.",
 	"title": "Rustic Frozen Bacon",
@@ -70793,11 +68323,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Sit necessitatibus architecto sint totam quia sed dolor expedita veniam. Qui accusantium pariatur id qui molestiae perferendis consequatur eaque et. Consequatur rerum unde.",
 	"title": "Gorgeous Soft Chips",
@@ -70923,11 +68448,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Quisquam nostrum consequuntur quae sint ipsa voluptas optio sed quia. Laborum quo blanditiis voluptate id officiis quis. Exercitationem asperiores quae qui unde sed fugiat officia consectetur reprehenderit. Rerum fuga qui qui eum. Est sapiente repellat voluptatem eaque occaecati.",
 	"title": "Awesome Rubber Soap",
@@ -71024,11 +68544,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Delectus impedit excepturi aut natus similique hic sunt delectus dolor. Assumenda a quidem et porro. Officia aspernatur voluptatum beatae molestiae delectus fugit dicta labore necessitatibus.",
 	"title": "Practical Granite Chair",
@@ -71154,11 +68669,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Nisi sit ipsa impedit excepturi quibusdam. Accusamus quis voluptatem nihil quia libero iusto et. Sint at voluptas nihil distinctio. Qui voluptatum quia natus fuga sunt rerum ut nihil consequatur. Possimus possimus nemo.",
 	"title": "Sleek Rubber Chair",
@@ -71342,11 +68852,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Doloremque neque fugiat ab deleniti totam. Sit vitae inventore maiores. Distinctio dolores pariatur quia consectetur delectus.",
 	"title": "Refined Frozen Shoes",
@@ -71472,11 +68977,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Autem deserunt molestiae. Perferendis vel facere provident reiciendis et ratione et laborum. Magni quos rerum non id voluptate. Nobis eius aut nam consequatur animi. Placeat excepturi a aut architecto iusto consequatur tempora sint id. Et asperiores aspernatur reprehenderit vitae rerum sint.",
 	"title": "Unbranded Granite Gloves",
@@ -71631,11 +69131,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Excepturi cum sed labore velit est consectetur. Mollitia repudiandae tenetur aut consectetur atque molestias in velit. Repellat nesciunt maxime ipsa nam inventore illo qui. Voluptas quos culpa voluptas deleniti eum sunt. Sint voluptas consequatur nam ullam quas officiis est neque dolore.",
 	"title": "Handmade Concrete Cheese",
@@ -71819,11 +69314,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Sed atque quisquam soluta amet consequatur ut modi est. Eos explicabo consequatur voluptas. Soluta eum dolorem reprehenderit sunt vitae earum id. Nihil aliquam consequatur earum nostrum eligendi esse necessitatibus enim.",
 	"title": "Licensed Plastic Pants",
@@ -71978,11 +69468,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Dolores numquam sit voluptas dignissimos beatae autem enim cupiditate. Voluptates consequatur modi quas velit ut dolore autem saepe. Ea laudantium quam mollitia impedit tempore. Id rerum esse nulla voluptatibus. Molestiae veritatis quod ducimus aut distinctio et numquam.",
 	"title": "Incredible Granite Cheese",
@@ -72079,11 +69564,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Excepturi doloribus sed praesentium quam facere est officiis quis qui. Molestiae quibusdam non assumenda velit nemo a blanditiis ab. Nisi sed dicta. Deserunt consequatur illo consectetur ut. Excepturi laborum cupiditate explicabo hic soluta vel in doloremque. Libero voluptas nesciunt voluptas necessitatibus ut perferendis.",
 	"title": "Handmade Steel Hat",
@@ -72267,11 +69747,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Harum illum numquam. Earum explicabo modi consequatur vitae impedit facere ducimus rerum dignissimos. Vel nisi voluptatem ut laborum minima. Quasi saepe doloremque exercitationem in doloremque consequatur ipsa sit.",
 	"title": "Intelligent Metal Bike",
@@ -72397,11 +69872,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Commodi atque corrupti eius vitae aut. In incidunt impedit nulla dicta totam sint recusandae dolorum. Officiis aut animi aut. Aut impedit enim velit eaque eveniet ex. Sint corporis consequatur ut. Assumenda eligendi ratione laborum voluptas eligendi voluptates.",
 	"title": "Licensed Cotton Hat",
@@ -72585,11 +70055,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Tenetur voluptatem veritatis est consequatur qui. Illum earum temporibus aut exercitationem omnis quaerat. In eos odio vel maiores repellat ea inventore. Quia ut similique.",
 	"title": "Intelligent Soft Computer",
@@ -72715,11 +70180,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Quibusdam dolor cupiditate odio ratione. Sunt quia placeat aut. Et beatae iusto ex. Exercitationem et perspiciatis amet. Velit fugit sit.",
 	"title": "Generic Frozen Towels",
@@ -72874,11 +70334,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Assumenda quidem unde fugit porro et eos sunt sequi et. Est repellat hic fugiat id delectus voluptatibus esse ducimus. Repudiandae consequatur ea eveniet quo iure est a. Quo nihil dolores voluptatibus. Molestiae sit cumque ipsum eos optio ut.",
 	"title": "Generic Plastic Gloves",
@@ -73033,11 +70488,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Iusto cum voluptatem et qui. Dolorum natus rem sapiente vel earum dolorem tempore similique modi. Voluptatum nihil nihil labore. Ipsam earum nisi eaque. Necessitatibus praesentium omnis totam molestiae qui rerum velit.",
 	"title": "Licensed Cotton Cheese",
@@ -73163,11 +70613,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Deserunt quisquam culpa tempora sint eveniet quo. Quia aspernatur reiciendis dolore sunt quisquam. Est dolor deserunt non et ut consequatur. Aut quas non ullam molestias. Et eveniet consequatur nihil excepturi.",
 	"title": "Rustic Frozen Pants",
@@ -73264,11 +70709,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Voluptatem voluptatem doloribus. Qui maxime harum tempora molestias. Doloribus qui expedita ipsam quasi iste nostrum quo et sapiente. Earum pariatur animi minima id et.",
 	"title": "Handmade Soft Towels",
@@ -73452,11 +70892,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Beatae sunt ea. Odit sit qui sunt consequatur quaerat tempore qui qui quo. Sit sit sit ut eveniet voluptas incidunt in. Quaerat debitis reiciendis. Sunt doloremque molestiae totam aut ea repudiandae nulla non non. Incidunt enim sed eum ipsum debitis eos officia quod.",
 	"title": "Rustic Plastic Pizza",
@@ -73611,11 +71046,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Sunt amet aut fugiat. Voluptatem ipsa repellendus. Dignissimos quas pariatur. Eligendi repellendus asperiores porro ut ea dolorem labore in molestias. Voluptatibus repudiandae inventore.",
 	"title": "Intelligent Fresh Computer",
@@ -73799,11 +71229,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Molestias molestias fugit iste placeat facere impedit excepturi ut sed. Vitae iusto aut explicabo libero quia voluptatem ex omnis commodi. Laborum recusandae amet corrupti sint enim eos animi dolorem quos. Libero deleniti est. Quisquam magnam ut necessitatibus quis non ut quia sit.",
 	"title": "Generic Metal Chair",
@@ -73958,11 +71383,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Voluptates ut autem totam ratione. Voluptas perferendis voluptate libero est nobis porro ut eos. Voluptatem enim voluptas aut enim ut qui officiis sapiente.",
 	"title": "Awesome Metal Shoes",
@@ -74146,11 +71566,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Omnis qui quidem expedita ratione soluta. Voluptas nemo minus. Tempora voluptatum mollitia debitis nam provident soluta cupiditate. Et quos tenetur est. Dolor debitis tempora sit. Et facere commodi sed iste voluptas ut et in.",
 	"title": "Gorgeous Wooden Car",
@@ -74247,11 +71662,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Corporis et est corrupti temporibus enim consequatur recusandae aut. Id aperiam soluta quis dolorem aliquam magnam. Molestiae aliquam corporis.",
 	"title": "Rustic Fresh Computer",
@@ -74406,11 +71816,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Voluptas repellendus vero occaecati ut est porro eum est. Ut iste quo et est commodi voluptates. Accusamus tenetur ea sit.",
 	"title": "Gorgeous Fresh Tuna",
@@ -74565,11 +71970,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Sed molestiae ex id. Fugiat nostrum dolor aut. Perspiciatis a voluptatem iste ratione officia explicabo consequatur autem libero. Quos natus ullam tempore sed voluptates ipsum tenetur rerum repudiandae. Qui ut possimus dolores voluptatem consequatur commodi. Consequatur voluptatem voluptatem quo.",
 	"title": "Rustic Rubber Pizza",
@@ -74724,11 +72124,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Maiores odit minus velit minima aliquid consequuntur eum ad voluptatem. Sapiente consequuntur optio. Laboriosam ullam praesentium libero et.",
 	"title": "Licensed Soft Tuna",
@@ -74854,11 +72249,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Aut consequatur repellat eaque. Voluptas et est et enim sit distinctio. Et voluptas ipsa quia dolores numquam sint. Repellat totam et quis asperiores culpa corrupti consequatur.",
 	"title": "Unbranded Frozen Bacon",
@@ -74984,11 +72374,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Ullam debitis perferendis qui rerum. Perferendis molestias amet et cumque reiciendis. Totam eos asperiores repellendus eligendi modi debitis. Ut sit eos. Nesciunt quae voluptas et.",
 	"title": "Handcrafted Plastic Ball",
@@ -75114,11 +72499,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Amet eligendi est dolores unde quia. Omnis modi ipsa quia asperiores facilis nobis ullam. Qui debitis aut officia esse excepturi praesentium. Nobis debitis eius accusantium natus placeat ut facere sunt non.",
 	"title": "Incredible Soft Salad",
@@ -75244,11 +72624,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Quia beatae laudantium corrupti est eius quia nobis reprehenderit. Nulla at quos consequuntur similique nihil dicta placeat ut. Repellat quis aut quia sunt sunt nulla nisi. Neque nesciunt optio consequatur.",
 	"title": "Practical Wooden Car",
@@ -75345,11 +72720,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Ratione dolor sit. Magni explicabo quo vero velit consequatur cum. Placeat doloribus saepe sint et rerum accusantium distinctio reiciendis nobis. Numquam magni quo consequatur quasi eaque sint.",
 	"title": "Generic Frozen Table",
@@ -75475,11 +72845,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Aspernatur optio rerum repellendus et voluptas amet alias non et. Necessitatibus quia perferendis eos placeat. Mollitia sit esse fuga eum ducimus cupiditate. Ipsum consequuntur sint ut. Quam iste nemo et consectetur. Qui et est libero praesentium delectus quidem iusto architecto aliquam.",
 	"title": "Practical Granite Mouse",
@@ -75663,11 +73028,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Eos pariatur laborum odio rem architecto. Aut beatae eligendi aut omnis eius perspiciatis sit. Dolor vero recusandae voluptatem ea voluptate aut occaecati. Quia maxime vel officia voluptas. Dicta quaerat enim accusamus temporibus. Ea id ipsum molestias.",
 	"title": "Gorgeous Granite Mouse",
@@ -75764,11 +73124,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Nihil soluta voluptates enim atque voluptates quia. Velit molestias eius rem esse doloribus quasi voluptas quos. Ut magnam vel itaque vero et et eius consequuntur dolores. Doloremque facilis nesciunt quibusdam aut culpa.",
 	"title": "Generic Steel Hat",
@@ -75865,11 +73220,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Qui sint est eveniet. Velit velit dolorem. Perspiciatis ducimus eius sapiente nobis ratione soluta.",
 	"title": "Rustic Frozen Gloves",
@@ -76024,11 +73374,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Sint ea sapiente animi nihil. Veritatis veniam corrupti. At mollitia voluptatem adipisci dolores et ea. Ut fuga et itaque sequi dicta nulla suscipit itaque et.",
 	"title": "Awesome Steel Keyboard",
@@ -76183,11 +73528,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "At quas aliquam deleniti quisquam. Sunt quaerat aliquid dolorem. Itaque reiciendis quia eius ut voluptatem amet nesciunt assumenda.",
 	"title": "Gorgeous Cotton Chips",
@@ -76342,11 +73682,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Sint non minima error sint sed mollitia nisi aperiam aut. Aspernatur nesciunt error consequatur explicabo qui blanditiis. Quibusdam tenetur accusamus et quos nostrum. Aspernatur delectus molestias impedit aut nihil non. Illo perspiciatis est libero accusantium omnis laudantium qui qui.",
 	"title": "Gorgeous Granite Shoes",
@@ -76472,11 +73807,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Velit et autem magni laboriosam. Accusamus deleniti enim aut rem. Dolorem et laborum animi id laudantium est incidunt quo eum.",
 	"title": "Intelligent Plastic Chair",
@@ -76631,11 +73961,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Porro sapiente quis et laboriosam suscipit. Dolor dolores non nulla reiciendis quo corporis vel voluptatibus. Enim sit nemo aliquam quos omnis ea. Aut sit et autem harum consequatur odio unde aut dignissimos. Non est eum laudantium.",
 	"title": "Handcrafted Steel Towels",
@@ -76732,11 +74057,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Voluptatem sit cumque sed sint quia pariatur minima voluptatum. Est molestiae suscipit. Explicabo voluptatibus voluptates expedita. Ut exercitationem eaque quis qui quibusdam nihil distinctio quisquam. Fugit deleniti facilis sequi placeat aut voluptatibus deserunt atque. Velit voluptatibus tempora saepe aliquam et.",
 	"title": "Rustic Soft Bacon",
@@ -76862,11 +74182,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Et fuga quia sunt laborum dolorem. Praesentium et earum accusamus est perspiciatis porro eos hic. Dolores aperiam ullam occaecati ut ipsa non illum.",
 	"title": "Licensed Plastic Computer",
@@ -76963,11 +74278,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Quidem est impedit aut velit repellendus et aliquid blanditiis quia. Numquam et ea est dolore consequuntur mollitia. Est in porro aliquid id repudiandae eos dolorem hic. Veniam vel aliquid sit dolore nulla. Assumenda dicta et est qui nam consequuntur necessitatibus sed nobis.",
 	"title": "Licensed Fresh Fish",
@@ -77093,11 +74403,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Omnis et expedita velit. Corrupti sit delectus aliquam vel rerum et omnis dolorum. Consequatur praesentium qui minima placeat eveniet eveniet qui magni. Exercitationem ratione voluptates. Debitis nesciunt consequatur et officiis est minima. Quis ut asperiores nam sunt sit sequi.",
 	"title": "Practical Plastic Bacon",
@@ -77194,11 +74499,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Aut vitae dicta. Optio ullam ut perspiciatis exercitationem optio. Et quae magni.",
 	"title": "Sleek Steel Sausages",
@@ -77324,11 +74624,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Qui modi quos quia. Earum ipsam accusantium. Aut ducimus impedit aut id aspernatur aliquam. Ex commodi voluptatem. Voluptatem beatae repellendus similique minus voluptatem. Sint necessitatibus dolores fugiat temporibus culpa.",
 	"title": "Awesome Metal Shoes",
@@ -77425,11 +74720,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Velit non et minus fugit aut cumque quia nam. Ut at cumque voluptate. Et qui sequi nemo facilis ipsam ut. Sequi accusamus culpa qui enim cum aut aspernatur.",
 	"title": "Incredible Steel Mouse",
@@ -77526,11 +74816,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Voluptas dolor deleniti nulla est. Est aut quisquam non. Corrupti numquam facilis eaque qui nisi totam non quasi laboriosam.",
 	"title": "Handcrafted Frozen Fish",
@@ -77714,11 +74999,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Ad eos et delectus est dolorem laborum iure. Est consequuntur ut. Quam facilis iste esse nihil. Esse blanditiis tempore facilis est aut quia. Perferendis non dicta explicabo est tempora et repudiandae expedita.",
 	"title": "Awesome Rubber Cheese",
@@ -77815,11 +75095,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Vero quo et nesciunt impedit et. Et reiciendis minima mollitia. Qui consectetur quo repudiandae et qui velit nihil voluptatem. Et vitae ad rem nostrum sunt quaerat dolorem fugiat.",
 	"title": "Sleek Frozen Chicken",
@@ -77945,11 +75220,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Magni sunt et. Modi quas molestiae blanditiis. Autem libero repellat nam assumenda quia modi. Incidunt suscipit aspernatur vel.",
 	"title": "Generic Rubber Computer",
@@ -78046,11 +75316,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Soluta molestias impedit voluptatem omnis quia ea autem adipisci porro. Laboriosam excepturi ex rerum ipsam. Voluptatum nostrum expedita. Repellendus quia consequuntur officia expedita illo nobis sequi iure atque. Sapiente aliquam iure ut.",
 	"title": "Unbranded Cotton Sausages",
@@ -78147,11 +75412,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Voluptas sunt qui voluptate sequi laborum et eius. Fugit architecto quis. Est autem consectetur quidem animi fugit aut. Saepe neque ut aut possimus rerum asperiores et perspiciatis voluptatum. Deleniti non fugit quia sed dolorem veniam voluptates ab. Est consequatur accusamus est dolorum et rem.",
 	"title": "Small Granite Keyboard",
@@ -78335,11 +75595,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Occaecati qui incidunt. Esse aut aut ut. Nisi illum velit ut voluptatum atque ipsa delectus officiis dolores. Harum est qui natus earum dolores excepturi facilis et. Dolor et id.",
 	"title": "Small Cotton Pizza",
@@ -78436,11 +75691,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Deserunt rerum omnis consequatur. Exercitationem sit harum assumenda accusantium. Non explicabo doloremque mollitia sit cum totam exercitationem error cupiditate.",
 	"title": "Fantastic Plastic Sausages",
@@ -78595,11 +75845,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Fugiat consequatur facilis debitis sit. Sed eum illo dolores pariatur occaecati sequi eos consequuntur. Perferendis sunt error. Voluptatem magnam eum. Facilis tempora repudiandae cupiditate distinctio distinctio consequuntur doloribus. Et dolore expedita saepe praesentium porro consequatur delectus illo repudiandae.",
 	"title": "Incredible Rubber Pants",
@@ -78754,11 +75999,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Quo quia cupiditate. Saepe eveniet magnam. Sunt dignissimos porro ab at blanditiis maiores. Accusamus error laudantium. Alias et quo ut voluptate eos incidunt ipsam assumenda ipsa. Provident dolorum non commodi vero dicta qui placeat laudantium debitis.",
 	"title": "Fantastic Plastic Chair",
@@ -78913,11 +76153,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Tempore dignissimos ut et cum vero. Molestiae repudiandae iusto molestiae eum incidunt. Vel quisquam officia culpa rerum deserunt iure non quasi minima. Itaque nam sit nihil sit eligendi magnam voluptatem saepe nihil.",
 	"title": "Ergonomic Steel Chair",
@@ -79072,11 +76307,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Consequatur dolores sed. Minima at iusto rerum expedita nisi voluptatibus quod. In ratione dignissimos aut rerum ea expedita reprehenderit et iste. Iste dolores voluptatem.",
 	"title": "Intelligent Cotton Chicken",
@@ -79173,11 +76403,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Saepe libero quod voluptatibus fugit voluptatem accusamus culpa. Autem omnis aspernatur. Qui ab voluptates voluptatem voluptatem magnam molestias nihil quia. Iure similique sapiente iure omnis.",
 	"title": "Incredible Concrete Fish",
@@ -79274,11 +76499,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Aut ut quis consequatur ut illo non. Culpa consequuntur id asperiores qui quia corporis. Delectus officia aut nulla perspiciatis voluptas rem ut quia delectus.",
 	"title": "Unbranded Steel Gloves",
@@ -79375,11 +76595,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Ut quod quod dolor id iure est eos officiis. Possimus aut alias et adipisci libero esse et. Et dignissimos quo ab magni sed.",
 	"title": "Gorgeous Wooden Keyboard",
@@ -79563,11 +76778,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Quo est ut in neque iste accusantium. Voluptatibus molestiae est minus excepturi. Animi ea assumenda autem perspiciatis cum repudiandae.",
 	"title": "Fantastic Fresh Fish",
@@ -79751,11 +76961,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Ullam est voluptatum vero. Distinctio velit ut. Iusto eum omnis iusto aut quidem. Id qui id sed repellendus. Assumenda adipisci id reiciendis et quia aut rerum quo. Dolorem accusamus dicta ullam dicta saepe.",
 	"title": "Awesome Cotton Towels",
@@ -79939,11 +77144,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Quisquam sed aut. Sed numquam voluptatem corporis provident sit provident ab illo ut. Dolorem iure asperiores delectus consequuntur iste ut sapiente voluptates sit. Et dicta accusantium consectetur earum dicta optio quos. Ratione nostrum provident blanditiis ut.",
 	"title": "Small Wooden Mouse",
@@ -80069,11 +77269,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Atque voluptatum nostrum possimus rem eaque dolores odio voluptatum aut. Impedit vel non. Asperiores ab quos occaecati dolor et illum similique voluptatem. Dolorum velit laudantium fuga.",
 	"title": "Unbranded Wooden Fish",
@@ -80228,11 +77423,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Autem et sint asperiores nemo earum vel. Fugiat autem modi commodi error officia. Et aut nostrum quia dolorem unde sapiente. Nemo blanditiis id et vel distinctio fuga voluptatem repudiandae consequatur. Quasi eum quam eos quisquam vel atque aliquid. Sed esse placeat veritatis suscipit molestiae dolorem.",
 	"title": "Awesome Plastic Shoes",
@@ -80416,11 +77606,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Laborum quidem non dolores. Perspiciatis distinctio soluta repudiandae quo praesentium saepe omnis aut. Sequi qui atque. Velit alias iusto sunt mollitia excepturi dolorem consequatur. Expedita aut dignissimos qui. Est beatae animi consequuntur ipsum rerum qui repudiandae.",
 	"title": "Licensed Soft Car",
@@ -80546,11 +77731,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Non quia eius delectus consequatur facere quaerat. Sint totam dolor ducimus laboriosam atque provident placeat. Doloremque maxime ab.",
 	"title": "Intelligent Frozen Shirt",
@@ -80705,11 +77885,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Doloremque at ullam ipsa possimus. Deleniti accusantium dicta qui. Repellendus et et odit consequatur nisi iusto est voluptatem. Et accusantium ut similique sapiente vitae ex.",
 	"title": "Gorgeous Wooden Computer",
@@ -80893,11 +78068,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Laborum ut quod soluta. Vel possimus deleniti. Voluptas ut omnis quae necessitatibus quaerat itaque dolor. Quia adipisci culpa labore est rerum velit nostrum eligendi.",
 	"title": "Rustic Rubber Bacon",
@@ -81023,11 +78193,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Odio tenetur facere nihil consequatur. Tempore assumenda id voluptatem non. Molestiae aliquid iure id non. Consequatur magnam cupiditate nostrum blanditiis vel.",
 	"title": "Awesome Soft Bike",
@@ -81182,11 +78347,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Quis ut omnis alias. Et alias optio recusandae aliquam nisi neque optio ipsum quia. Velit possimus aut animi facere dolore. Aut est aut nihil quaerat magnam.",
 	"title": "Ergonomic Steel Tuna",
@@ -81341,11 +78501,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Magnam dolore beatae necessitatibus porro. Sapiente fugiat nisi sed a ut dolorum quibusdam quas. Alias quisquam quod aperiam est suscipit. Dolore aut dicta.",
 	"title": "Fantastic Frozen Mouse",
@@ -81442,11 +78597,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Est asperiores molestiae quia et odit numquam eligendi voluptatem. Facere minima alias est occaecati nulla voluptas. Consequatur quaerat similique et quo ea quae. Ad reiciendis qui velit ad mollitia molestiae aut. Soluta aliquam voluptatem.",
 	"title": "Unbranded Granite Car",
@@ -81572,11 +78722,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Sapiente rerum nesciunt qui. Voluptas quas reiciendis dolor quae modi et error architecto aut. Dicta aut vel. Soluta a nemo est omnis ut ad tempore ut. Dolor aut beatae pariatur.",
 	"title": "Handcrafted Rubber Sausages",
@@ -81702,11 +78847,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Qui modi sit et. Quo perspiciatis molestias neque ducimus. Odio at autem nihil nisi et. Adipisci possimus et eum est. Explicabo voluptatem dolor aspernatur incidunt aut.",
 	"title": "Ergonomic Fresh Bacon",
@@ -81832,11 +78972,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Quis voluptates molestias eveniet ab. Iusto quisquam pariatur magnam. Voluptas qui voluptatem atque alias tempore.",
 	"title": "Awesome Plastic Pants",
@@ -81991,11 +79126,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Quae repudiandae omnis iste in dolorem voluptatem perspiciatis molestiae. Incidunt recusandae qui est vitae ea. Reprehenderit veritatis consectetur voluptatem. Distinctio corrupti consequatur aut laborum. Accusamus laudantium voluptatem.",
 	"title": "Intelligent Soft Mouse",
@@ -82179,11 +79309,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Provident et qui totam nisi consequatur laborum dolorum. Qui molestias sit corrupti ipsam. Praesentium illo velit aut voluptas voluptatem temporibus aliquid nesciunt.",
 	"title": "Rustic Plastic Soap",
@@ -82367,11 +79492,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Tenetur ut ipsam rem id accusamus commodi. Commodi quos sit itaque rerum at maxime deserunt tenetur et. Soluta at aut repellendus modi in odit suscipit rem. Quod id velit exercitationem dolor aut voluptas commodi. Et mollitia veritatis placeat suscipit expedita accusamus.",
 	"title": "Generic Wooden Bacon",
@@ -82526,11 +79646,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Provident ut in. Possimus omnis deleniti laborum veniam repellat minus eaque. Sit ea dolores. Sit quia nam repudiandae non. Et quia ex aliquam harum ratione.",
 	"title": "Unbranded Concrete Mouse",
@@ -82627,11 +79742,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Impedit fugit alias doloribus possimus quo reiciendis et quasi soluta. Et enim tempora animi aperiam quo. Nobis et fugiat excepturi autem et nemo nihil in ipsum.",
 	"title": "Generic Soft Mouse",
@@ -82757,11 +79867,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Distinctio ab assumenda iusto ut pariatur odio est. Doloribus aut consequatur. Fugiat enim et minus expedita molestiae error cumque porro. Reprehenderit sit quo natus hic est delectus nihil. Et eius quaerat error facere est vitae. Aut voluptatem quos aspernatur necessitatibus.",
 	"title": "Handcrafted Soft Chair",
@@ -82916,11 +80021,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Enim consequatur tempora corrupti quae aspernatur omnis reiciendis. Dicta officiis ab totam voluptas tempora iusto dolor voluptas qui. Enim voluptatem recusandae sit debitis voluptas et consequatur. Id sapiente earum consequatur id aut sit magni temporibus est. Suscipit libero unde temporibus reiciendis sed provident nobis impedit. Cum modi qui qui est porro voluptatem impedit.",
 	"title": "Generic Cotton Chair",
@@ -83075,11 +80175,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Ea minus eius. Quidem in quam ut sit soluta. Modi earum adipisci non velit quod voluptates quo. Iure non in saepe. Aut dolor harum id rerum voluptate.",
 	"title": "Licensed Rubber Computer",
@@ -83176,11 +80271,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Voluptas numquam sequi voluptatibus aliquam dignissimos aliquid quia suscipit similique. Ipsum voluptatibus id ut sunt dignissimos magni aut reiciendis. Ab voluptatem voluptate id rerum quos omnis. Voluptatem recusandae voluptatum cupiditate voluptatibus aliquid aut alias. Officia dolore ipsum ab commodi optio.",
 	"title": "Sleek Metal Towels",
@@ -83277,11 +80367,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Ipsam doloremque deserunt. Doloremque sed neque dicta. Et sapiente molestiae asperiores.",
 	"title": "Practical Cotton Keyboard",
@@ -83407,11 +80492,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Et mollitia incidunt excepturi nemo. Voluptate optio cumque dolores laborum voluptatem. Voluptatem quis blanditiis cupiditate voluptate laboriosam perferendis quo laudantium.",
 	"title": "Rustic Soft Gloves",
@@ -83508,11 +80588,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Perspiciatis soluta sunt ut. Quos omnis quod ab dolores perspiciatis inventore. Distinctio repellat accusantium ipsa voluptates quo et voluptatem.",
 	"title": "Gorgeous Rubber Ball",
@@ -83609,11 +80684,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Exercitationem ratione cum libero. Neque mollitia molestiae doloribus amet omnis perferendis sed quaerat perferendis. Et dolorem tempora illo enim. Sit error vel dolorem enim repellat.",
 	"title": "Tasty Metal Sausages",
@@ -83710,11 +80780,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Autem dicta qui possimus eveniet similique qui quos corporis sed. Nemo illum rerum molestiae nemo. Quis ut totam. Aut soluta recusandae animi accusamus odit et dolor.",
 	"title": "Practical Steel Bacon",
@@ -83898,11 +80963,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Dolore omnis ea consectetur rerum laudantium molestiae. Dicta perspiciatis amet quasi. Nihil a veritatis. Non tempore omnis velit. Dolore id nesciunt exercitationem illo quidem ut. Vitae possimus et voluptatum et illo.",
 	"title": "Ergonomic Rubber Cheese",
@@ -84057,11 +81117,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Odit fugit consequatur ut culpa. Ea molestiae quis alias. Sint facere ea. Quis sit quidem ullam. Sint odio impedit rerum fugit quasi optio incidunt facere.",
 	"title": "Gorgeous Plastic Table",
@@ -84187,11 +81242,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "A nam nostrum et officiis. Iure fuga occaecati temporibus eveniet incidunt ut. Error quibusdam aut doloremque eum molestiae reprehenderit delectus sit dolores. Labore totam qui a est est aliquid.",
 	"title": "Refined Rubber Chair",
@@ -84375,11 +81425,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Cupiditate aliquam earum mollitia officia. Id nam id et et alias eos. Quia odio nam. Omnis iure rerum minus sit. Exercitationem cupiditate dolorem reiciendis est exercitationem placeat labore esse. Debitis quasi iste dolore consequatur quia ea est quis consequuntur.",
 	"title": "Rustic Wooden Car",
@@ -84476,11 +81521,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Iste sunt repellendus adipisci vel maxime. Voluptate eligendi modi nobis. Eaque sit nesciunt facere nam corrupti autem provident et veniam.",
 	"title": "Gorgeous Cotton Pizza",
@@ -84635,11 +81675,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Similique veritatis similique ratione deserunt nisi iste aut dignissimos. Aut sit veritatis voluptas asperiores nam. Voluptatum porro qui eos nostrum sit commodi enim officiis consectetur. Quisquam velit accusantium nobis pariatur vel vero minus similique laborum. Nam possimus quia voluptas molestiae. Qui enim delectus.",
 	"title": "Fantastic Plastic Pants",
@@ -84765,11 +81800,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Iste aut totam cupiditate eaque illo labore nobis molestiae. Ut dolorum quibusdam adipisci qui maiores laborum dolorem. Voluptate voluptate ea voluptas consequatur et sit unde voluptas. Odit autem debitis saepe incidunt. Ex omnis id odit iusto repudiandae est.",
 	"title": "Incredible Plastic Table",
@@ -84924,11 +81954,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Velit eos voluptatibus eveniet reiciendis ad mollitia. Magni id est doloribus necessitatibus aut. Facere nihil eos explicabo adipisci id. Fuga ut sint. Qui provident eos consequatur. Iure iure ut sed sint amet quia animi.",
 	"title": "Intelligent Steel Pants",
@@ -85083,11 +82108,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Omnis ut tempore doloribus quam nihil. Expedita fuga aliquid repellendus. Aliquid iste est dolore ab esse ex.",
 	"title": "Handmade Steel Cheese",
@@ -85271,11 +82291,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Repudiandae voluptatem quis perspiciatis ad hic laudantium vitae minus. Voluptatem eum non aut voluptatibus voluptatem impedit dolorum commodi. Repellat temporibus facilis quidem assumenda sit. Possimus alias facilis corrupti quis sed hic eos. Ut praesentium sint expedita. Soluta libero quod autem aut aut quo.",
 	"title": "Rustic Frozen Chicken",
@@ -85459,11 +82474,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Eaque vitae molestias earum omnis. Placeat eum et et est possimus voluptatum. At quasi dolorem at. Molestiae id minima voluptas. Corrupti molestiae odio dolorum in hic optio.",
 	"title": "Awesome Frozen Fish",
@@ -85647,11 +82657,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Ea aperiam delectus. Odit eaque ut dolorem accusamus. Voluptate nemo ab delectus autem qui.",
 	"title": "Ergonomic Steel Chair",
@@ -85748,11 +82753,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Enim aut et vitae. Quos ad est. Distinctio sapiente atque sint natus provident ut.",
 	"title": "Handcrafted Metal Soap",
@@ -85849,11 +82849,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Cupiditate nihil et rerum. Enim repudiandae consequuntur consequuntur amet et in eaque. Amet ut animi non. Velit iste veniam voluptatum perspiciatis quidem perferendis dolorum quos voluptas. Quis neque maxime. Corrupti quae est suscipit recusandae nobis.",
 	"title": "Licensed Steel Computer",
@@ -85950,11 +82945,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Ut provident ullam nostrum praesentium. Cum dignissimos molestias quasi dolore voluptas. Nesciunt pariatur ab omnis est.",
 	"title": "Fantastic Concrete Towels",
@@ -86109,11 +83099,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Consequatur et illo ad quasi nesciunt ut. Distinctio a facilis nihil qui. Voluptatem ut in dolore reiciendis quam nesciunt cum similique et. Ut incidunt repudiandae debitis quibusdam est voluptates nobis blanditiis voluptatem. Accusantium laboriosam dolorum ipsa pariatur sequi maxime. Enim excepturi mollitia quasi sit expedita.",
 	"title": "Tasty Wooden Hat",
@@ -86210,11 +83195,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Culpa consequatur velit magni et quis dolore sint explicabo. Nesciunt dicta suscipit eum et praesentium explicabo mollitia. Quisquam dolores sit ratione sit.",
 	"title": "Awesome Wooden Pants",
@@ -86340,11 +83320,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Nesciunt deserunt et. Voluptates doloremque totam expedita id cum. Doloribus qui asperiores velit ex pariatur est et fuga aut. Voluptate quas porro eius accusantium cumque dolores voluptas aut.",
 	"title": "Refined Cotton Bacon",
@@ -86528,11 +83503,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Est et est soluta enim nobis et. Quibusdam voluptas ea. Sit optio nemo sed et quia nam sit et.",
 	"title": "Handmade Frozen Pizza",
@@ -86629,11 +83599,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Et quod neque possimus natus autem incidunt. Cum est facere. Perspiciatis commodi accusantium voluptatibus. Eum molestiae voluptatibus ea non deserunt ratione. Quam repudiandae quisquam totam quas unde deserunt vero sed molestiae.",
 	"title": "Handcrafted Steel Chair",
@@ -86759,11 +83724,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Repudiandae et omnis qui quibusdam iste error in velit dolorem. Quo eum sint facere expedita. Itaque ullam velit impedit fugiat nostrum incidunt est natus.",
 	"title": "Small Concrete Chicken",
@@ -86889,11 +83849,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Temporibus quis excepturi quia aut animi culpa. Illum unde porro iusto vitae ut id. Itaque in vero et officiis repudiandae non praesentium vel cumque.",
 	"title": "Generic Frozen Shirt",
@@ -87019,11 +83974,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Aliquam natus est id qui eum molestiae rem. Voluptatem earum sint in officiis est. Corrupti enim fuga quam qui ducimus voluptates. Architecto qui et. Consequatur et similique occaecati culpa consequatur.",
 	"title": "Ergonomic Granite Bacon",
@@ -87178,11 +84128,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Voluptatum omnis ab. Et nobis omnis quos aut modi. Quia nesciunt enim pariatur totam enim quis. Voluptas nobis rem fugiat vel et nemo. Excepturi natus quidem praesentium dignissimos animi aliquam qui qui deserunt. Eos quasi ut et recusandae dolorem corrupti.",
 	"title": "Gorgeous Plastic Tuna",
@@ -87337,11 +84282,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Ex dicta voluptatum dolorem quidem iusto cupiditate aut. Repudiandae dignissimos pariatur suscipit tenetur voluptas quia. Harum adipisci sequi labore consequatur optio et architecto placeat iste. Facere quibusdam repellendus ut.",
 	"title": "Generic Granite Chair",
@@ -87525,11 +84465,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Rerum illum minima vel quia. Ea quibusdam distinctio vitae quod nihil. Molestias quis odio magnam ut eos. Iste aut quam quae veritatis labore sit aut. Quaerat incidunt et minus non nesciunt.",
 	"title": "Small Granite Towels",
@@ -87655,11 +84590,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "A voluptatem et qui. Eum molestiae magnam excepturi eaque sunt iure. Voluptatem voluptatem provident harum quia. Ducimus explicabo a voluptatem doloribus omnis vel et repudiandae quis. Quo et distinctio consequatur doloremque praesentium quae. Deleniti corporis distinctio tenetur laborum sunt sint.",
 	"title": "Ergonomic Wooden Salad",
@@ -87785,11 +84715,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Laboriosam quis et accusantium iste debitis ex odio suscipit consequatur. Molestias odio id sapiente qui excepturi voluptates. Numquam modi laudantium minus quasi. Ex tenetur rerum est repellat.",
 	"title": "Intelligent Cotton Soap",
@@ -87973,11 +84898,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Et aperiam sint dolorum molestiae accusamus non. Temporibus dolor fugit et a et. Ea voluptates similique ab commodi. Eum magnam distinctio et vero provident. Non laudantium ducimus molestiae minima.",
 	"title": "Rustic Frozen Pizza",
@@ -88074,11 +84994,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Maxime voluptas nostrum suscipit eaque voluptas veritatis sed esse. Amet id consectetur. Expedita doloribus quos iste. Itaque libero possimus velit non architecto fugiat.",
 	"title": "Awesome Granite Keyboard",
@@ -88204,11 +85119,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Ut consequatur rerum aliquid non quod suscipit blanditiis in voluptas. Quam eius omnis excepturi dicta odit sint. Vero et voluptatem id expedita non sunt dolores minima voluptate. Expedita ea non suscipit non quis.",
 	"title": "Awesome Metal Bacon",
@@ -88392,11 +85302,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Reiciendis ut ut nemo nobis et exercitationem. Corporis ut excepturi et est. Pariatur voluptates exercitationem. Sed earum mollitia et quia rerum vel quia quia voluptatem.",
 	"title": "Handmade Concrete Chair",
@@ -88551,11 +85456,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Non quos rerum magni et quasi eius ratione quibusdam accusamus. Assumenda quisquam asperiores tempora ipsum tempora fugiat. Possimus animi ipsam possimus. Veritatis qui quia molestiae dolores tempore. A modi quas porro saepe sed voluptatem natus quia. Consequatur aut iusto.",
 	"title": "Handmade Frozen Sausages",
@@ -88681,11 +85581,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Consectetur quam consequatur sit laboriosam placeat et voluptatem laudantium modi. Blanditiis quia enim quae aliquid delectus sunt provident. Nesciunt quam ex delectus modi reiciendis asperiores. Sit corporis tenetur asperiores.",
 	"title": "Fantastic Metal Tuna",
@@ -88811,11 +85706,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Harum nobis nihil distinctio laboriosam accusantium eaque. Sed debitis dolorum rerum. Iste vero minima impedit ea non. Molestiae amet ratione et tempore atque. Maxime dolorum animi in expedita eligendi fuga rerum ut consequuntur. Qui et perferendis officiis.",
 	"title": "Awesome Fresh Pizza",
@@ -88941,11 +85831,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Aut similique tempora consequatur illo amet ratione sed. Odit magni vel itaque totam at molestiae perspiciatis vitae facilis. Facere nemo corporis et quia eius. Et expedita et ut hic similique modi sequi sunt. Aut dolor deleniti. Cupiditate quo et laboriosam quam ex nulla qui.",
 	"title": "Ergonomic Metal Car",
@@ -89129,11 +86014,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Magnam fugiat animi maxime distinctio sint assumenda. Repellendus enim necessitatibus odio. Mollitia rem autem ullam voluptas adipisci reiciendis. Corrupti illo voluptatibus et sapiente magni sed est. Sint nihil officiis. Autem quam culpa aspernatur debitis dicta beatae nostrum.",
 	"title": "Small Cotton Pants",
@@ -89288,11 +86168,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Ipsam mollitia inventore tempora quaerat. Non ad voluptas non fuga quos fuga atque sint nesciunt. Ratione assumenda numquam eos. Praesentium enim incidunt laborum.",
 	"title": "Small Soft Bacon",
@@ -89476,11 +86351,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Aut sed eligendi ut magni. Sapiente et ullam nihil sit minima atque. Tempore praesentium reprehenderit aliquid est.",
 	"title": "Ergonomic Fresh Bacon",
@@ -89606,11 +86476,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Praesentium voluptas quo tempora dolores reprehenderit. Aliquid vero veritatis quia assumenda ut. Cum eos doloremque adipisci eaque voluptas.",
 	"title": "Incredible Cotton Keyboard",
@@ -89794,11 +86659,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Tempora earum quo facere. Quia dolorum reprehenderit quia rerum. Officia quis quos. Eveniet quisquam voluptate necessitatibus consequuntur sed quia est quo. Et enim ut nesciunt illum eos dolorum.",
 	"title": "Intelligent Fresh Chair",
@@ -89924,11 +86784,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Quas suscipit eum voluptatibus reiciendis eum. Et voluptas delectus. Deserunt itaque ut cum laborum.",
 	"title": "Licensed Cotton Gloves",
@@ -90112,11 +86967,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Vero aut ut placeat sunt. Atque exercitationem rerum provident quia distinctio qui est aliquid cumque. Debitis aspernatur recusandae numquam sit. Similique saepe dolor dolores. Assumenda expedita quidem molestias necessitatibus voluptas nulla porro distinctio. Voluptatem non esse ut non.",
 	"title": "Gorgeous Frozen Mouse",
@@ -90242,11 +87092,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Officiis voluptas eaque ab ut. Laborum explicabo nam nobis occaecati et. Similique aut et praesentium recusandae omnis reprehenderit.",
 	"title": "Incredible Wooden Mouse",
@@ -90343,11 +87188,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Dolorem eos sit corrupti. Ipsa eos nam necessitatibus dolor sint eos. Et sit consequatur dolore aspernatur perferendis sequi.",
 	"title": "Incredible Granite Pants",
@@ -90444,11 +87284,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Similique inventore omnis minus autem placeat. Quo voluptate consequatur nisi sit et saepe maxime pariatur ad. Quas vel molestiae earum dolores.",
 	"title": "Unbranded Rubber Chair",
@@ -90545,11 +87380,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Esse qui similique sequi expedita. Quibusdam voluptatem quam sed facilis voluptatem doloribus officiis eos sit. Tempora quo quos veniam voluptate atque nisi. Necessitatibus repellendus nihil dolorem adipisci illum voluptatem consequatur voluptatem. Et quisquam et qui quia tempore voluptas molestiae. Dolores ut officiis repellendus.",
 	"title": "Handcrafted Fresh Bacon",
@@ -90704,11 +87534,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Numquam incidunt sint eaque laudantium ut. Quos quaerat occaecati et ea praesentium rem ducimus. Cumque voluptate nemo reiciendis dicta animi ab. Voluptatem facilis molestiae amet ut.",
 	"title": "Handmade Soft Mouse",
@@ -90834,11 +87659,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Ex fugit est doloribus. Doloremque eos autem aut est minima ullam. Iure incidunt quod nihil est dicta rerum vel. Debitis atque voluptatem ut cum qui eaque est.",
 	"title": "Gorgeous Frozen Pizza",
@@ -90993,11 +87813,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Explicabo accusantium qui doloremque rem accusantium qui. Commodi dolore praesentium eveniet quos similique aspernatur fuga ea tempore. Minus molestiae maiores commodi ipsa dolorem. Aut pariatur reiciendis enim aspernatur pariatur id. Ea doloremque iste et quisquam.",
 	"title": "Awesome Fresh Soap",
@@ -91181,11 +87996,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Consectetur voluptate ea et iure iste tenetur et incidunt tempore. Autem saepe quas ab labore eligendi nostrum ut neque porro. Ducimus tempore officiis doloremque placeat culpa qui. Ea quaerat esse. Officia atque distinctio debitis necessitatibus officiis. Aut amet expedita doloremque hic.",
 	"title": "Sleek Cotton Soap",
@@ -91311,11 +88121,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Dolorem eius rerum consectetur natus modi. Reprehenderit quibusdam adipisci dolor perspiciatis non aut commodi neque id. Optio ea facere fugit ut explicabo. Dolores illo non atque quo explicabo aut corrupti aut. Voluptas aut laudantium.",
 	"title": "Tasty Frozen Towels",
@@ -91412,11 +88217,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Assumenda incidunt vitae. Sunt ad provident. Velit rerum itaque aperiam enim perferendis enim minus aut. Similique aut ad neque natus id dolorem. Aliquid ipsum esse omnis mollitia quas quibusdam sunt ut est.",
 	"title": "Tasty Wooden Bacon",
@@ -91542,11 +88342,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Error veritatis inventore. Necessitatibus labore dolores sed vel. Et ut consequatur sapiente fuga. Est et quo facere modi.",
 	"title": "Rustic Soft Hat",
@@ -91643,11 +88438,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Saepe ut omnis id. Reiciendis natus magnam reprehenderit. Eos qui dolores unde voluptatem voluptates. Qui officia optio eveniet consectetur excepturi laudantium. Eos voluptatem qui commodi expedita ipsa velit debitis eum cum. Maxime ex ea esse veniam ratione ut ipsa.",
 	"title": "Incredible Wooden Pants",
@@ -91802,11 +88592,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Hic fuga repudiandae quia voluptatem ab. Harum eius modi non reiciendis voluptas. Accusantium voluptas aut. Praesentium sapiente voluptatem dolores sunt distinctio. Sint illum illo perspiciatis iste porro sit eos. Magni aliquam corporis ab culpa minima ut.",
 	"title": "Unbranded Cotton Gloves",
@@ -91990,11 +88775,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Quidem unde rem. Quia et id doloremque assumenda repellendus praesentium distinctio. Et tempore omnis quaerat neque quia quas laudantium in. Est natus delectus error a voluptatem accusamus.",
 	"title": "Handmade Steel Soap",
@@ -92091,11 +88871,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Quidem dolorem voluptatum aut laborum optio voluptas sit. Non voluptate culpa ipsa enim sapiente. Cumque temporibus ut harum rem praesentium adipisci voluptatem porro. Quasi nostrum eum. Voluptas praesentium aspernatur aut officia.",
 	"title": "Ergonomic Frozen Pants",
@@ -92221,11 +88996,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Dolor vitae dolor tenetur laboriosam voluptas. Molestiae eaque omnis maiores repellendus ut dignissimos aut accusantium labore. Qui qui et dolor.",
 	"title": "Small Cotton Sausages",
@@ -92322,11 +89092,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Quia enim dicta voluptatem iure iusto sed. Quia odio enim quasi consequatur. Perferendis minus veritatis est odit omnis nisi.",
 	"title": "Rustic Steel Shoes",
@@ -92423,11 +89188,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Autem eius facilis et et dolorem. Animi nesciunt quis sapiente ex quis. Assumenda omnis aspernatur dolores. Eos aut commodi qui iste cumque dicta. Dolores dicta cum necessitatibus numquam explicabo quis laudantium aut.",
 	"title": "Generic Soft Gloves",
@@ -92582,11 +89342,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Laborum molestias est dolore placeat eligendi fugit vitae dolorem maxime. Ut quidem et culpa. Consequuntur a ut autem. Tenetur rerum totam rerum dolores sit occaecati. Perferendis minus illum voluptatem pariatur aut doloremque molestias delectus. Laborum nemo illum beatae quos sit qui numquam.",
 	"title": "Intelligent Granite Tuna",
@@ -92683,11 +89438,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Aut voluptatem deserunt vel quis quia sed assumenda. Nesciunt voluptas dolores delectus officia ab est porro. Aut tenetur deserunt quos praesentium. Quia vero aliquam est sint sapiente. Dolor laboriosam est rem aliquam mollitia ullam enim incidunt.",
 	"title": "Rustic Granite Gloves",
@@ -92813,11 +89563,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Incidunt reiciendis ratione placeat. Omnis rem asperiores eaque consectetur et. Repudiandae reprehenderit placeat omnis deleniti hic soluta sint. Accusantium inventore aut quisquam. Autem et distinctio aut. Omnis et maxime nostrum veniam omnis repellendus.",
 	"title": "Intelligent Concrete Sausages",
@@ -92972,11 +89717,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Beatae quo possimus. Qui totam distinctio. Sint enim quia. Consequatur provident maxime natus ad ea ex aut ex voluptatem.",
 	"title": "Handcrafted Cotton Tuna",
@@ -93073,11 +89813,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Nisi omnis amet ut eos mollitia et ullam sint. Cum amet et fugiat eius sit. Consequuntur laboriosam corrupti facere quas impedit non nisi.",
 	"title": "Practical Rubber Fish",
@@ -93203,11 +89938,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Asperiores id quibusdam est incidunt natus nam corporis dolor quod. Minus rem at consequatur dignissimos velit voluptas ipsam rem libero. Voluptatem repellat quia et ea dolores. Cumque officia omnis adipisci. Corporis doloremque et. Modi molestiae ut.",
 	"title": "Refined Rubber Shoes",
@@ -93304,11 +90034,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Cumque nisi iusto labore earum earum cumque. Aut veritatis quas et. Omnis iusto hic aperiam voluptate sit fugit assumenda quo.",
 	"title": "Licensed Wooden Chicken",
@@ -93492,11 +90217,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Ipsam deserunt iusto adipisci dolorem laudantium maiores consequatur. Dolores consequatur et itaque ea quis similique vel. Dolores nulla voluptatem dolore expedita accusantium odit laboriosam. Veniam est minima eum eaque aut aut recusandae. Animi consequatur esse officia molestias quo doloribus facilis. Ea qui ipsa nemo voluptas mollitia officia ipsa odio perspiciatis.",
 	"title": "Practical Metal Towels",
@@ -93651,11 +90371,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Possimus sed sunt dolorem esse minima fuga et neque. Consequuntur voluptates asperiores deserunt cumque repudiandae dolorum qui beatae. Molestias numquam facere non. Quos similique quibusdam ea atque doloremque sint impedit reprehenderit dicta. Repudiandae vero alias voluptas aut sit perspiciatis dolor.",
 	"title": "Refined Rubber Chair",
@@ -93810,11 +90525,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Ipsam et rem sit temporibus quisquam. Qui eum omnis et eum omnis neque pariatur est laudantium. Quis maiores ipsam qui dignissimos voluptatum dignissimos blanditiis sed. Quia quia eaque unde aut illo vel ut nulla sunt. Velit molestiae iure. Aut eos molestiae aspernatur dicta.",
 	"title": "Sleek Rubber Gloves",
@@ -93969,11 +90679,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Illum fugit eum debitis pariatur possimus est. Iure voluptatem est in accusantium ad dolores velit pariatur. Voluptatibus voluptatem soluta reprehenderit ducimus est.",
 	"title": "Generic Wooden Soap",
@@ -94070,11 +90775,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Et assumenda nesciunt est exercitationem. Velit et autem eius eligendi nostrum sint. Est inventore aliquam sint itaque qui velit quia eligendi eum. Eos aspernatur nulla sint voluptatem rem voluptas temporibus repellendus. Deleniti similique neque occaecati. Impedit ipsa qui qui enim.",
 	"title": "Ergonomic Soft Salad",
@@ -94171,11 +90871,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Omnis aut quia. Deserunt dolorem in molestiae. Qui ea voluptate aliquam id similique. Magni id magni cupiditate modi nam est totam quibusdam cupiditate.",
 	"title": "Tasty Plastic Computer",
@@ -94330,11 +91025,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Voluptatem odit eos blanditiis dolores sequi. Ut animi aliquam corporis quia quam error. Explicabo et reiciendis nihil animi voluptatem. Sed quibusdam porro quae ut ut. Rem quo omnis sint. Eum necessitatibus aliquid reiciendis consequatur maiores eos voluptatum est esse.",
 	"title": "Practical Wooden Bacon",
@@ -94518,11 +91208,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Temporibus qui id laudantium omnis doloribus nobis. Rem est eligendi et quo voluptatem et corrupti odit. Commodi aperiam placeat ipsa iure. Pariatur eligendi placeat in consequatur praesentium molestiae. Pariatur ullam nihil odio.",
 	"title": "Generic Rubber Shoes",
@@ -94706,11 +91391,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Ipsa quia quam aut qui et consequuntur. Neque voluptas deserunt. Ipsam fuga perspiciatis. Assumenda ad nobis aut animi quia. Ipsam tempora est similique suscipit illum nihil aut rerum.",
 	"title": "Intelligent Concrete Computer",
@@ -94807,11 +91487,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Accusantium illum numquam asperiores sit voluptas et. Laboriosam culpa et veniam ad autem iusto qui assumenda ut. Ea ab velit voluptas earum facere facilis.",
 	"title": "Licensed Plastic Ball",
@@ -94966,11 +91641,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Assumenda et vitae modi ut necessitatibus facilis tempore. Voluptatem quis nam aliquam est itaque. Voluptatem temporibus aut sunt nemo voluptates quo sequi provident. Tenetur perferendis soluta.",
 	"title": "Awesome Metal Mouse",
@@ -95154,11 +91824,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Aperiam autem consequuntur ullam autem quaerat quia impedit dolor cum. Ut adipisci officiis sed tenetur laudantium. Accusantium officia deleniti excepturi qui itaque ea. Nisi perferendis blanditiis maiores in numquam aliquam quasi. Harum quod ut sed doloremque impedit officia molestiae molestiae rerum. Repudiandae necessitatibus delectus ut tempora vel et.",
 	"title": "Tasty Frozen Hat",
@@ -95284,11 +91949,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Est vel nostrum iure. Aut quidem voluptatum atque facere voluptatem et nam eos voluptatibus. Qui eaque laudantium qui illum at perspiciatis ut facilis possimus. Quo dolorem eius dignissimos nam. Accusamus accusantium et quia vel.",
 	"title": "Handmade Concrete Gloves",
@@ -95414,11 +92074,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Provident est beatae rerum nulla fuga vel. Natus tempora neque id est. Non ad deleniti suscipit omnis eveniet in. Iusto consequatur dignissimos qui minima laboriosam dolorem voluptatibus corporis modi. Explicabo voluptatum minus.",
 	"title": "Handmade Soft Towels",
@@ -95573,11 +92228,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Omnis cum aut consequatur quis. Qui quisquam sunt ut officiis vero voluptatem voluptatem. Aut voluptatem asperiores earum deleniti laboriosam illum numquam in voluptate.",
 	"title": "Practical Wooden Cheese",
@@ -95703,11 +92353,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Aliquam aspernatur nihil cumque. Voluptatem voluptatem quam dolorem omnis consectetur necessitatibus suscipit. Minima cumque explicabo eos laboriosam et inventore recusandae ut reprehenderit. Cupiditate suscipit eius odit sit culpa ut provident.",
 	"title": "Handmade Rubber Soap",
@@ -95891,11 +92536,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Reiciendis non officia non. Quas soluta ut corporis. Officiis quas eos omnis distinctio facilis veniam quos voluptatem deleniti. Autem cum id eos ut.",
 	"title": "Refined Cotton Ball",
@@ -96050,11 +92690,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Ut est exercitationem iusto laborum. In praesentium saepe id suscipit enim ut quae doloribus repellat. Porro vero dolorum nostrum sed perferendis vitae dolorum placeat. Qui ut consequatur.",
 	"title": "Refined Rubber Hat",
@@ -96238,11 +92873,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Deserunt non consequuntur adipisci. Quia numquam inventore dolores a itaque porro. Enim consequatur facilis eos ut. Consequatur voluptatem sint.",
 	"title": "Ergonomic Wooden Mouse",
@@ -96397,11 +93027,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Perspiciatis iusto iusto unde illum eum tenetur repudiandae quo deserunt. Odit nobis odit qui consectetur enim. Voluptas cupiditate minima distinctio aut officiis. Beatae neque nobis earum.",
 	"title": "Rustic Granite Chair",
@@ -96556,11 +93181,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Voluptatibus commodi consequatur eius voluptas nam fugiat. Aspernatur voluptatum et numquam quaerat labore aperiam nostrum vitae aliquam. Officiis sunt iste illum optio aspernatur dolores voluptatem quae. Exercitationem qui aut vel amet ut sed ut libero alias. Voluptatem est omnis omnis quis dolorem et quos sed.",
 	"title": "Fantastic Steel Tuna",
@@ -96715,11 +93335,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Esse dolores non. Accusamus autem qui et inventore pariatur. Dolorum eaque voluptas dolorem soluta voluptatem sint. Sunt et et saepe est delectus esse doloremque minima velit. Excepturi consequatur impedit ullam odit asperiores incidunt.",
 	"title": "Sleek Granite Chicken",
@@ -96816,11 +93431,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Esse fugit numquam illo exercitationem voluptas iure quae magnam. Iure omnis culpa dolorem aperiam aperiam. Voluptates eum eum. Ut velit ea ipsa cumque quis nam. Omnis soluta iste. Harum officia dolorem qui assumenda ea delectus dolores deserunt.",
 	"title": "Rustic Cotton Computer",
@@ -97004,11 +93614,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Eius molestiae aut doloribus odio sunt quae et cum. Perspiciatis quis consectetur sint et similique. Qui in ut excepturi autem quisquam voluptatem sit repellendus ratione.",
 	"title": "Handmade Concrete Chicken",
@@ -97192,11 +93797,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Deserunt adipisci qui eos sit. Harum et fuga aut quisquam. Sed corrupti enim. Accusamus nulla sit eos aut illum est a ipsa. Illo maxime odio sunt illum.",
 	"title": "Handmade Metal Tuna",
@@ -97351,11 +93951,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Et omnis cumque tenetur quia officiis necessitatibus. Sed praesentium molestiae. Voluptas veritatis unde dolores reiciendis recusandae. Consequuntur expedita in hic placeat et fugit voluptatem. Nisi enim voluptatibus in.",
 	"title": "Refined Concrete Salad",
@@ -97481,11 +94076,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Sit perferendis laudantium omnis itaque ut iusto. Fugiat ea nisi dicta et. Sed esse omnis maiores provident. Labore mollitia eum quia numquam laborum sunt est.",
 	"title": "Refined Frozen Bacon",
@@ -97582,11 +94172,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Molestias similique molestiae perspiciatis. Dolor consectetur non aut odio in. Sequi iste nobis voluptate nostrum ut sequi vel doloribus.",
 	"title": "Tasty Fresh Ball",
@@ -97683,11 +94268,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Sint molestiae nihil. Quo unde vel totam sed tempore quod. Pariatur est consequatur. Eos vitae quia est sint aut. Tempore sunt sint sed ipsa facilis porro voluptas veniam consectetur. Aliquid et placeat alias aspernatur.",
 	"title": "Licensed Cotton Shoes",
@@ -97842,11 +94422,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Commodi earum provident quisquam cumque earum. Aut libero ea quia. Ea quis architecto temporibus.",
 	"title": "Unbranded Steel Pizza",
@@ -97972,11 +94547,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Aut corporis consequatur repellat. Suscipit qui similique voluptatibus perferendis est tempora excepturi. Quo sint est. Ratione consequatur incidunt repudiandae corporis dolores. Totam repellendus quia.",
 	"title": "Ergonomic Cotton Car",
@@ -98073,11 +94643,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Earum aut alias quod. Placeat amet nemo. Repellat tenetur possimus omnis enim in. Omnis reiciendis consequatur et doloribus. Quae est eaque dolorum illo quo rem eius.",
 	"title": "Incredible Steel Tuna",
@@ -98203,11 +94768,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Autem accusantium ut et vel rerum voluptatem. Numquam cum consequatur quibusdam quia. Iure in eveniet quidem nihil facere. Id delectus quod.",
 	"title": "Sleek Steel Gloves",
@@ -98362,11 +94922,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Facilis perspiciatis autem repellat non. Modi quidem ut. Et est sunt. Impedit laudantium ullam.",
 	"title": "Fantastic Rubber Soap",
@@ -98550,11 +95105,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Et iste voluptatum rerum quia voluptas hic. Veritatis excepturi est id non sit et sint. Aut atque soluta nisi hic voluptatem quas est ducimus id. Dolorum ea illum nostrum veniam officia veniam illum. Perspiciatis quibusdam unde.",
 	"title": "Sleek Fresh Soap",
@@ -98709,11 +95259,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Error veritatis impedit accusantium. Maxime eos praesentium voluptatum impedit quis inventore non earum fugit. Corrupti ut vel voluptatum. Qui ut reprehenderit et dolorem qui reprehenderit sed soluta atque. Adipisci ex laboriosam aperiam magnam et quia.",
 	"title": "Incredible Concrete Ball",
@@ -98868,11 +95413,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Non earum est et neque voluptatem dolores consequatur beatae fuga. Esse unde ea illo enim. Ut pariatur eos est. Molestiae laudantium ipsa.",
 	"title": "Incredible Metal Car",
@@ -99056,11 +95596,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Et magni non ut ut quos. Quos at itaque ut itaque sit quod. Aut inventore iure optio accusamus incidunt et.",
 	"title": "Fantastic Plastic Chips",
@@ -99186,11 +95721,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Reiciendis aut id et cum voluptatem ipsum delectus consequatur. Reprehenderit ducimus molestias adipisci veritatis molestias repudiandae eum possimus perferendis. Esse voluptatem praesentium eum aut placeat iure dolor. Et consequatur tenetur rerum reprehenderit ducimus voluptatem. Est rerum odit hic dolore.",
 	"title": "Incredible Metal Mouse",
@@ -99287,11 +95817,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Et dolore occaecati voluptatem dolore rerum. Magni quis sed dolor dignissimos. Impedit enim suscipit voluptas consequatur voluptatum et recusandae. Voluptas explicabo tenetur illo molestiae qui a sint ut laboriosam.",
 	"title": "Gorgeous Metal Towels",
@@ -99417,11 +95942,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Quis rem nulla ut optio illum voluptatibus totam. Eligendi consectetur in. Ipsum dolores culpa velit fugit nulla amet tempora eos laboriosam. Consequatur itaque ut illum quia a aliquid iste autem aut.",
 	"title": "Small Wooden Tuna",
@@ -99576,11 +96096,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Nobis et reiciendis earum neque. Rerum deserunt est. Sit libero amet cupiditate esse odio repellendus. Sit non nihil velit ipsum iure. Omnis voluptate aut sit odit.",
 	"title": "Handcrafted Steel Chips",
@@ -99764,11 +96279,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Id autem alias hic. Iste placeat veniam non eum deserunt ut itaque est. Ab quasi aut et modi fugiat sed. Reiciendis necessitatibus est quia est vel necessitatibus rem animi voluptates. Facere vero soluta consequatur accusamus nulla repellendus consequatur qui. Similique ea cupiditate et non quo illo.",
 	"title": "Sleek Rubber Chair",
@@ -99865,11 +96375,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Vel recusandae et magni in voluptate aut est quo. Commodi rerum non quis omnis nobis distinctio iure. Quia maiores praesentium. Nam animi omnis dolores. Dolores id minima fuga doloremque quo. Quo itaque quas sed itaque.",
 	"title": "Ergonomic Granite Cheese",
@@ -99995,11 +96500,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Magni sit in adipisci. Est asperiores ut repellendus ut et minima quia nisi et. Odit fugit dolorem.",
 	"title": "Unbranded Frozen Pizza",
@@ -100183,11 +96683,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Voluptas veniam qui necessitatibus eaque ut. Asperiores eum sit hic perspiciatis. Delectus nulla ab eaque ducimus. Et blanditiis nulla magni culpa sit reiciendis. Mollitia libero velit quisquam non rerum. Voluptatum doloremque adipisci vitae suscipit quis quo quae fuga.",
 	"title": "Unbranded Granite Shirt",
@@ -100342,11 +96837,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Optio ut maxime labore consequatur sint ut rerum. Sit veritatis aut id voluptatem. Nihil aut quis suscipit aut iure in quia.",
 	"title": "Small Rubber Car",
@@ -100472,11 +96962,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Unde voluptatibus officia et nulla. Veniam est nam at harum dolorem reiciendis inventore. Et laudantium fuga distinctio aut.",
 	"title": "Incredible Granite Shirt",
@@ -100602,11 +97087,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Earum sapiente occaecati rerum ea. Doloremque ipsa non architecto quas voluptatem aut sapiente qui. Nostrum perferendis nostrum sapiente cum dolore libero qui.",
 	"title": "Licensed Fresh Chair",
@@ -100732,11 +97212,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Eligendi autem fugit et labore nisi maiores culpa odio. Corporis culpa commodi aut optio sit unde iste pariatur asperiores. Sed vel fuga placeat numquam quas voluptatum sit. Quia commodi ut nesciunt quam.",
 	"title": "Handmade Steel Salad",
@@ -100862,11 +97337,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Repudiandae ea voluptatibus provident. Autem sed qui. Eveniet nulla aut.",
 	"title": "Small Fresh Pants",
@@ -101050,11 +97520,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Saepe odit et quia et omnis rem excepturi. Ea nesciunt ab quia numquam non dolorem et. Sapiente enim odio rerum dolorum expedita.",
 	"title": "Generic Fresh Bike",
@@ -101238,11 +97703,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Tenetur libero veritatis. Quos vitae exercitationem voluptatem omnis fugiat incidunt consectetur. Pariatur omnis culpa ut. Totam et occaecati. Vel porro est libero et quia nihil.",
 	"title": "Awesome Concrete Salad",
@@ -101397,11 +97857,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Corrupti ut iusto. Laudantium ullam facilis consectetur ut. Iure nesciunt qui qui qui facilis.",
 	"title": "Unbranded Metal Tuna",
@@ -101556,11 +98011,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Sed voluptas rerum voluptas provident delectus mollitia sequi. Non id molestiae non. Qui consequuntur suscipit corporis earum non. Unde esse placeat doloremque sit qui eveniet dolor et libero. Dolorem maiores vel vel velit fuga suscipit aut provident eaque.",
 	"title": "Handcrafted Wooden Chair",
@@ -101686,11 +98136,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Aut quasi quos ut ut sed in corrupti. Laudantium aut sequi consequatur perferendis ut animi. Dolores officia distinctio qui eligendi architecto praesentium qui. Illum minus quidem dolores impedit. Veniam eligendi eos consequatur iste ipsam esse. Soluta dolorem repellat distinctio ut molestiae.",
 	"title": "Rustic Steel Towels",
@@ -101787,11 +98232,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Inventore eveniet neque mollitia. Sit qui asperiores nemo quo id non est nemo ut. Et tenetur architecto amet quas maxime. Ea et asperiores. Eveniet non aliquam nisi ab incidunt ut.",
 	"title": "Unbranded Concrete Bike",
@@ -101975,11 +98415,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "In aut sed qui et deleniti eligendi. Ad animi quo accusantium corrupti. Qui vitae sint numquam quia odit aliquam consequatur. Ipsam voluptas aliquid repellendus quasi sed optio est porro.",
 	"title": "Unbranded Plastic Shirt",
@@ -102105,11 +98540,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Quo sit qui dolorum accusantium vel saepe earum ut quia. Quia rerum maxime magni necessitatibus deleniti est. Tempora saepe quisquam quas temporibus placeat et consequatur animi.",
 	"title": "Sleek Steel Sausages",
@@ -102235,11 +98665,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Rerum accusantium enim placeat et soluta eum. Est repellendus repellat quibusdam. Animi nisi sit. Delectus vel illo facilis quibusdam occaecati sit et sunt amet. Aut quia exercitationem numquam debitis.",
 	"title": "Gorgeous Metal Chair",
@@ -102365,11 +98790,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Exercitationem et laborum eos cupiditate facere vel vel ut ea. Vitae possimus blanditiis ducimus eligendi omnis pariatur inventore non. Architecto dolorum fuga commodi dolor. Et quia magnam reiciendis. Dolor accusamus sit. Nemo at enim placeat quaerat illo numquam soluta error.",
 	"title": "Ergonomic Granite Bike",
@@ -102466,11 +98886,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Ipsam voluptas itaque voluptatum alias. Illum ex sit vero iusto id est possimus. Voluptas eaque cumque saepe ut ut. Eius est nesciunt sunt ea natus totam dignissimos. Quisquam atque veritatis et non incidunt aut rerum rerum vel.",
 	"title": "Generic Cotton Salad",
@@ -102654,11 +99069,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Hic repudiandae tenetur labore quis suscipit deleniti. Iure iusto est libero et quas eos magni. Cumque enim similique sit tempore consequuntur et. Qui doloremque cumque dolorum. Autem amet laborum hic. Velit eos quaerat qui dolores deleniti natus enim voluptatem.",
 	"title": "Incredible Concrete Tuna",
@@ -102784,11 +99194,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Odit sit aut. Sit vel sit autem et sapiente aut quaerat dicta deserunt. Molestiae dolor sint odit est nemo nesciunt. Molestias eligendi nihil autem autem. Enim totam voluptas deleniti veniam totam nulla.",
 	"title": "Awesome Rubber Mouse",
@@ -102972,11 +99377,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Voluptas nihil iure quod. Sint ipsum accusantium quasi veniam facilis facere. Accusantium consequuntur nisi doloribus sit. Magnam quasi dolore ad possimus illum. Beatae omnis enim porro quia dolorem quia nobis error cumque. Facere voluptate reprehenderit voluptates molestiae doloremque voluptatem qui.",
 	"title": "Intelligent Rubber Gloves",
@@ -103102,11 +99502,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Est eos voluptates laudantium facere quia velit. Velit est autem error nulla. Voluptates illo et sunt odio assumenda id sit est hic. Aut et et.",
 	"title": "Small Fresh Shoes",
@@ -103261,11 +99656,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Et quasi vero dicta aut aut velit quia. Id aspernatur illo modi et impedit nihil explicabo eaque. Natus vel quasi reiciendis in.",
 	"title": "Awesome Granite Computer",
@@ -103362,11 +99752,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Placeat laudantium repudiandae atque eos eos. Labore aut esse nihil beatae qui sunt perferendis dicta tempora. Dolore consequuntur odit iure atque. Voluptatem ut exercitationem ut voluptatem et ut doloribus. Molestiae fuga minus.",
 	"title": "Small Frozen Chips",
@@ -103521,11 +99906,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Ea blanditiis amet non corrupti dolores quae nostrum et sunt. Aut autem fugit aliquid. Accusamus laboriosam voluptas aperiam ullam consequuntur beatae praesentium magni. Aut consequatur blanditiis.",
 	"title": "Practical Fresh Pants",
@@ -103680,11 +100060,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Reprehenderit est deleniti autem voluptatem delectus non cum ut ipsum. Maiores at quod ut non consectetur porro consequatur in temporibus. Ut sit optio.",
 	"title": "Ergonomic Plastic Pizza",
@@ -103868,11 +100243,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Eaque vero sit voluptatem voluptas. Quae ex sed. Rerum tempora architecto qui. Iure et quo.",
 	"title": "Practical Metal Table",
@@ -104027,11 +100397,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Reiciendis quod dolorem ipsum voluptatum non dolorum magnam blanditiis. Necessitatibus exercitationem reprehenderit deleniti. Est itaque dolores optio enim quam velit. Dignissimos ab ut veritatis et eos doloremque recusandae maxime mollitia. Nostrum nostrum dolores est. Ea mollitia modi dolores aperiam.",
 	"title": "Small Steel Car",
@@ -104128,11 +100493,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Deleniti non fugit facere sit aperiam ad. In sequi at ad. Repellat quia ea aperiam consequatur consequatur natus adipisci dolorem. Laborum molestias ab assumenda voluptatem labore quod sint ipsa. Expedita temporibus commodi consequatur dolores inventore eos distinctio. Non recusandae rerum dolorum aut deserunt praesentium.",
 	"title": "Generic Fresh Soap",
@@ -104316,11 +100676,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Non omnis repellendus debitis perspiciatis tenetur et. Et nihil excepturi in libero. Quisquam ipsum laboriosam consequatur ea non nesciunt non. Sit labore consequatur.",
 	"title": "Practical Plastic Computer",
@@ -104504,11 +100859,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Non qui qui et officia molestias id. Veritatis quia impedit voluptas nesciunt voluptas voluptatibus dolorem harum. Vel sequi ea consequuntur aut.",
 	"title": "Small Granite Pizza",
@@ -104692,11 +101042,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Expedita dolores occaecati perferendis similique quisquam aut. Facilis impedit aut non ut incidunt sequi sit in. Et qui et aperiam assumenda tenetur. Voluptas odio et veniam at voluptatem. Ut tenetur nostrum alias iste et dolorum.",
 	"title": "Sleek Fresh Fish",
@@ -104851,11 +101196,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Ad consequuntur nesciunt sit amet. Et sunt est. Rerum non et porro totam.",
 	"title": "Generic Soft Chicken",
@@ -104981,11 +101321,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Sit odio aperiam et eius consequatur non. Sit sed molestias natus omnis numquam deserunt rerum sint et. Accusamus aut reiciendis molestias animi saepe optio sunt reprehenderit aut. Porro voluptas veritatis est quod blanditiis veniam enim. Quam explicabo consequatur aut. Totam sunt eum est.",
 	"title": "Rustic Cotton Shoes",
@@ -105082,11 +101417,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Et quos reiciendis voluptatem non. Est vel ullam illum. Est ab ut reprehenderit quae amet qui. Laudantium adipisci hic ratione iusto magnam. Eos suscipit velit deserunt officiis.",
 	"title": "Licensed Granite Salad",
@@ -105241,11 +101571,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Amet nulla dolorem distinctio blanditiis ratione provident. Eius molestiae cum nemo molestiae omnis. Ratione deserunt aut dolore expedita est ut. Rerum molestiae ut tempore sint minus atque mollitia.",
 	"title": "Generic Frozen Hat",
@@ -105342,11 +101667,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Enim nam voluptates similique unde. Animi provident ut. Quas quas animi sit at qui. Soluta consequatur ea in.",
 	"title": "Intelligent Concrete Computer",
@@ -105443,11 +101763,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Iure similique autem placeat nesciunt qui consequatur aut dicta. Odio sed vel. Asperiores ad et. Saepe quasi tempore. Enim illo voluptatum accusamus tempora ut nihil ad itaque.",
 	"title": "Rustic Cotton Tuna",
@@ -105631,11 +101946,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Nihil molestiae quos accusamus possimus quasi molestiae nobis. Qui nihil quas voluptates. Maiores atque sed impedit.",
 	"title": "Ergonomic Soft Chair",
@@ -105732,11 +102042,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Ipsa quibusdam quisquam commodi qui. Voluptas aut totam. Cumque quisquam quia perferendis praesentium enim dolore a. Est quia vitae ad suscipit quos ex harum ipsam.",
 	"title": "Sleek Granite Tuna",
@@ -105891,11 +102196,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Consequatur repellendus maiores minus nisi excepturi voluptas. Enim atque quo laudantium qui quasi quas incidunt tempore. Optio fugiat nam aut vero. Sed hic natus dolorem veritatis aperiam incidunt.",
 	"title": "Incredible Cotton Car",
@@ -106021,11 +102321,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Quia consequatur autem voluptas adipisci voluptate ut ullam a enim. In adipisci totam nobis et tempore facilis natus quaerat harum. Eveniet sed porro quo tempore quidem.",
 	"title": "Handmade Wooden Chips",
@@ -106151,11 +102446,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Sint est molestiae vel fuga esse corporis. Adipisci similique tempore ea. Sit consequatur exercitationem ea. Enim debitis voluptas ducimus molestias quisquam voluptates iure. Dolorem quaerat in.",
 	"title": "Awesome Fresh Bike",
@@ -106252,11 +102542,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Quos deleniti praesentium omnis repudiandae voluptatem aut. Ducimus eos voluptatem error sapiente temporibus voluptate tenetur. Tempora id modi vel et porro vitae aperiam dolor consequuntur.",
 	"title": "Ergonomic Soft Gloves",
@@ -106411,11 +102696,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Temporibus totam omnis suscipit laboriosam repellat nam aut. Similique pariatur tenetur. Tenetur error illum. A ea sint neque ab quas explicabo. Sed numquam alias dolor laudantium sequi. Sit praesentium animi est.",
 	"title": "Handmade Granite Soap",
@@ -106570,11 +102850,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Omnis temporibus impedit dolore vitae corrupti non accusantium fuga. Minus velit aut sapiente est quae pariatur dicta eius. Qui ab dolor non deleniti occaecati quasi.",
 	"title": "Generic Fresh Soap",
@@ -106729,11 +103004,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Quos magni aliquid perspiciatis molestias. Aut enim quisquam dolorem porro consequatur culpa fuga similique. Sed enim autem voluptas. Fugiat odit omnis qui est non rerum nesciunt numquam.",
 	"title": "Small Concrete Salad",
@@ -106830,11 +103100,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Quis aut placeat modi odit amet. Ducimus enim deserunt. Velit iusto molestiae qui facilis veniam maiores saepe. Rem quis qui quis ipsam fuga odit sunt autem. Laudantium ut et doloremque quasi laboriosam. Accusantium aut autem.",
 	"title": "Licensed Concrete Gloves",
@@ -106931,11 +103196,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Dolores incidunt dolor nobis eum est. Enim maiores dignissimos autem minima exercitationem officia. Repellat praesentium accusamus. Et est aut qui consectetur temporibus consequatur soluta rerum distinctio. Eos consectetur et minus eum explicabo placeat.",
 	"title": "Intelligent Cotton Gloves",
@@ -107061,11 +103321,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Voluptas rerum nam non rem. Voluptatem dolor voluptates nesciunt molestiae vitae rerum natus et. Architecto id a qui sequi qui corporis optio eos. Eaque nihil reprehenderit delectus dolore dignissimos quaerat earum.",
 	"title": "Generic Granite Bike",
@@ -107249,11 +103504,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Ut quisquam eos sed non. Veniam nostrum sed. Placeat consectetur occaecati quia aut consequatur. Dolores ut est eveniet.",
 	"title": "Sleek Plastic Sausages",
@@ -107408,11 +103658,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Cupiditate quos quis et deleniti. Modi ullam facilis sed quia sint. Voluptas eos rerum autem reprehenderit autem commodi molestiae sapiente aut. Quia consequuntur tempora quasi eius. Voluptas nisi minus dolore repudiandae veritatis qui. Quo non et pariatur ut voluptates rerum maxime.",
 	"title": "Tasty Fresh Car",
@@ -107567,11 +103812,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Suscipit delectus et temporibus ad esse. Amet praesentium laboriosam non est. Iusto et sit maiores ab.",
 	"title": "Refined Cotton Chips",
@@ -107668,11 +103908,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Nisi ut fugiat. Et ullam quia repudiandae velit rem quo. Dolor tempora et quo magnam nam. Quo architecto dolore. Eius molestias sit alias aut voluptatem ut. Ex nobis dolorem hic dolor est.",
 	"title": "Incredible Soft Salad",
@@ -107827,11 +104062,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Vel debitis beatae incidunt tempora ut voluptatem facere quo consequatur. Ut impedit sunt accusamus. Natus sunt numquam ratione. Quidem voluptas aut libero maxime ut neque. Maxime nihil vel est aut corporis provident soluta. Voluptates magni ducimus aut quia fugiat ea optio totam.",
 	"title": "Practical Plastic Salad",
@@ -107986,11 +104216,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Quibusdam velit a sit voluptas. Et sed corrupti accusamus voluptatem aut commodi eos voluptatibus aut. Qui nulla minima vitae corporis consequatur molestiae et enim.",
 	"title": "Unbranded Soft Fish",
@@ -108174,11 +104399,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Assumenda rem perspiciatis. Iusto tempora dignissimos quasi natus beatae. Qui in est quaerat eos.",
 	"title": "Gorgeous Cotton Tuna",
@@ -108362,11 +104582,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "At assumenda enim fugit sunt fugit illo dolorum maxime. Blanditiis sed molestiae magnam rem rerum consectetur deserunt. Debitis harum et ipsa nesciunt temporibus voluptatibus voluptatem nisi voluptates.",
 	"title": "Incredible Wooden Soap",
@@ -108521,11 +104736,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Debitis reiciendis aliquam quasi impedit quia. Quaerat expedita iusto molestiae non. Et nisi et.",
 	"title": "Practical Metal Table",
@@ -108651,11 +104861,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Possimus quis ducimus. Numquam eos dolorem quidem sit placeat ratione. Officiis culpa quos est laborum incidunt repellendus quisquam. Debitis nostrum necessitatibus.",
 	"title": "Handmade Frozen Bacon",
@@ -108810,11 +105015,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Tempora eveniet illo iste doloremque sit rem esse reprehenderit architecto. Autem ipsa fugiat aperiam consequatur perferendis voluptas sit dolorem. Et exercitationem dolorem animi corporis in et sunt nihil libero.",
 	"title": "Generic Frozen Mouse",
@@ -108911,11 +105111,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Reprehenderit odio voluptate est et quaerat illo consequatur. Iste ratione placeat sequi ab voluptas amet qui quis sint. Quod iste voluptatibus. Omnis officiis cum quo.",
 	"title": "Gorgeous Frozen Pizza",
@@ -109012,11 +105207,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Repudiandae doloremque labore quod laboriosam et. Sunt quis eius est debitis assumenda quae neque exercitationem. Voluptatem dolores quam unde ipsa cumque illum veritatis. Voluptatibus dolorum deserunt velit aspernatur ea officia voluptatem. Fugiat dolor quis omnis impedit. Suscipit dicta molestias.",
 	"title": "Intelligent Concrete Pizza",
@@ -109113,11 +105303,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Ad explicabo eligendi nihil eum qui aut quos beatae. Suscipit ad hic aut saepe aut. Provident qui recusandae. Sit quo deserunt ratione dolor deleniti quo fugiat blanditiis.",
 	"title": "Rustic Granite Keyboard",
@@ -109301,11 +105486,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Ut voluptates officiis magnam quis accusamus molestias animi. Vero debitis minus nobis et facere voluptas. Laudantium et reprehenderit veritatis ut. Quo qui tempora voluptate deserunt voluptas totam eos vitae. Quod dignissimos molestias autem ut minus reprehenderit. Officiis odio aut sapiente qui perspiciatis nihil aperiam.",
 	"title": "Refined Steel Tuna",
@@ -109489,11 +105669,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Aspernatur reprehenderit atque quidem eos quae reprehenderit ex. Magnam occaecati quia adipisci doloremque asperiores. A deleniti distinctio mollitia quisquam perferendis ratione. Non perspiciatis libero culpa. Maiores impedit et nulla ad natus exercitationem et.",
 	"title": "Ergonomic Metal Table",
@@ -109677,11 +105852,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Quam nulla quas reprehenderit. Nobis aspernatur cum. Voluptatem mollitia dolor atque doloremque quaerat voluptates earum. Sint natus ut et eius dolor autem repudiandae.",
 	"title": "Intelligent Soft Car",
@@ -109836,11 +106006,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Qui fuga iusto culpa eos nobis est voluptatibus aperiam. Eos magni mollitia quo est sint veritatis dolorem recusandae. Laborum nihil harum.",
 	"title": "Practical Fresh Sausages",
@@ -109966,11 +106131,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Reiciendis et excepturi voluptatibus in quis ut. Molestias sed et ut odit atque quis et. Commodi ut mollitia excepturi neque fuga omnis aut et. Impedit veritatis dolore aliquam eos doloremque reprehenderit. Est in molestiae vel et numquam iusto est. Nostrum qui et hic amet ullam.",
 	"title": "Sleek Soft Pizza",
@@ -110154,11 +106314,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Nihil omnis blanditiis debitis neque quidem corrupti blanditiis minima. Non consequatur autem dolor. Voluptas maiores sunt velit sunt mollitia veritatis.",
 	"title": "Gorgeous Fresh Mouse",
@@ -110342,11 +106497,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "In explicabo ut ab et soluta qui facilis id aperiam. Et nam vel. Vitae sed iusto explicabo repudiandae et laboriosam culpa.",
 	"title": "Intelligent Granite Car",
@@ -110472,11 +106622,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Sequi ut exercitationem porro velit vel ducimus sint rem. Necessitatibus eveniet omnis sunt. Quia id sit. Maxime aut in explicabo qui quas et ex porro debitis.",
 	"title": "Licensed Rubber Bacon",
@@ -110602,11 +106747,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "A quae libero a illum accusantium. Consequatur temporibus et autem nisi omnis. Et magni voluptatem earum sit quae quia commodi laudantium ipsa.",
 	"title": "Handmade Rubber Shoes",
@@ -110703,11 +106843,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Sint nulla esse ullam et inventore. Est aut fuga sit dolor et facilis harum et sint. Et eum provident omnis nemo aspernatur. Omnis quaerat ex corrupti. Ut doloremque doloribus excepturi sunt ea. Est et molestias libero.",
 	"title": "Incredible Fresh Keyboard",
@@ -110862,11 +106997,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Consequatur officia qui sed explicabo quaerat eligendi. Necessitatibus impedit incidunt omnis. Et nihil nihil labore voluptatibus id.",
 	"title": "Tasty Fresh Hat",
@@ -111050,11 +107180,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Reprehenderit earum voluptates et dolore et voluptatem. Ab iste dolorem. Excepturi ut nostrum ut velit autem ab fugit repudiandae. Ullam sint amet nisi accusamus sed nulla cum.",
 	"title": "Generic Soft Chicken",
@@ -111209,11 +107334,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Nesciunt est ab. Reiciendis quisquam rerum et voluptates cupiditate odio et. Velit sed quisquam quia.",
 	"title": "Sleek Granite Chicken",
@@ -111310,11 +107430,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Harum molestias non quo consequatur ab. Cupiditate voluptatem esse sit tempore. Repellat non consequuntur.",
 	"title": "Fantastic Wooden Bike",
@@ -111469,11 +107584,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Et facilis rerum ducimus. Amet voluptatem non. Quos vel ut voluptatem eveniet consequatur delectus. Cumque aut repellendus accusamus provident officia officia. Voluptatem ut inventore. Culpa in ea et ipsum neque occaecati quibusdam qui ducimus.",
 	"title": "Intelligent Plastic Cheese",
@@ -111570,11 +107680,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Doloribus nihil perspiciatis id nisi soluta consequatur quis veniam ex. Rerum ipsum porro aut adipisci velit mollitia architecto ipsa perspiciatis. Debitis ut expedita. Dolorem in cumque voluptatem nesciunt qui. Odit eos cum.",
 	"title": "Refined Plastic Car",
@@ -111671,11 +107776,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Libero ullam adipisci est explicabo ex ipsam repudiandae. Quam asperiores et dolorum omnis dolorem. Aut sapiente quod velit ab vitae. Rerum voluptate eveniet est recusandae voluptatem vitae ipsum voluptatem placeat.",
 	"title": "Sleek Plastic Computer",
@@ -111830,11 +107930,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Quas commodi aut excepturi qui porro aut eum. Molestias voluptate molestiae est cupiditate a. Tenetur et est aut sit cum iure ullam. Veritatis in ex quisquam modi quia occaecati accusantium et.",
 	"title": "Sleek Wooden Car",
@@ -111989,11 +108084,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Et vel est dolorem in autem. Recusandae quo optio mollitia sunt voluptates ea. Beatae nulla sed ea accusantium. Dolor laborum praesentium. Culpa officiis est recusandae. Possimus quia hic fuga.",
 	"title": "Tasty Cotton Sausages",
@@ -112177,11 +108267,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Sit harum facere fugiat sed dolore consequatur. Aliquam distinctio voluptate velit vitae aut laudantium voluptatibus velit. Velit dolorem doloremque dignissimos et qui aperiam eum illum. Velit explicabo provident voluptas veritatis aut voluptates culpa ea odio. Nihil facere ad et iusto iure. Amet dolorum consequatur dolor veritatis quos excepturi autem et dolor.",
 	"title": "Intelligent Plastic Chair",
@@ -112336,11 +108421,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Quod sit accusamus soluta atque. Beatae aliquid vero cumque nam voluptatem a nobis vel. Adipisci ipsum sit facere voluptates molestiae voluptates quam accusantium adipisci.",
 	"title": "Gorgeous Frozen Tuna",
@@ -112524,11 +108604,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Quisquam qui consequatur ut voluptatem et consequatur dolorem dicta. Et illo et harum dolorem et velit provident officia dolore. Commodi soluta enim dolore in blanditiis.",
 	"title": "Licensed Wooden Soap",
@@ -112683,11 +108758,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Consequatur earum dolor expedita sed quisquam ut. Assumenda nihil dolorem aut a. Dignissimos sapiente cum deserunt repellat. Et itaque quidem voluptatem qui qui quos praesentium. Nihil nisi est sint vel optio voluptatem quo vero rem.",
 	"title": "Licensed Fresh Fish",
@@ -112813,11 +108883,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Ipsa vel dolores enim ipsa corporis ratione doloremque est nihil. Saepe est maiores nostrum fugiat soluta corporis voluptas optio consequatur. Sunt amet error sint omnis aut dolorem enim. Sapiente non placeat laboriosam ad. Omnis corrupti doloremque esse facilis et reprehenderit eveniet.",
 	"title": "Intelligent Metal Sausages",
@@ -113001,11 +109066,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Cum beatae perspiciatis molestiae. Ullam ab enim laboriosam autem nemo et consequatur. Rerum quos similique repellat eum debitis nulla consequatur veniam. Accusamus neque rem in. Reiciendis ut impedit deleniti consectetur officia occaecati inventore accusamus quam. Et et aut quia modi omnis quibusdam natus est.",
 	"title": "Rustic Soft Tuna",
@@ -113160,11 +109220,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Sit aperiam aut excepturi accusantium amet neque qui. Voluptatem excepturi voluptas non quisquam qui dolore assumenda. Maiores consectetur deleniti rem error numquam velit aut atque quaerat.",
 	"title": "Generic Cotton Ball",
@@ -113290,11 +109345,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Ab porro iusto ipsa ut iure nemo doloribus. Sit hic laborum. Incidunt et tenetur.",
 	"title": "Incredible Metal Ball",
@@ -113478,11 +109528,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Ab beatae et aut excepturi id aperiam. Rem in dolores velit cumque exercitationem asperiores cupiditate est illo. Sapiente quod laborum deserunt.",
 	"title": "Generic Plastic Cheese",
@@ -113666,11 +109711,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Eum maiores assumenda est. Dolorum non amet unde itaque explicabo minus et in officiis. Et natus inventore officiis accusamus aut fugit ut. Et rerum iusto sapiente dolores libero qui voluptatem. Exercitationem eos et quia eveniet pariatur esse enim dicta rem. Sed atque voluptas aliquam temporibus facere sit culpa adipisci necessitatibus.",
 	"title": "Handcrafted Wooden Ball",
@@ -113825,11 +109865,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Qui numquam facilis autem ad quis dolorum qui. Sed sunt et velit perspiciatis et aliquam et quis. Atque nam aspernatur necessitatibus culpa consequatur odit ut. Quia omnis voluptatem maiores soluta ea nihil repellendus quas nihil. Et quidem voluptatem perspiciatis sit aliquam molestiae consequatur optio quidem. Hic nihil dignissimos dignissimos iusto dolorum voluptas natus odio.",
 	"title": "Intelligent Rubber Fish",
@@ -113926,11 +109961,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Et iusto itaque. Est eum aspernatur illo voluptatem suscipit quia. Nobis dolorum suscipit sint molestiae odit quae dolor quo. Dolore minus nam adipisci. Numquam ut repellendus sed non sed reiciendis quia.",
 	"title": "Licensed Wooden Keyboard",
@@ -114056,11 +110086,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Omnis dolor iste facere harum placeat ratione animi dolor. Iste non nihil cumque porro beatae asperiores qui. Quod dicta est. Architecto debitis beatae qui laborum saepe ducimus officiis. Voluptatibus est veritatis officiis aliquid beatae.",
 	"title": "Generic Concrete Pizza",
@@ -114186,11 +110211,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Dicta laudantium ad in id omnis rerum repudiandae voluptas. Officiis similique minima et. Dolorem quos aperiam provident ut iure ducimus cupiditate et.",
 	"title": "Practical Granite Pizza",
@@ -114374,11 +110394,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Quibusdam id sunt placeat consequatur et. Deleniti laborum et id vel et delectus natus deleniti provident. Aut et perspiciatis sit repellat maiores commodi assumenda cum.",
 	"title": "Fantastic Soft Bike",
@@ -114475,11 +110490,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "A ea vero voluptatem explicabo ratione praesentium. Assumenda vel quidem numquam voluptatem. Iusto et sint quia dolores corrupti. Aut cumque modi. Sint sed eum ad. Aliquid voluptas corrupti qui et labore laudantium.",
 	"title": "Small Steel Tuna",
@@ -114663,11 +110673,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Sed sed earum voluptas dignissimos ut numquam pariatur quaerat. Culpa a et incidunt dolores consequatur repudiandae ea et. Tenetur dolor laboriosam hic eaque facere commodi quidem ipsum vel.",
 	"title": "Intelligent Plastic Soap",
@@ -114793,11 +110798,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Nisi velit quis consequatur aperiam. In iste consequatur. Dolorum neque dolor molestias nihil sint. Est harum illo magnam eos.",
 	"title": "Generic Soft Pizza",
@@ -114894,11 +110894,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Nisi perferendis labore aut minima optio corporis commodi. Nostrum praesentium nobis. Harum quibusdam suscipit.",
 	"title": "Awesome Steel Pizza",
@@ -115082,11 +111077,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Quia quo sunt fugit omnis recusandae. Mollitia omnis possimus sunt aliquid ab eveniet libero est aut. Dolorum iste repellat est.",
 	"title": "Rustic Steel Ball",
@@ -115270,11 +111260,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Recusandae aliquid possimus aliquam blanditiis. A velit odit repellat dolores sit. Maxime ut sint cumque rerum repellat. Delectus voluptatum at consequuntur assumenda.",
 	"title": "Awesome Fresh Sausages",
@@ -115429,11 +111414,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Nulla repellat enim et tempore non et. Quibusdam id ut vero doloribus odit odit atque amet. Repellat quis necessitatibus reiciendis magni quia ipsa.",
 	"title": "Intelligent Cotton Pants",
@@ -115559,11 +111539,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Consequuntur quaerat est architecto vero a vel quia accusantium. Voluptatibus repellat ut quos ut aut aut modi accusamus sequi. Voluptas enim quia harum recusandae delectus non fugiat qui deleniti.",
 	"title": "Generic Metal Mouse",
@@ -115747,11 +111722,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Aliquam nobis soluta quo id non rerum provident eveniet aut. Rerum ullam distinctio necessitatibus quae laborum qui architecto repellendus. Excepturi commodi eum eum quam sunt mollitia ut et.",
 	"title": "Practical Rubber Shirt",
@@ -115877,11 +111847,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Veritatis quia nobis. Placeat at dolore repellendus cupiditate eius dicta dolore et. Nobis voluptatem ipsa impedit aliquam odit.",
 	"title": "Unbranded Wooden Towels",
@@ -116036,11 +112001,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Suscipit vel sit qui asperiores. Voluptatibus voluptas labore amet perferendis ut. Est eos dolorem. Reiciendis provident sit alias dolore.",
 	"title": "Small Fresh Shirt",
@@ -116166,11 +112126,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Expedita rerum debitis maxime rerum ut earum. Nostrum quae laudantium reiciendis voluptas consequuntur sed non architecto quaerat. Voluptates vel quo culpa.",
 	"title": "Tasty Soft Table",
@@ -116325,11 +112280,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Rerum iste et sunt sint et quibusdam rerum eveniet. Temporibus quas assumenda. Fuga quibusdam ad et est.",
 	"title": "Practical Fresh Towels",
@@ -116513,11 +112463,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Ut ad soluta hic est odit rerum aut iusto eum. Mollitia perspiciatis occaecati. Amet et fuga fuga molestiae. Error cumque ducimus magnam inventore consequuntur et modi cupiditate dolor. Molestiae culpa qui corporis.",
 	"title": "Unbranded Concrete Tuna",
@@ -116672,11 +112617,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Aut et eum recusandae numquam architecto. Dolore ullam nostrum pariatur consequatur repudiandae. Sunt provident aliquam et corrupti velit occaecati. Rerum quis aut nam ut harum. Est nisi est. Qui quia vero ullam illo dolor.",
 	"title": "Rustic Metal Shoes",
@@ -116773,11 +112713,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Illo fuga ab. Velit quae architecto ratione quos. Rem est id mollitia autem occaecati fugit est.",
 	"title": "Unbranded Plastic Chicken",
@@ -116932,11 +112867,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Laborum ipsam accusamus veniam aspernatur eum quidem nam. Fugit labore cumque enim ratione voluptas. Illo in ut quis inventore voluptatem itaque laboriosam esse sint.",
 	"title": "Tasty Frozen Mouse",
@@ -117091,11 +113021,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Neque blanditiis quis velit deleniti quos voluptate provident. Ad modi quos mollitia nihil aut doloremque error. Consequatur impedit atque omnis qui id quia a vel mollitia. Non fugit assumenda et.",
 	"title": "Fantastic Steel Pizza",
@@ -117250,11 +113175,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Nisi animi fugit nostrum perferendis non laboriosam. Inventore laborum asperiores. Id rerum minima dicta ut id.",
 	"title": "Ergonomic Cotton Fish",
@@ -117409,11 +113329,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Rem nemo veniam qui necessitatibus nesciunt aut et. Qui laboriosam fugiat. Eaque tenetur inventore. Dolore adipisci ipsam maxime.",
 	"title": "Practical Plastic Salad",
@@ -117597,11 +113512,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Veritatis tempora eveniet ipsa perferendis necessitatibus veniam veniam et consectetur. Ea velit nesciunt consectetur dolores dolores. Blanditiis neque molestias voluptatem hic et id. Tenetur autem voluptas accusantium omnis eius quas autem omnis harum. Est et soluta rem.",
 	"title": "Intelligent Soft Bacon",
@@ -117727,11 +113637,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Odio nisi et dolore assumenda aut et et. Perspiciatis dolor eaque molestiae eligendi consectetur voluptate velit et. Veniam maxime est aut totam aut libero id fugiat sunt.",
 	"title": "Licensed Soft Bacon",
@@ -117857,11 +113762,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Ullam aspernatur velit voluptatem ut. Natus porro voluptas suscipit odit occaecati consequatur porro numquam. Aut aperiam minus perspiciatis magni et odio rerum.",
 	"title": "Refined Plastic Chicken",
@@ -117958,11 +113858,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Magnam sequi quia sed autem quas. Ut itaque atque nam provident rerum dicta. Quia est voluptas omnis delectus voluptas ea. Aut rerum quis veniam sequi in consequatur.",
 	"title": "Tasty Steel Sausages",
@@ -118146,11 +114041,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Et ducimus quidem molestias aut expedita adipisci. Et ad sequi aliquam nostrum voluptatem voluptatem. Repellat itaque et laboriosam quia accusantium ut fuga rerum. Dolores vitae qui illum vel est. Et quia accusamus.",
 	"title": "Tasty Steel Table",
@@ -118334,11 +114224,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Doloremque libero sint. Consequatur voluptatem et reiciendis ut quos autem inventore commodi. Commodi similique molestiae sit doloremque veniam necessitatibus. Magni qui consequatur. Et odio aliquam hic.",
 	"title": "Handcrafted Concrete Tuna",
@@ -118464,11 +114349,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Quae qui porro perferendis aut et dolorem sunt. Voluptatem voluptatem enim cum possimus qui eaque et. Reprehenderit aut fuga sit rerum dolor. In sint est. Est perferendis nihil repellendus reprehenderit sit officiis dolor non quasi.",
 	"title": "Small Rubber Pants",
@@ -118565,11 +114445,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Illum quibusdam sit. Velit necessitatibus nulla qui. Quas accusamus dignissimos est.",
 	"title": "Unbranded Granite Car",
@@ -118666,11 +114541,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Similique cum doloremque ab incidunt est voluptas. Qui voluptates quas velit molestiae accusamus. Eius enim impedit quo ut et.",
 	"title": "Licensed Metal Cheese",
@@ -118796,11 +114666,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Suscipit molestias nemo voluptatem sed inventore rerum id. Doloribus omnis et perferendis quo corporis ex tempora totam et. Non et sapiente pariatur dicta harum.",
 	"title": "Licensed Plastic Car",
@@ -118984,11 +114849,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Nam vel et omnis omnis. Sed dolores nobis minus recusandae veritatis velit velit et. Adipisci nesciunt quibusdam molestiae aut excepturi reiciendis. Incidunt veniam omnis consequatur unde.",
 	"title": "Gorgeous Frozen Cheese",
@@ -119143,11 +115003,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "At eum commodi ad voluptatem animi voluptatem provident eaque. Soluta tempora labore et aspernatur. Et occaecati voluptates iusto repellat nemo quia. Molestiae nam maxime minima rerum consequatur aliquid unde officia quia. Ex soluta omnis dolorem et incidunt.",
 	"title": "Handmade Metal Soap",
@@ -119244,11 +115099,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Consequatur qui iusto. Enim distinctio vel. Ex et ipsam error magnam atque voluptatem eum facilis. Repellat dolor aut delectus non itaque non. Blanditiis iste sunt aut debitis qui.",
 	"title": "Ergonomic Concrete Cheese",
@@ -119403,11 +115253,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Suscipit rerum recusandae. Rerum ipsa quo dolores. Repudiandae sed in voluptas ratione. Et esse et vel qui adipisci temporibus quisquam ea non. Qui consequuntur est magnam quis velit. Sit facilis iste sed.",
 	"title": "Awesome Wooden Ball",
@@ -119533,11 +115378,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Dicta et aliquid. Ratione repudiandae odit. Ut fugiat aspernatur sunt numquam enim inventore. Veritatis dolor ipsa beatae velit sed quia consequuntur.",
 	"title": "Licensed Concrete Towels",
@@ -119634,11 +115474,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Eligendi enim quasi rem aut ipsum voluptas. Molestias sed quae et itaque et eum id rerum laboriosam. Aliquid iusto repudiandae impedit ducimus assumenda sequi. Deserunt quo amet dicta unde fugiat. Ut eligendi perferendis sint qui saepe et quia est voluptas.",
 	"title": "Handmade Cotton Chicken",
@@ -119822,11 +115657,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Ab sunt delectus illo excepturi beatae corporis similique. Autem quia mollitia. Omnis beatae tempore itaque quos nam voluptas maiores voluptas sequi. Repellendus sunt eveniet. Nostrum quia aut cumque vero.",
 	"title": "Ergonomic Metal Cheese",
@@ -119923,11 +115753,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Est corrupti officiis. Eos eum quibusdam. Dolorem quas et molestiae aut architecto. Eligendi numquam ex similique perferendis eligendi. Voluptates ducimus expedita distinctio. Consequatur ullam aperiam dolores voluptas aut voluptatum.",
 	"title": "Refined Fresh Car",
@@ -120024,11 +115849,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Nihil placeat eligendi ut tenetur atque. Eum odit vel et sed aperiam laudantium sit ratione placeat. Aliquid voluptatem saepe provident deserunt laboriosam accusantium optio et. Neque qui reprehenderit aut sit rerum et delectus. Sed pariatur odio nulla velit cum.",
 	"title": "Gorgeous Wooden Fish",
@@ -120183,11 +116003,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Consequuntur fugit ea tempore sint maiores magni. Consequatur eaque amet. Dolorem cupiditate provident autem neque sint voluptatibus maiores omnis nihil. Soluta et culpa possimus voluptas nam odio ullam.",
 	"title": "Tasty Cotton Chair",
@@ -120371,11 +116186,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Voluptatem minus magnam et aperiam eum ea. Ex quia natus ut nostrum sit error. Sint esse a et soluta officiis fugiat alias consectetur in. Repellendus omnis ducimus et et accusantium. Possimus necessitatibus inventore deserunt aut cumque consequatur aliquam facilis.",
 	"title": "Handcrafted Granite Ball",
@@ -120472,11 +116282,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Aliquam esse corrupti quis nihil qui. Omnis quis aut quia rem nihil aut aut sunt. Sunt repudiandae consequatur maiores fuga et qui alias id velit. A temporibus eligendi pariatur. Cumque vel hic ut unde tempore exercitationem et. Corporis molestias omnis fuga molestiae voluptate placeat.",
 	"title": "Handmade Granite Ball",
@@ -120602,11 +116407,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Nam natus id. Dolores in quasi nulla ut labore. Animi rerum veniam corporis aut. Nulla aperiam impedit unde. Optio accusantium perferendis. Dolores natus architecto qui quasi est et cupiditate.",
 	"title": "Handmade Granite Mouse",
@@ -120703,11 +116503,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Iure dolorum error ipsum quisquam rerum nulla molestiae consequatur mollitia. Id corrupti fugit mollitia minus sunt. Inventore harum molestiae dolore velit aspernatur quae. Sit voluptate rem. Est accusamus inventore sapiente ex reprehenderit earum beatae assumenda.",
 	"title": "Intelligent Cotton Towels",
@@ -120804,11 +116599,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Aliquid sed quam eos et sint a. Omnis laborum quia. Qui voluptates eligendi fugit consectetur autem quibusdam esse. Non animi quaerat harum eos harum aut qui provident dignissimos.",
 	"title": "Gorgeous Cotton Sausages",
@@ -120934,11 +116724,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Nostrum asperiores enim ipsa et quia incidunt ratione laboriosam autem. Non illum ut. Commodi voluptatibus voluptate molestiae possimus unde facilis quos quae. Quas doloribus hic.",
 	"title": "Fantastic Frozen Pants",
@@ -121035,11 +116820,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Esse voluptatem delectus libero fuga. Nostrum rem dolorem est. Dicta accusamus possimus ad quos. Optio sit qui voluptatem dolores vel eligendi quasi officiis veritatis.",
 	"title": "Intelligent Plastic Shoes",
@@ -121194,11 +116974,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Commodi distinctio sed tenetur numquam eos nihil inventore sapiente. Qui omnis rerum nihil ut provident quibusdam veritatis est architecto. Sed est quia consequatur temporibus. Fugit quia ut enim voluptatem non labore. Voluptas officiis tempora nobis eos voluptatem minima recusandae. Quia quaerat voluptates omnis nemo.",
 	"title": "Gorgeous Wooden Table",
@@ -121353,11 +117128,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Aperiam dolorem sed eveniet. Neque officiis laborum. Sapiente et minima ad.",
 	"title": "Handcrafted Frozen Gloves",
@@ -121483,11 +117253,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Facere et ut vero dolore ipsa aut quo quis qui. Fugiat nobis nobis culpa fugiat minima reprehenderit dolorum harum perferendis. Debitis vel sunt saepe pariatur. Nobis sunt reiciendis veritatis omnis ipsa ea. Laboriosam id impedit vel magnam.",
 	"title": "Fantastic Soft Chips",
@@ -121671,11 +117436,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Temporibus dolor asperiores eum cumque qui consequatur eum. Molestias laudantium quia quidem aut et blanditiis in labore quia. Fugiat dolores ea cum ratione. Iusto velit rerum repellendus dolorem culpa tempore ullam eveniet accusamus. Vel vel voluptatibus corrupti magni aperiam et et modi. Consequatur doloremque nemo molestias animi omnis.",
 	"title": "Unbranded Plastic Sausages",
@@ -121801,11 +117561,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Repellat veritatis nobis recusandae sed cum repellat. Laboriosam est praesentium. Magnam ut expedita voluptate unde nisi ratione. Omnis animi corporis corporis sunt molestias sunt quisquam.",
 	"title": "Fantastic Concrete Chair",
@@ -121931,11 +117686,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Est et quidem doloremque ad sit saepe ipsam consequatur sint. Aut illo dolorem culpa et ducimus architecto aliquid ut non. Quia hic labore asperiores.",
 	"title": "Refined Metal Cheese",
@@ -122061,11 +117811,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Aliquid perferendis consectetur fugit impedit quia error autem. Sit est debitis ullam consequuntur. Molestias repudiandae consequatur sapiente fugit aut nemo incidunt itaque debitis. Vel magnam et. Quia temporibus libero incidunt error omnis.",
 	"title": "Handcrafted Concrete Sausages",
@@ -122162,11 +117907,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Sit ea et consequatur nostrum rerum magnam harum nemo. Omnis dolorem eos doloremque possimus impedit ratione occaecati. Itaque voluptas eaque alias ut iure ipsam. Illum et accusamus impedit. Omnis quia iusto eos facilis quo aut fuga dolorem eligendi.",
 	"title": "Small Plastic Hat",
@@ -122321,11 +118061,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Perspiciatis hic illum dolore placeat iusto ipsum fuga a. Dolore debitis soluta. Ut unde eum vel perspiciatis dolores.",
 	"title": "Small Rubber Tuna",
@@ -122480,11 +118215,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Reiciendis voluptas dignissimos rerum explicabo incidunt ut. Saepe perferendis tenetur veniam aspernatur fuga. Distinctio nostrum reprehenderit dolor dolores. Quisquam aut quae omnis. Mollitia alias eos ea aspernatur quos. Rerum totam inventore.",
 	"title": "Fantastic Fresh Bike",
@@ -122668,11 +118398,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Temporibus quo dolore quia est blanditiis voluptatem dolores unde. Mollitia corrupti neque qui consequatur reprehenderit voluptatem. Provident saepe possimus ducimus facilis magni quaerat.",
 	"title": "Handcrafted Fresh Shoes",
@@ -122769,11 +118494,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Accusamus natus itaque. Rerum corporis ab. Minima et culpa nesciunt. Repellendus rerum eius ut beatae id ipsum.",
 	"title": "Tasty Concrete Car",
@@ -122957,11 +118677,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Excepturi minima exercitationem dolorem in sunt consequuntur voluptatem rerum in. Blanditiis aliquid aut quia vel officia perspiciatis quod. Repellat nam nihil dolorum ad voluptatum cum officia dolorum.",
 	"title": "Practical Wooden Hat",
@@ -123116,11 +118831,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Sed dolorum nihil. Et ullam enim tempore porro at ipsum qui sit voluptatibus. Sunt earum quo nobis quia laborum officia cumque exercitationem. Tenetur et consequuntur est. Cumque quos esse nisi architecto quae sint possimus. In sunt doloremque eaque.",
 	"title": "Tasty Granite Shoes",
@@ -123217,11 +118927,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Quas iure molestiae exercitationem saepe aut rerum autem enim molestiae. Soluta quas quae totam ullam ex soluta. Et magni a eum et. Perferendis eaque autem quidem non ea laboriosam qui non. Natus illum voluptas assumenda saepe eveniet quia tempora rem. Ut dolorem tempora deleniti.",
 	"title": "Intelligent Metal Hat",
@@ -123318,11 +119023,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Molestias corrupti accusamus. Voluptatem et magni accusantium sed velit ratione quo aspernatur minima. Necessitatibus possimus voluptates aut sapiente enim ducimus alias veniam. Voluptatem aut quis asperiores voluptatem consequatur a voluptate adipisci in. Cumque et dignissimos ex veniam non corporis voluptate. Dolores quis molestiae ut.",
 	"title": "Tasty Rubber Sausages",
@@ -123506,11 +119206,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Quidem rerum ab. Quibusdam amet corrupti repellendus ut est aut ut. Molestias perferendis magni doloremque assumenda quasi.",
 	"title": "Rustic Frozen Bacon",
@@ -123694,11 +119389,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Rerum aut voluptas reprehenderit id et ut qui. Cum saepe dolorem tempora ipsa repellat esse minus aut. Tempora earum aut odit recusandae tenetur. Est eum dolorum facere sequi quis est esse non ex. Tenetur dolorem ex eos non quasi vero et soluta.",
 	"title": "Small Soft Mouse",
@@ -123824,11 +119514,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Rem inventore repudiandae necessitatibus voluptate sint. Voluptas labore error iusto ut quaerat ratione ut ducimus. Non repellendus vel est similique deleniti quo et asperiores omnis. Voluptatibus rerum consequatur perspiciatis est qui.",
 	"title": "Tasty Metal Towels",
@@ -124012,11 +119697,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Vero ab sit et nam accusantium aliquid et voluptate. Qui dolores voluptas. Quia ratione est eveniet quo.",
 	"title": "Tasty Plastic Gloves",
@@ -124142,11 +119822,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Culpa nemo error similique ea minima animi delectus et magni. Aliquid molestiae voluptas maiores et ullam laboriosam nihil. Laborum mollitia sint velit. Est totam voluptates illo architecto aut iure sit. Occaecati quaerat ex aut blanditiis commodi praesentium. Exercitationem culpa aut.",
 	"title": "Gorgeous Frozen Bike",
@@ -124243,11 +119918,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Ullam et non ipsum repudiandae. Omnis dolor dolor distinctio. Consequatur commodi ut minus incidunt. Laborum neque ad praesentium itaque ut voluptate et consequuntur.",
 	"title": "Handcrafted Cotton Hat",
@@ -124344,11 +120014,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Blanditiis eaque excepturi sed laudantium aut et mollitia odit ut. Voluptatem fuga natus assumenda harum. Et quod blanditiis maiores repudiandae qui rem. Id placeat eligendi dolorem. Architecto repellat voluptates reiciendis at. Asperiores pariatur eligendi provident voluptatem eos.",
 	"title": "Tasty Plastic Car",
@@ -124503,11 +120168,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Omnis laboriosam officiis iste vel quos pariatur nesciunt. Dignissimos repudiandae dolore saepe. Architecto ut quo id eos. Tenetur alias quidem voluptatibus aliquid consequuntur necessitatibus laboriosam qui maxime. Vitae distinctio cupiditate hic qui cum expedita.",
 	"title": "Rustic Frozen Fish",
@@ -124662,11 +120322,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Possimus ut eos et. Recusandae nemo quo. Exercitationem aut et quidem. Iure esse facere magni quibusdam voluptatibus.",
 	"title": "Intelligent Frozen Chips",
@@ -124850,11 +120505,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Fugit eaque facilis ea et est voluptas pariatur quis animi. Incidunt aut corrupti eos accusantium perferendis dolor ut adipisci. Quo est et laboriosam minima reprehenderit quia. Et distinctio recusandae. Consequatur voluptas repudiandae deserunt architecto deserunt.",
 	"title": "Unbranded Soft Car",
@@ -125009,11 +120659,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Velit modi rerum officia voluptatem autem autem numquam. Eos suscipit quia. Rerum sint est assumenda magni aut aut quidem iusto itaque. Quis hic voluptate.",
 	"title": "Refined Soft Ball",
@@ -125197,11 +120842,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Quidem sed asperiores eius. Optio consequatur non numquam ipsum consequatur totam dignissimos. Voluptatem numquam asperiores velit ea vero quasi.",
 	"title": "Gorgeous Rubber Pizza",
@@ -125356,11 +120996,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Distinctio non libero voluptas vel et quia. Eveniet nulla sed rerum. Debitis provident ea cupiditate quibusdam id. Officia repellendus quia soluta vel nihil quo consequuntur enim. Sint vitae laboriosam nihil beatae minima enim.",
 	"title": "Unbranded Steel Table",
@@ -125457,11 +121092,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Et nihil accusamus aut voluptatem vel iusto id. Sit veritatis sed magnam amet eum et at nostrum eligendi. Vel voluptas enim accusantium doloremque tempora fugit. Ut consequuntur eum ipsa natus adipisci.",
 	"title": "Incredible Frozen Pizza",
@@ -125616,11 +121246,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Facilis quia error. Reiciendis quis rerum nemo rerum voluptatem. Sit magnam ipsum. Sit atque cupiditate molestiae itaque ut quisquam.",
 	"title": "Refined Plastic Towels",
@@ -125804,11 +121429,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Rerum id ipsa officiis blanditiis suscipit est quidem repudiandae quia. Numquam incidunt corporis eveniet sapiente ut in doloribus sint nostrum. Et modi exercitationem error perspiciatis beatae voluptas saepe et. Id cumque praesentium facilis atque porro quia. Molestiae vel quasi ut voluptates iure dolorem. Inventore neque ut laborum sequi.",
 	"title": "Generic Granite Cheese",
@@ -125934,11 +121554,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Impedit reprehenderit eveniet ex sed reprehenderit officia at. Adipisci et ab nihil magni. Iure inventore distinctio accusantium maiores id quasi labore quis tempore. Aut vero ratione sed quae. Adipisci labore officia unde tenetur eos facilis quasi.",
 	"title": "Ergonomic Soft Pants",
@@ -126035,11 +121650,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Officiis quisquam aliquid vitae porro ut expedita saepe cumque qui. Praesentium at eum. Qui est deleniti dolores perferendis quis dolore. Odio et qui delectus iste. Quibusdam voluptates quos praesentium.",
 	"title": "Refined Rubber Gloves",
@@ -126136,11 +121746,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Tempore non non autem reprehenderit sed nesciunt. Ratione hic reiciendis ullam ut et. Dolorem doloribus et quidem.",
 	"title": "Ergonomic Metal Keyboard",
@@ -126324,11 +121929,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Earum sed commodi distinctio. Sapiente dolorem magnam aut veniam qui sit. Vero in sapiente itaque voluptate dolor omnis iste. Sunt in perferendis enim animi at. Ab voluptatem corrupti aperiam vel quod.",
 	"title": "Gorgeous Metal Chair",
@@ -126454,11 +122054,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Sunt nihil ut perspiciatis est. Eius inventore reprehenderit sed dolores laudantium. Similique quo ut labore aliquam. Perferendis reprehenderit voluptas quo tenetur quia dolorem nostrum.",
 	"title": "Tasty Soft Computer",
@@ -126642,11 +122237,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Inventore totam voluptatibus quis voluptatem dolorem. Quisquam omnis et quia amet veritatis dignissimos et laboriosam. Voluptas iure libero nihil repudiandae in ullam sint et pariatur. Maiores magnam sunt a.",
 	"title": "Generic Steel Gloves",
@@ -126801,11 +122391,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Omnis aliquid ea nam magnam dicta quos possimus quasi sint. Voluptatem odio sapiente numquam. Id aut dolor non.",
 	"title": "Sleek Frozen Pants",
@@ -126989,11 +122574,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Praesentium id quisquam et quia et fuga est iusto. Magnam sed voluptatem unde totam. Libero qui amet laboriosam quia.",
 	"title": "Incredible Fresh Car",
@@ -127177,11 +122757,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Explicabo voluptates pariatur id laudantium. Sequi ut atque aut consectetur. Eum et nesciunt commodi quia beatae aperiam quos quas accusamus. Veniam omnis ut fuga atque et.",
 	"title": "Intelligent Concrete Chips",
@@ -127307,11 +122882,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Repellat vero adipisci at enim ipsum sed vel quia. Recusandae dolores placeat quas facilis magnam dolor distinctio. Quis qui ducimus in ut officiis sit cupiditate. Ab quam iste provident quibusdam quasi sint natus vitae. Sit eum cumque ut omnis incidunt saepe similique et nisi. Aut corporis quis enim quisquam error rerum minus molestias molestias.",
 	"title": "Unbranded Metal Pizza",
@@ -127466,11 +123036,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Deserunt voluptates vel vel quos quia eum. Quos enim voluptates ut incidunt quasi saepe est nemo. Ipsum quaerat veniam quia omnis sit sit.",
 	"title": "Awesome Wooden Pizza",
@@ -127567,11 +123132,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Adipisci nobis illo esse beatae inventore amet a. Hic dolor cupiditate. In eligendi odio accusamus animi. Dolorem dolor alias quis ut necessitatibus. Veniam provident rerum ab repellendus soluta.",
 	"title": "Rustic Metal Soap",
@@ -127697,11 +123257,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Autem nisi nobis pariatur vitae cumque deleniti ut sit minus. Ut laudantium consequatur harum. In qui sed deserunt. Perferendis facere voluptatibus sed accusantium maiores voluptas iste. Molestiae quis autem pariatur. Voluptates est animi dolorem consequuntur et saepe pariatur sed.",
 	"title": "Fantastic Fresh Chair",
@@ -127885,11 +123440,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Consequatur commodi autem dignissimos qui. Ea adipisci in atque. Consequatur enim aut et. Libero sint harum. Voluptatem sunt alias explicabo eum occaecati impedit perspiciatis reprehenderit accusantium.",
 	"title": "Awesome Plastic Cheese",
@@ -128015,11 +123565,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Labore unde rerum officia. Eum assumenda fugit suscipit ratione voluptatem. Et sunt ullam sed. Quisquam dolor corrupti cum nam eum ratione.",
 	"title": "Refined Granite Sausages",
@@ -128145,11 +123690,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Provident quia non. Ut explicabo eum sed. Occaecati sint voluptate temporibus fugit. Sequi qui hic quidem in dolor reiciendis id.",
 	"title": "Ergonomic Wooden Gloves",
@@ -128246,11 +123786,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Maxime autem est sed aliquid unde voluptatibus aspernatur. Et suscipit accusamus dolorem. Culpa voluptatum aut dolor delectus porro dignissimos veniam qui amet. Voluptas odit nobis. Cum molestiae iure sint tempora amet.",
 	"title": "Ergonomic Cotton Sausages",
@@ -128434,11 +123969,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Ea itaque necessitatibus illum rerum aut minima et iusto. Iure reprehenderit laborum molestiae et accusamus fugiat dolore. Vel porro dolorum. Facilis ab corrupti veritatis qui adipisci quis.",
 	"title": "Sleek Metal Bike",
@@ -128622,11 +124152,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Voluptates rem voluptatem quia sunt beatae quaerat fugiat quia. Odit doloremque rerum non. Nam occaecati necessitatibus eveniet alias ratione consectetur. Eum consequatur nemo molestias fugit similique.",
 	"title": "Tasty Soft Table",
@@ -128781,11 +124306,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Unde voluptates ea delectus nihil praesentium reprehenderit quo voluptatem ea. Aut ullam architecto soluta provident. Aut voluptatem et similique perspiciatis. A iure blanditiis. Dolor nihil ut perspiciatis dolore. Dignissimos hic voluptates.",
 	"title": "Handmade Rubber Shoes",
@@ -128969,11 +124489,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Quidem fugit saepe labore. Esse saepe sed architecto magni quidem quia provident. Voluptatibus nemo vero totam eius totam pariatur ullam eius.",
 	"title": "Unbranded Soft Gloves",
@@ -129128,11 +124643,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Fuga laudantium officiis quisquam nulla perferendis dolorem est et. Laborum ratione non quia iusto et cupiditate quibusdam nostrum quia. Voluptate suscipit amet inventore harum accusantium et. Perferendis dolorum aspernatur illo iste optio eos aut.",
 	"title": "Handmade Concrete Table",
@@ -129258,11 +124768,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Officiis rerum recusandae et qui laudantium id enim. Et culpa eum qui. Vero est dolor voluptates libero alias. Nihil nam sit facilis velit sapiente illo.",
 	"title": "Handcrafted Granite Car",
@@ -129388,11 +124893,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Ut voluptatem tenetur consequatur ad veniam eveniet. Asperiores qui et dolorem qui numquam voluptas fugit eos. Eveniet corporis ducimus perferendis cum maiores vitae similique sed rem. Sit eos vitae repudiandae harum sed.",
 	"title": "Gorgeous Wooden Shirt",
@@ -129489,11 +124989,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Nobis quae et quia doloribus amet recusandae est dolor. Neque omnis natus cum illum. Dolorum voluptatem voluptatem nisi sint placeat officiis.",
 	"title": "Licensed Plastic Soap",
@@ -129590,11 +125085,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Qui nesciunt repellat. Doloribus optio voluptas quia. Eligendi veniam rem minus consectetur. Quos architecto doloribus veritatis in omnis.",
 	"title": "Handmade Fresh Bacon",
@@ -129749,11 +125239,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Molestiae in id eos cum. Iure itaque voluptatibus odio omnis. Molestiae illo rerum ex commodi.",
 	"title": "Small Plastic Soap",
@@ -129908,11 +125393,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Labore repellat corporis velit. Aut quam est. Possimus enim quos ea praesentium sit. Quaerat praesentium quibusdam id sunt non rerum.",
 	"title": "Awesome Soft Cheese",
@@ -130067,11 +125547,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Omnis laborum ut eum provident. Omnis optio accusantium minus eveniet qui. Qui quae sunt. In dicta eveniet dolores iusto et est ducimus eum ea. Qui repudiandae sint reiciendis illo et cum et distinctio labore. Animi voluptate et minus.",
 	"title": "Small Plastic Shirt",
@@ -130168,11 +125643,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Sit voluptate aut sint ab quod ut dolor laboriosam omnis. Dolorem facere sed et magni et aliquid. Deserunt optio iure accusantium nam sed maxime. Quasi nesciunt sapiente aut.",
 	"title": "Refined Wooden Table",
@@ -130356,11 +125826,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Voluptates est voluptatem. Eveniet commodi magnam incidunt. Dolor aliquid ut quis dolorum perspiciatis non. Nihil ut veniam amet vero beatae. Sed quisquam nihil fuga quasi ab.",
 	"title": "Awesome Metal Tuna",
@@ -130457,11 +125922,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Voluptas facilis omnis. Similique ut dolore excepturi non. Iure dolor adipisci.",
 	"title": "Unbranded Fresh Bacon",
@@ -130558,11 +126018,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Recusandae maxime harum enim rem eligendi deserunt dolorum. Vero omnis inventore incidunt cum. Fugit ut dolor quasi vel vel aut. Molestiae magnam et ut voluptatibus amet nulla optio enim similique. Sequi nihil voluptatem. Commodi molestiae non.",
 	"title": "Handcrafted Concrete Bacon",
@@ -130688,11 +126143,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Id blanditiis est impedit cum ab maxime. Nihil inventore praesentium eos. Expedita eius aspernatur dolor deserunt recusandae porro id qui. Omnis sed est quibusdam. Enim illum nobis sapiente repellendus assumenda qui sit quia. Animi voluptas possimus totam voluptas totam hic quisquam omnis.",
 	"title": "Handmade Granite Tuna",
@@ -130789,11 +126239,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Laudantium praesentium dolorem. Aut consequatur est. Quisquam voluptas harum quas perferendis hic. Voluptate veritatis eum.",
 	"title": "Handcrafted Metal Chicken",
@@ -130977,11 +126422,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Incidunt fuga voluptatem non. Eaque aperiam aut quibusdam quos vitae id. Ut eaque voluptatem repellat voluptatem dignissimos et itaque. Voluptatibus nobis veniam dolorem. Ad laborum a.",
 	"title": "Fantastic Concrete Chicken",
@@ -131136,11 +126576,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Eveniet corrupti incidunt voluptates esse impedit molestias quis in. Delectus illum et id illo ipsa. Quia voluptas assumenda laboriosam vel at qui atque tenetur et. Velit sint molestiae at. Qui voluptatem nihil harum ab quia vitae.",
 	"title": "Refined Metal Hat",
@@ -131295,11 +126730,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Animi omnis exercitationem et ut quos. Sint dolore quia cumque ut soluta magnam adipisci. Sequi est porro in.",
 	"title": "Ergonomic Steel Chicken",
@@ -131483,11 +126913,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Neque sed excepturi id rem eum. Est vero et qui assumenda sed deserunt facilis. Saepe aspernatur delectus ad aut iste rerum recusandae. Qui dolorem nobis dolor cum et aliquid sit consequatur. Quaerat quibusdam explicabo et qui cumque beatae quis. Dolores officia voluptatem sed suscipit repellat in temporibus.",
 	"title": "Gorgeous Cotton Salad",
@@ -131642,11 +127067,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Consequatur odit iure est unde illum eum. Quibusdam quasi ipsa tenetur. Repellat fugit et quod enim incidunt. Occaecati molestiae et. Quos ipsum ducimus omnis distinctio at sint saepe consectetur. In porro voluptatem provident quod ipsum nihil consequatur atque libero.",
 	"title": "Sleek Cotton Bacon",
@@ -131830,11 +127250,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Voluptates eum voluptatem consequatur sunt tempore et tempora et. Quae adipisci sunt est sint vitae rerum ducimus at. Aut ab accusamus. Expedita inventore voluptate modi.",
 	"title": "Gorgeous Fresh Mouse",
@@ -131931,11 +127346,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Quis esse ut. Facere qui hic. Possimus magnam quis voluptatem voluptate libero. Dolores atque expedita est consequuntur a officia recusandae eligendi.",
 	"title": "Gorgeous Steel Sausages",
@@ -132090,11 +127500,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Reiciendis quia dolor ea non incidunt rem et voluptatem quis. Sunt qui voluptatum magni est non sunt. Alias dolor et aut consequuntur hic deleniti dolores. Consequatur exercitationem ratione qui tempora vitae possimus modi voluptate alias.",
 	"title": "Handcrafted Rubber Bike",
@@ -132191,11 +127596,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Non ullam voluptas non qui nulla. Consequatur molestias dolor vero amet repellat voluptates. Hic sunt est accusamus sequi aspernatur unde. Nihil minus mollitia in ea occaecati fuga distinctio vero molestiae. Vel sapiente eos facere quis beatae corrupti aut.",
 	"title": "Rustic Steel Salad",
@@ -132350,11 +127750,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Aut pariatur totam quia a voluptates placeat ut occaecati quam. Aut at porro velit et ut excepturi assumenda assumenda. Atque illum nostrum qui dolorem nemo fugit aspernatur. Nihil qui error repellat ea omnis. Quas recusandae est. Aut repudiandae atque consequuntur libero magni voluptatem illum molestiae.",
 	"title": "Tasty Plastic Cheese",
@@ -132538,11 +127933,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Qui eveniet eos eos quia accusamus officia libero. Esse ut magni blanditiis non cum reprehenderit. In molestiae culpa officiis. Sint quia dolorem consequatur omnis omnis. Laudantium modi voluptatem vero.",
 	"title": "Refined Rubber Shirt",
@@ -132639,11 +128029,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Sunt ipsam libero quae aut blanditiis nulla quidem neque iste. Qui dolore pariatur et. Eius qui maiores qui. Dignissimos eos excepturi odio et aut qui omnis ut est. Eaque dolore atque impedit id id rerum.",
 	"title": "Rustic Granite Bacon",
@@ -132827,11 +128212,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Est minima tempora rem est occaecati earum voluptas voluptas laboriosam. Fugiat sapiente distinctio esse nesciunt omnis explicabo. Molestias qui ex in voluptates reiciendis magnam neque ipsam ut. Temporibus amet tenetur quasi totam reprehenderit dolorem. Autem optio officiis voluptas voluptatum pariatur enim. Consequatur debitis aut dolores.",
 	"title": "Gorgeous Wooden Cheese",
@@ -133015,11 +128395,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Quis omnis aspernatur voluptatem saepe nihil. Enim illum omnis ratione tempore. Distinctio voluptatem deserunt laborum facilis temporibus.",
 	"title": "Rustic Rubber Pants",
@@ -133203,11 +128578,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Velit illo corporis blanditiis ex beatae iusto. Nihil aspernatur dolor non accusamus enim. Odit eligendi illo esse voluptas alias. Voluptas aut aut est et et delectus tempore. Vitae at ut ipsam numquam et rem suscipit sit. Quis sint ea beatae rem.",
 	"title": "Tasty Plastic Computer",
@@ -133391,11 +128761,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Ut esse saepe consequatur ratione. Deserunt deserunt aspernatur omnis omnis odio omnis itaque. Maxime explicabo dicta consequatur et aliquid est.",
 	"title": "Handmade Fresh Car",
@@ -133492,11 +128857,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Voluptates suscipit illo est dolores earum deserunt voluptatem ipsa. Sed est harum voluptatem quam dolore. Illo commodi minima voluptatibus laudantium architecto. Odit veniam nostrum voluptate.",
 	"title": "Handmade Fresh Table",
@@ -133622,11 +128982,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Qui et ea velit dolorum et veritatis harum sapiente. Qui dolores et eveniet exercitationem perferendis enim nobis. Quis eos inventore blanditiis. Non ipsum impedit commodi error. Aut ut iste corporis dolorem ab. Et id architecto.",
 	"title": "Licensed Concrete Sausages",
@@ -133723,11 +129078,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Perspiciatis optio aut. Architecto cum quaerat vel ratione cupiditate facilis id repudiandae. Aut iure perferendis impedit vel sint sed aliquam. Quibusdam harum officia sint voluptate ut error in nostrum.",
 	"title": "Awesome Steel Shoes",
@@ -133824,11 +129174,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Sit in debitis molestias velit ad ut voluptatem aut. Qui rerum mollitia hic rerum molestias aut nam. Ipsum aut et ducimus et et esse aut quisquam omnis.",
 	"title": "Handmade Frozen Shirt",
@@ -133983,11 +129328,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Harum autem commodi unde in accusamus nostrum. Iste non qui sapiente voluptatem est sequi molestias rerum et. Qui optio pariatur et temporibus maiores. Necessitatibus quae qui et ipsam ad veritatis perspiciatis nesciunt omnis.",
 	"title": "Practical Soft Chair",
@@ -134142,11 +129482,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Neque rerum odio. Optio facere modi maxime cupiditate aut itaque. Ut maxime dolorem consequatur neque voluptatem nostrum placeat et exercitationem. Ullam praesentium libero voluptatibus fuga voluptatem dignissimos architecto. Distinctio et et facilis aliquam minima necessitatibus.",
 	"title": "Licensed Metal Computer",
@@ -134272,11 +129607,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Laborum cumque quibusdam. Neque quas et. Et tempore delectus. Tempora aut magni consequatur aut delectus non error aperiam. Dolorem ut minima quia aut adipisci quis officiis. Magnam labore doloribus vero odit voluptatem saepe.",
 	"title": "Incredible Wooden Ball",
@@ -134373,11 +129703,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Quia libero quia. Non est et dolor nemo qui sunt qui ea quam. Dicta nisi nihil. Et vel ipsa ad tempore rerum velit placeat saepe tenetur. Amet hic sunt sunt quis minus quas rerum sunt. Quia delectus quia voluptatem sit non ullam.",
 	"title": "Incredible Metal Towels",
@@ -134474,11 +129799,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Et reprehenderit sunt provident ipsum vitae dolor repellat aut. Qui possimus rem labore quo sapiente et sint eum ipsa. Recusandae natus eos quod quia sit in. Possimus repellendus facere. Veniam est quae sunt. Enim aspernatur officiis saepe ut autem ut culpa nobis quae.",
 	"title": "Generic Soft Keyboard",
@@ -134604,11 +129924,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Eum natus fuga repudiandae laborum hic maiores officia id laboriosam. Dolor consequuntur fugiat officiis eos delectus iste. Veritatis aut voluptatum soluta officia facere non assumenda.",
 	"title": "Licensed Concrete Salad",
@@ -134705,11 +130020,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Optio recusandae est nihil incidunt deleniti architecto inventore molestiae deserunt. Laborum quaerat cupiditate nisi deleniti harum ad. Et tempora voluptatem assumenda distinctio eius hic voluptas officiis. Cum explicabo accusantium architecto labore tempora labore occaecati voluptas dolorem. Aut mollitia voluptatibus sit non deserunt quis natus. Nisi reiciendis placeat exercitationem voluptates ullam nobis.",
 	"title": "Practical Granite Tuna",
@@ -134806,11 +130116,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Maxime consequuntur officia dolor non tempora dolores repellat quam voluptas. Minima nobis omnis. Aperiam maiores et vel voluptatibus similique velit. Non voluptas voluptas.",
 	"title": "Licensed Soft Tuna",
@@ -134994,11 +130299,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Sunt nam dolor est. Aliquid laudantium atque est quo quas sit recusandae voluptatem. Qui aliquid et accusamus voluptatem deserunt. Nam quasi dignissimos fuga earum qui officia repellendus est sint. Explicabo et sed.",
 	"title": "Licensed Plastic Sausages",
@@ -135153,11 +130453,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Quis accusantium beatae sed. Illum omnis explicabo consequuntur et fuga nihil sunt ipsa. Voluptatum velit et sed facilis accusamus.",
 	"title": "Unbranded Plastic Hat",
@@ -135341,11 +130636,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Animi cumque pariatur laborum et qui aut sint aut. Nam totam aut nisi dolorum id perferendis dolorem. Placeat esse pariatur sint aliquam ut provident. Aliquid autem laboriosam et.",
 	"title": "Practical Soft Bacon",
@@ -135500,11 +130790,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Odio ut magni dolores adipisci illo in recusandae quos. Magnam nostrum rerum aspernatur sunt et. Sed hic dolorem. Ullam nemo nihil dolor iure est rerum nisi. Dolorem nisi cupiditate esse quis. Ut eaque id delectus quia at voluptas placeat.",
 	"title": "Practical Cotton Sausages",
@@ -135630,11 +130915,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Dicta nostrum adipisci repellendus. Voluptatem quis quisquam sed. Facilis incidunt possimus nihil ut autem molestias. Delectus ad similique id doloribus sint eius.",
 	"title": "Sleek Fresh Pants",
@@ -135760,11 +131040,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Sequi rem perferendis. Ut animi similique facilis commodi blanditiis at. Voluptatem aut voluptatem rerum distinctio ea adipisci. Dolorum odio placeat.",
 	"title": "Incredible Concrete Mouse",
@@ -135890,11 +131165,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Qui distinctio voluptates sunt ducimus sunt iusto. Eos culpa dolores laudantium et et eum enim laboriosam dolores. Repellat fugiat pariatur excepturi aliquid rerum dolor doloribus neque ipsum.",
 	"title": "Ergonomic Wooden Bike",
@@ -135991,11 +131261,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Culpa exercitationem doloremque aut. Quia labore temporibus voluptatem aliquam. Unde et iusto voluptatem dolorum iure quae. Ut vel doloribus pariatur sapiente et laudantium et quasi et. Consequuntur et qui.",
 	"title": "Handmade Soft Bacon",
@@ -136092,11 +131357,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Nesciunt adipisci qui et deserunt cum. Incidunt iusto et tempora repudiandae maxime sunt tenetur animi et. Tempora numquam quas voluptatibus omnis omnis et animi omnis repellendus. Ut veniam et tempore minus ullam iste quam dolores. Atque nam aliquam sapiente suscipit illo doloribus nulla. Autem nemo tenetur dolores voluptatibus sit et.",
 	"title": "Fantastic Cotton Chicken",
@@ -136222,11 +131482,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Possimus earum nihil nostrum. Minima labore voluptas voluptates eius qui doloribus est quia adipisci. Tempore sit excepturi ex enim dignissimos quam. Et minima hic at quod animi.",
 	"title": "Refined Soft Tuna",
@@ -136323,11 +131578,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Ratione ratione similique eius dolorem error. Provident architecto ipsa delectus. Dignissimos eligendi sunt qui quas deleniti molestiae consequuntur. Mollitia magni hic. Earum sed soluta qui officia quas.",
 	"title": "Tasty Rubber Ball",
@@ -136482,11 +131732,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Quis placeat facilis fugit ad dolorum quos commodi aspernatur. Deleniti nostrum assumenda libero. Veniam a a ut architecto qui quaerat. Est quaerat mollitia quam.",
 	"title": "Fantastic Soft Chair",
@@ -136583,11 +131828,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Sit voluptatem ut at velit. Est eligendi vitae perferendis ab enim quia. Et enim sit sint quis ut voluptatem.",
 	"title": "Small Plastic Chips",
@@ -136684,11 +131924,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Corrupti exercitationem exercitationem vero fugit expedita cupiditate. Quam exercitationem asperiores. Velit doloremque dolor laborum voluptates id dolores.",
 	"title": "Ergonomic Rubber Chair",
@@ -136785,11 +132020,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Dolore necessitatibus dolorem iusto voluptate similique pariatur et ratione. Et nisi ratione. Rerum quasi ratione laudantium sed omnis dolorum et.",
 	"title": "Ergonomic Rubber Car",
@@ -136973,11 +132203,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Enim modi rerum quod harum doloremque corporis atque voluptatem. Rerum blanditiis non quasi dolorem illum earum. Nihil et voluptate illum et adipisci ut.",
 	"title": "Awesome Rubber Gloves",
@@ -137161,11 +132386,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Accusantium id non nisi placeat. Ut soluta est qui blanditiis dolorem rerum voluptatem et. Omnis voluptatum cupiditate sed id similique esse nisi voluptatum omnis. Voluptatibus nisi dolorum ratione voluptate in eligendi non. Iure reiciendis cupiditate laborum. Totam velit dolorem explicabo et ad quia sit vitae possimus.",
 	"title": "Fantastic Concrete Chicken",
@@ -137349,11 +132569,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Sit unde nobis dolorum. Optio illum fugiat quia eligendi assumenda amet hic ipsam accusantium. Facere blanditiis repellat aut eum excepturi et quo. Harum sunt excepturi voluptas et officia ut sit. Qui necessitatibus itaque voluptatem qui occaecati velit libero at.",
 	"title": "Rustic Concrete Chips",
@@ -137537,11 +132752,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Rem et perspiciatis. Ex necessitatibus illo et. Quis non modi placeat reprehenderit qui cumque ipsa et. Dolorem aut ut et voluptate vel ut autem at.",
 	"title": "Tasty Steel Towels",
@@ -137667,11 +132877,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Ea in quia quia enim nulla. Provident consequatur possimus nobis eos. Omnis deserunt dolorum vitae deleniti.",
 	"title": "Small Fresh Shirt",
@@ -137797,11 +133002,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Placeat provident officia quaerat. Temporibus incidunt nemo earum. Omnis sint a. Iste omnis quia aspernatur officia molestiae. Exercitationem facere occaecati nihil doloribus eum minus.",
 	"title": "Handcrafted Steel Computer",
@@ -137956,11 +133156,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Beatae sunt adipisci neque natus laboriosam rerum qui delectus. Molestias necessitatibus consequatur cum sed. Ad repellendus ipsum tempore eveniet dolor qui placeat. Qui quam quam nihil nihil sapiente praesentium. Minus labore quod explicabo voluptates in ut veritatis.",
 	"title": "Refined Granite Chicken",
@@ -138057,11 +133252,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Corporis eos soluta provident omnis cum repellat repellendus. Magnam eveniet laboriosam reiciendis iusto nam rem. Delectus et voluptatum est ab. Consequatur ducimus aliquam voluptatem pariatur eligendi ut. Eos inventore eum consequatur consequatur.",
 	"title": "Gorgeous Cotton Computer",
@@ -138158,11 +133348,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Iusto atque nesciunt vel rerum minima aut voluptas veritatis. Voluptatem beatae blanditiis commodi nam vitae. Ut minima asperiores non adipisci qui.",
 	"title": "Fantastic Rubber Chips",
@@ -138259,11 +133444,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Nostrum non eos laboriosam blanditiis in aspernatur molestiae id excepturi. Alias a veniam. Voluptates numquam quasi. Voluptas fuga corrupti corporis ducimus.",
 	"title": "Fantastic Granite Towels",
@@ -138360,11 +133540,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Sed libero sint harum et omnis id. Repellat velit quaerat officia iure cum. Ab quod eaque eos ullam. Similique cum voluptatem corporis autem fuga. Incidunt laboriosam deleniti. Id et ab et.",
 	"title": "Awesome Wooden Towels",
@@ -138490,11 +133665,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Odio et eveniet ut corporis velit doloribus sapiente voluptas. Consequatur magni illum non in illum. Quia nam tempore eum ut. Ducimus molestiae qui corporis ut vero consequatur. Eos voluptates debitis illo repellat blanditiis nobis deserunt. Voluptas facere aut est.",
 	"title": "Small Granite Table",
@@ -138591,11 +133761,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Est corrupti veniam vitae commodi. Exercitationem rem dolores. Reiciendis asperiores enim possimus officiis sunt recusandae molestiae. Tenetur rem beatae omnis minima a vel odio eaque.",
 	"title": "Practical Soft Cheese",
@@ -138721,11 +133886,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Laboriosam quasi expedita quis labore ut quam commodi. Eum autem porro omnis quibusdam voluptatem aut. Nobis dolorum voluptatem est accusamus aliquam assumenda. Soluta ut id.",
 	"title": "Incredible Plastic Towels",
@@ -138909,11 +134069,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Perferendis harum libero et repellat qui dolor modi. Odio amet et non reprehenderit non ex. Autem explicabo dolore unde voluptas est alias id quia quos.",
 	"title": "Refined Concrete Towels",
@@ -139097,11 +134252,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Et ratione et ex non. Veniam blanditiis in. Velit et dolores dicta voluptatem ut et. Aut ad repellat et et aliquam fuga quaerat reiciendis quas. Neque rerum voluptatem recusandae. Sapiente mollitia quo laudantium corrupti.",
 	"title": "Tasty Frozen Ball",
@@ -139198,11 +134348,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Expedita asperiores voluptas harum nesciunt nulla. Necessitatibus est amet. Illo voluptates labore nulla cupiditate consequatur voluptates velit officia laboriosam. Asperiores vel assumenda incidunt expedita in est a. Officiis unde fugiat nostrum et suscipit vitae.",
 	"title": "Ergonomic Fresh Soap",
@@ -139328,11 +134473,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Dolorem est enim voluptas porro quod. Temporibus libero rerum corporis sunt impedit et. Illum nihil soluta ad voluptatem autem similique nisi iure. Aliquam optio suscipit cumque perspiciatis. Eum ducimus culpa nostrum consequuntur pariatur qui corrupti nemo in. Aut exercitationem dolorem.",
 	"title": "Generic Wooden Gloves",
@@ -139487,11 +134627,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Ex sint illo cupiditate consequatur iste voluptatem error. Expedita debitis reprehenderit enim perspiciatis harum eaque aliquid ut. Labore veniam autem praesentium qui vel repudiandae dolorem ipsum unde. Iste earum amet adipisci ea fugit fuga et aperiam. Ducimus doloremque sint nobis velit quaerat. Magnam beatae placeat architecto.",
 	"title": "Awesome Frozen Pants",
@@ -139675,11 +134810,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Magnam magnam omnis repellat. Ullam voluptatem voluptas. Voluptas fugiat non voluptas consequatur. Nam beatae reprehenderit nulla ut deserunt mollitia eius est facilis.",
 	"title": "Intelligent Frozen Pants",
@@ -139805,11 +134935,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Quod occaecati quo sunt voluptatum et voluptates quam. Dolorum maxime ea voluptatem et ea. Inventore magni voluptatem voluptas occaecati maiores qui. Non expedita ipsum.",
 	"title": "Refined Soft Chips",
@@ -139906,11 +135031,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Dolores quis occaecati perspiciatis rerum natus culpa sunt numquam ex. Ut reiciendis alias ducimus consequatur rerum est qui accusantium natus. Natus ut ab ipsam reiciendis et voluptatum et ea. Quia et temporibus eligendi eaque non libero id dignissimos nesciunt. Accusamus culpa placeat numquam quis a. Possimus quam inventore deleniti necessitatibus quibusdam commodi atque.",
 	"title": "Small Plastic Ball",
@@ -140065,11 +135185,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Porro possimus sint dolorum officiis eum dolorem excepturi. Unde dolorem possimus quo aut molestias ipsa iusto perferendis ea. Culpa quo totam porro.",
 	"title": "Awesome Steel Chair",
@@ -140253,11 +135368,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Et quaerat corrupti ad officiis quo ullam at. Aut molestias velit amet maiores. Voluptates amet perspiciatis autem nihil quod. Alias voluptas libero iusto earum dignissimos excepturi distinctio eos.",
 	"title": "Sleek Soft Soap",
@@ -140412,11 +135522,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Voluptatibus occaecati impedit animi recusandae assumenda aut et maiores consequatur. Quia id voluptates qui possimus assumenda qui molestiae iusto qui. Maiores est exercitationem eligendi.",
 	"title": "Refined Fresh Keyboard",
@@ -140600,11 +135705,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Explicabo et in voluptates unde sit aut est nihil. Asperiores quia vel non provident ullam sed numquam. Ullam maiores quis sit ullam. Explicabo earum incidunt eveniet. Dolores eaque est laborum nisi quos quod molestias repudiandae. Nulla ut itaque praesentium doloremque omnis quam voluptatem quidem laborum.",
 	"title": "Handmade Frozen Soap",
@@ -140701,11 +135801,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Eum minus sed molestiae sit iusto incidunt fuga iste. Nesciunt natus porro sint temporibus qui itaque eos laudantium. Voluptates ea consequatur molestiae ut ut recusandae aut hic. Dolores labore voluptatem non atque corrupti enim. Est sapiente vel et iste et nesciunt. Mollitia rerum optio deserunt vel incidunt blanditiis.",
 	"title": "Practical Cotton Table",
@@ -140889,11 +135984,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Ut sapiente officiis nisi doloremque sunt incidunt sint neque sit. Atque sapiente soluta accusamus magni eum. At excepturi nostrum quis adipisci suscipit. Rem quos et aut magnam consectetur similique eaque natus beatae.",
 	"title": "Incredible Cotton Hat",
@@ -141048,11 +136138,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Veniam beatae repudiandae libero quidem velit. Porro rerum veniam dignissimos sit suscipit excepturi at quo. In enim laboriosam laboriosam ut dolor laborum deserunt. Ut ab assumenda illo recusandae omnis et. Aut nam aspernatur quia qui quod.",
 	"title": "Intelligent Fresh Hat",
@@ -141207,11 +136292,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Nesciunt suscipit corporis mollitia expedita commodi. Dolore et veritatis voluptatem. Aut et sit accusantium ipsum soluta omnis tempora id voluptatem. Sint quia qui consequatur iure maiores quis nisi nemo.",
 	"title": "Licensed Granite Car",
@@ -141337,11 +136417,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Culpa quo suscipit consectetur excepturi aliquid quisquam eius. Consequuntur dignissimos consequatur est in. Sed omnis quia est nemo ea mollitia ea quis dolorem. Tempore vero est quasi beatae et sint qui est. Similique eligendi distinctio aperiam soluta.",
 	"title": "Intelligent Granite Cheese",
@@ -141467,11 +136542,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Officia rem expedita et aliquid iusto officia. Consectetur architecto voluptas et qui ut est quidem. Rem deleniti dignissimos voluptatem suscipit id.",
 	"title": "Ergonomic Frozen Mouse",
@@ -141655,11 +136725,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Aut doloremque est ea dicta quis. Maxime est non et. Aliquam deserunt eaque dolorum. Suscipit neque rerum vitae omnis. Officia quasi aut sequi aut ea sed.",
 	"title": "Practical Cotton Bacon",
@@ -141785,11 +136850,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Quam id molestiae aut. Dolorem ut est quo ut odit nihil est ut. Amet consequatur nobis vel recusandae omnis soluta. Non dolor officiis iste voluptas ab.",
 	"title": "Fantastic Soft Bacon",
@@ -141973,11 +137033,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Laudantium possimus consequuntur. Perspiciatis quisquam illo. Rerum rerum iste. Modi sapiente quae voluptas et nobis.",
 	"title": "Ergonomic Rubber Chair",
@@ -142103,11 +137158,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Temporibus voluptatibus ut aliquam autem. Quo rerum expedita aliquid sed vitae ut. Eaque provident doloribus eum maiores. Quaerat nihil amet ullam sed maiores. Autem adipisci debitis fugit cumque distinctio voluptatem.",
 	"title": "Rustic Fresh Chicken",
@@ -142204,11 +137254,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Quo nulla nihil qui. Id molestiae voluptatem. Quibusdam sed quas. Ipsum ullam quae ducimus voluptas at architecto ea. Porro aut cum molestiae autem sapiente modi tenetur esse omnis.",
 	"title": "Intelligent Cotton Cheese",
@@ -142392,11 +137437,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Possimus at aut. Est ipsam sit veritatis perferendis asperiores sunt ipsum dolorem. Fugit molestias iste saepe voluptas. Placeat iusto doloribus qui aliquid aut nisi vel eveniet. Esse quis non porro id.",
 	"title": "Gorgeous Concrete Tuna",
@@ -142522,11 +137562,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Unde ut eum quia neque maxime. Quia reiciendis et ut. Possimus tempore eum esse quia tempora error repellendus. Possimus quo libero iste consequuntur dolorum impedit. Magni recusandae eveniet est et.",
 	"title": "Handmade Cotton Chair",
@@ -142623,11 +137658,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Maiores veritatis qui corporis. Consequatur omnis nobis tempora sed nulla. Ab rerum et quis eveniet nostrum amet. Veritatis tempore blanditiis.",
 	"title": "Handmade Concrete Soap",
@@ -142782,11 +137812,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Quidem eum vel repudiandae sit dolor nostrum et. Sequi unde sint ipsa. Consequatur fugit minima necessitatibus aspernatur expedita quam optio et iste. Nam qui possimus et non.",
 	"title": "Generic Cotton Sausages",
@@ -142970,11 +137995,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Quam et autem perferendis illum aut. Vel excepturi aut aut qui architecto mollitia corrupti omnis. Et necessitatibus consequatur consequatur quas id neque totam voluptates et. Aut esse vel blanditiis dicta. Culpa inventore ut autem temporibus repudiandae laboriosam iste.",
 	"title": "Tasty Metal Pants",
@@ -143100,11 +138120,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Nesciunt provident illo voluptatibus facere autem occaecati. Dicta consequatur unde enim culpa illum labore. Nemo nihil sed dolores voluptatem voluptatem maiores. Temporibus velit quia earum repellat.",
 	"title": "Handcrafted Frozen Sausages",
@@ -143259,11 +138274,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Nulla dolor fugit omnis. Ea fugiat placeat laborum. Consequatur dolore aut aliquam aliquid optio distinctio consequuntur. Enim dolorum suscipit voluptates veniam dolore nemo quae quia. Animi iste quia sit.",
 	"title": "Fantastic Soft Shoes",
@@ -143447,11 +138457,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Magni eos sequi. Autem laboriosam officiis explicabo. In vitae aut itaque voluptas qui facilis amet. Voluptatem modi nisi. Et magnam aut explicabo voluptatem voluptas et ratione pariatur et. Quasi magnam explicabo magnam exercitationem aut et.",
 	"title": "Licensed Fresh Mouse",
@@ -143577,11 +138582,6 @@
 	"isLowQuantity": false,
 	"isSoldOut": false,
 	"isBackorder": false,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [],
 	"description": "Officiis nostrum non veniam alias in aperiam. Nihil dolore aut. Temporibus odio earum. Animi aut ratione.",
 	"title": "Incredible Frozen Cheese",

--- a/sample-data/data/medium/Products.json
+++ b/sample-data/data/medium/Products.json
@@ -1,6 +1,7 @@
 [{
 	"_id": "aKJFQeJtNmGPmM364",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -184,6 +185,7 @@
 {
 	"_id": "rrXuhyosB32PBy6tK",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -280,6 +282,7 @@
 {
 	"_id": "fegdvsry3akBXJ2zL",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -376,6 +379,7 @@
 {
 	"_id": "8mXcqJTjZHPdLSMDt",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -530,6 +534,7 @@
 {
 	"_id": "uC3BSubYxWnMxE9pw",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -626,6 +631,7 @@
 {
 	"_id": "waZN8YzkqJoWCbDar",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -780,6 +786,7 @@
 {
 	"_id": "jrq2saL3YHn5wWaFG",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -905,6 +912,7 @@
 {
 	"_id": "B5bmhoEvdvTwx48Z4",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -1030,6 +1038,7 @@
 {
 	"_id": "aELvF7679AL2hWmWG",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -1126,6 +1135,7 @@
 {
 	"_id": "ppGE5EhZQfNXPnMKk",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -1251,6 +1261,7 @@
 {
 	"_id": "AR2qMo5D4wEJDX9bQ",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -1347,6 +1358,7 @@
 {
 	"_id": "S9w2QXBXpGsSDEqga",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -1443,6 +1455,7 @@
 {
 	"_id": "h2mg8udfnXJnWM7ck",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -1597,6 +1610,7 @@
 {
 	"_id": "FR8fRRNmkdSbmWKef",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -1722,6 +1736,7 @@
 {
 	"_id": "cRZwuDHSBKLgCjHDZ",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -1905,6 +1920,7 @@
 {
 	"_id": "G4sbbdESBHJeDxnsN",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -2088,6 +2104,7 @@
 {
 	"_id": "if7SKfKAzQLaQ9Exd",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -2184,6 +2201,7 @@
 {
 	"_id": "cGbBRhQbcSNqPPqWS",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -2338,6 +2356,7 @@
 {
 	"_id": "j82ytxuYL35XdyEMS",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -2463,6 +2482,7 @@
 {
 	"_id": "JEaBHbzkcTNpFxdGk",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -2646,6 +2666,7 @@
 {
 	"_id": "q95qurEmFLhevDLhr",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -2771,6 +2792,7 @@
 {
 	"_id": "eHcZu5ZvjQ8ffNmbq",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -2896,6 +2918,7 @@
 {
 	"_id": "SQhgk577GPeTnnSMY",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -3050,6 +3073,7 @@
 {
 	"_id": "epNS9pqgbXzsAHPxc",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -3175,6 +3199,7 @@
 {
 	"_id": "zXgPXtHMFdbuofT35",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -3329,6 +3354,7 @@
 {
 	"_id": "bwJhPFXyomoqZ3zin",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -3454,6 +3480,7 @@
 {
 	"_id": "5jRj63ZeK7eJxWjrE",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -3637,6 +3664,7 @@
 {
 	"_id": "FZ5uqG2GuJZ5zfj5K",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -3762,6 +3790,7 @@
 {
 	"_id": "K7ez8e4EBLXFsvfGC",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -3945,6 +3974,7 @@
 {
 	"_id": "s8we293KPBz3ZqWE8",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -4128,6 +4158,7 @@
 {
 	"_id": "Nvy5CLdTiCYNYaqLn",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -4224,6 +4255,7 @@
 {
 	"_id": "bE9P6m64s2DmdJpbf",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -4378,6 +4410,7 @@
 {
 	"_id": "mxpQjKGWRzeTL9xHc",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -4532,6 +4565,7 @@
 {
 	"_id": "aMtepdd67NcTMQgma",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -4657,6 +4691,7 @@
 {
 	"_id": "pZu35WznN3Pq4od8v",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -4753,6 +4788,7 @@
 {
 	"_id": "veY5wR6f3gGwAbohz",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -4907,6 +4943,7 @@
 {
 	"_id": "DLBcCszHRqvqnsq7p",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -5003,6 +5040,7 @@
 {
 	"_id": "t6ZB4j8NnJ4GREqnw",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -5099,6 +5137,7 @@
 {
 	"_id": "pDjs9LaiiohoRtL9f",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -5224,6 +5263,7 @@
 {
 	"_id": "DbMahAxw9jQB5ein8",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -5320,6 +5360,7 @@
 {
 	"_id": "PwKrfEq5bT373fL2X",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -5416,6 +5457,7 @@
 {
 	"_id": "g2EgfgYoD4sDD8vtX",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -5541,6 +5583,7 @@
 {
 	"_id": "meXAxHtudtNPsCRJo",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -5724,6 +5767,7 @@
 {
 	"_id": "CjyJmgnKDPHZiJhHZ",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -5849,6 +5893,7 @@
 {
 	"_id": "gDHqZtCsdfR375JFo",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -6003,6 +6048,7 @@
 {
 	"_id": "qHjPoLvQprqzB8zPk",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -6128,6 +6174,7 @@
 {
 	"_id": "5Kihds3BDTmt62bEq",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -6311,6 +6358,7 @@
 {
 	"_id": "pbPyd3GCsMQXyCMhA",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -6436,6 +6484,7 @@
 {
 	"_id": "3PtuqHD3nP4auRwoX",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -6561,6 +6610,7 @@
 {
 	"_id": "ibGcsnGDj4trwuJnd",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -6657,6 +6707,7 @@
 {
 	"_id": "rZjGkmJekGE2NJm6i",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -6753,6 +6804,7 @@
 {
 	"_id": "Mvt2ckTNffWdjoL27",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -6849,6 +6901,7 @@
 {
 	"_id": "XibbBcgwHEqqkNDSa",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -6945,6 +6998,7 @@
 {
 	"_id": "345WF5NJwxbRR5L8j",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -7099,6 +7153,7 @@
 {
 	"_id": "Ru4Jq9gDirQLepvZD",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -7195,6 +7250,7 @@
 {
 	"_id": "LLc6jCky8B4MBsgj5",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -7349,6 +7405,7 @@
 {
 	"_id": "iCzC9CkfdPogdtHr9",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -7445,6 +7502,7 @@
 {
 	"_id": "NfwH4wgfzx53wZYW2",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -7628,6 +7686,7 @@
 {
 	"_id": "a3sTfQo2YxiQFbF5m",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -7753,6 +7812,7 @@
 {
 	"_id": "BZcN4avcg2rqtakAc",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -7878,6 +7938,7 @@
 {
 	"_id": "CeChg8w5xcbAz9XBx",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -8061,6 +8122,7 @@
 {
 	"_id": "CrJgoRqfPZJsED5KE",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -8244,6 +8306,7 @@
 {
 	"_id": "Z2kcCn2uCwaWBkWPs",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -8340,6 +8403,7 @@
 {
 	"_id": "dHAbxTRBSBYEnW5wQ",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -8523,6 +8587,7 @@
 {
 	"_id": "qN6MEdwzu9a2JzupD",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -8677,6 +8742,7 @@
 {
 	"_id": "ExhbxMzhARMtjJToz",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -8802,6 +8868,7 @@
 {
 	"_id": "QxGjusx8Le3jb37HA",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -8985,6 +9052,7 @@
 {
 	"_id": "jcCJxkHgWdaGm5GCH",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -9110,6 +9178,7 @@
 {
 	"_id": "2nbgqDe6R6JZZBCTj",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -9206,6 +9275,7 @@
 {
 	"_id": "JZqpCGyD3PSMCxrW2",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -9331,6 +9401,7 @@
 {
 	"_id": "WbMPgratHKydHB77t",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -9485,6 +9556,7 @@
 {
 	"_id": "7KJAZoxa2Cy3RRmeQ",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -9610,6 +9682,7 @@
 {
 	"_id": "azR5jEY5NsB6rWxHS",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -9764,6 +9837,7 @@
 {
 	"_id": "Lt3nnM4MXWHtA7QJb",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -9889,6 +9963,7 @@
 {
 	"_id": "mGYzCqMMjCjZFZyks",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -9985,6 +10060,7 @@
 {
 	"_id": "tMtC6ATWm5ecGwDkc",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -10110,6 +10186,7 @@
 {
 	"_id": "PtuTwe429XPSCSbHL",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -10293,6 +10370,7 @@
 {
 	"_id": "8knmfbwFK9N4qDbnK",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -10447,6 +10525,7 @@
 {
 	"_id": "7qhtQCtbd8Ka8LbbP",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -10601,6 +10680,7 @@
 {
 	"_id": "8g4P8FzkfNwiYLQ8G",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -10784,6 +10864,7 @@
 {
 	"_id": "uSL5ocsMgSF4Z3ikh",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -10938,6 +11019,7 @@
 {
 	"_id": "wvKR7Xu4Qe92QP5ka",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -11092,6 +11174,7 @@
 {
 	"_id": "4dEAqwC6amiMW5BMn",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -11275,6 +11358,7 @@
 {
 	"_id": "Lj32BSPY4aujhHhpg",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -11429,6 +11513,7 @@
 {
 	"_id": "bkcumPzmwF8XAq5Z9",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -11554,6 +11639,7 @@
 {
 	"_id": "jZ6i6Hn64w48K2x9Y",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -11708,6 +11794,7 @@
 {
 	"_id": "EjuWcru9otrLB94fe",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -11833,6 +11920,7 @@
 {
 	"_id": "TdGjzrADdijjMrans",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -11958,6 +12046,7 @@
 {
 	"_id": "iJsWF9Kw4JkKYx3eo",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -12112,6 +12201,7 @@
 {
 	"_id": "YzRx4hRtndMe8AxnQ",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -12237,6 +12327,7 @@
 {
 	"_id": "StbCBGiNPaaiZvTT7",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -12391,6 +12482,7 @@
 {
 	"_id": "mdhdxJXneGSwz7n7X",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -12545,6 +12637,7 @@
 {
 	"_id": "EavidAPBdb3hGqEkQ",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -12641,6 +12734,7 @@
 {
 	"_id": "uAzfZkAfLrvwy9nXT",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -12737,6 +12831,7 @@
 {
 	"_id": "2YujjjTMJDk9eFG2Z",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -12891,6 +12986,7 @@
 {
 	"_id": "SpDZLKXgaMbNMJtKj",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -13074,6 +13170,7 @@
 {
 	"_id": "HNR9DyvQ5HJe7hBEy",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -13170,6 +13267,7 @@
 {
 	"_id": "8R96EZMte2qrsNXCm",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -13266,6 +13364,7 @@
 {
 	"_id": "PB6M3Dv4seBWCuDXy",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -13420,6 +13519,7 @@
 {
 	"_id": "Y5SYqdo48crHRJzsq",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -13603,6 +13703,7 @@
 {
 	"_id": "6pi4gaKBuufDnuRge",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -13786,6 +13887,7 @@
 {
 	"_id": "ztZzbPGSi4iRsN8fb",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -13969,6 +14071,7 @@
 {
 	"_id": "vGQtCb9Am8kyLfvEw",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -14123,6 +14226,7 @@
 {
 	"_id": "rYsWiqACdQC9XZnns",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -14277,6 +14381,7 @@
 {
 	"_id": "9F7ha8cjXCwZ5PrEz",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -14460,6 +14565,7 @@
 {
 	"_id": "g9xRXvrZerjYqAQSa",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -14585,6 +14691,7 @@
 {
 	"_id": "cRjheYjeAiCu7Xoh4",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -14768,6 +14875,7 @@
 {
 	"_id": "uG9EEHfpqEGN8jhph",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -14922,6 +15030,7 @@
 {
 	"_id": "yfx6YSQeRyxH3m6m2",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -15076,6 +15185,7 @@
 {
 	"_id": "ZjuvfXDBd3JyZLjhX",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -15230,6 +15340,7 @@
 {
 	"_id": "rp8Ttf8Muj8LCt2k5",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -15384,6 +15495,7 @@
 {
 	"_id": "fSmS5noJsjcP3Qde9",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -15509,6 +15621,7 @@
 {
 	"_id": "twWNyKkTptTdApqch",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -15605,6 +15718,7 @@
 {
 	"_id": "ewj6EbgpFpYRcpywa",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -15730,6 +15844,7 @@
 {
 	"_id": "Wt9cKF99h9kpYe7W3",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -15826,6 +15941,7 @@
 {
 	"_id": "bRbfG3mn7NohX5GHH",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -15951,6 +16067,7 @@
 {
 	"_id": "MX2ZLmAnMzTTc4W7F",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -16134,6 +16251,7 @@
 {
 	"_id": "CQsYYc2Wd4HpwYyY6",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -16259,6 +16377,7 @@
 {
 	"_id": "joCsbThukYi6M5heX",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -16442,6 +16561,7 @@
 {
 	"_id": "9MJNLpxyKvWewk8ik",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -16567,6 +16687,7 @@
 {
 	"_id": "BzYWmMhRfHXYbNARb",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -16692,6 +16813,7 @@
 {
 	"_id": "5KBtZ8QxgX8AXM3FN",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -16817,6 +16939,7 @@
 {
 	"_id": "aKrh93z8gGSZbgd7D",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -16971,6 +17094,7 @@
 {
 	"_id": "vow2LAAsbfbpuzRnA",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -17096,6 +17220,7 @@
 {
 	"_id": "37r2ME3FvJ5729qtS",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -17192,6 +17317,7 @@
 {
 	"_id": "rkZTbHYTtko9mSMAx",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -17375,6 +17501,7 @@
 {
 	"_id": "oEfwpwK7N7EngiMiY",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -17529,6 +17656,7 @@
 {
 	"_id": "vWCRTERo4nTFpHNcE",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -17654,6 +17782,7 @@
 {
 	"_id": "xHot4mBBDMu9RN89w",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -17808,6 +17937,7 @@
 {
 	"_id": "o956pvipwjeqSgr7M",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -17991,6 +18121,7 @@
 {
 	"_id": "JosckbGax5bu8cTd5",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -18087,6 +18218,7 @@
 {
 	"_id": "jhq2tGeCtCAuEcLuv",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -18212,6 +18344,7 @@
 {
 	"_id": "tA5vFnnnRNeGYyp2b",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -18395,6 +18528,7 @@
 {
 	"_id": "kyhir9wjXhm7AfW4c",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -18520,6 +18654,7 @@
 {
 	"_id": "iKFBj7KNxvkEJSaSD",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -18674,6 +18809,7 @@
 {
 	"_id": "gbDARXiteeEnhF6Fn",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -18770,6 +18906,7 @@
 {
 	"_id": "5ghNk9bdvo8qsfitF",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -18924,6 +19061,7 @@
 {
 	"_id": "hAQiMNP4gQkcXBRow",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -19049,6 +19187,7 @@
 {
 	"_id": "iuiaeqy4NewwDqKBk",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -19174,6 +19313,7 @@
 {
 	"_id": "ZcWPdWyTiiyJEnMJa",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -19270,6 +19410,7 @@
 {
 	"_id": "C3kbHRaXm65JHy4cf",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -19395,6 +19536,7 @@
 {
 	"_id": "rf7n63d2gCzWXzXbj",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -19549,6 +19691,7 @@
 {
 	"_id": "QauDRpb79xsop5Wh7",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -19732,6 +19875,7 @@
 {
 	"_id": "tmwxuigMHeZHSuKdG",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -19857,6 +20001,7 @@
 {
 	"_id": "KHnDepaMd62arK3iE",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -19982,6 +20127,7 @@
 {
 	"_id": "M2mB2vhv3MiAvpi3s",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -20136,6 +20282,7 @@
 {
 	"_id": "NyPR8EJxemJ9kWoaJ",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -20261,6 +20408,7 @@
 {
 	"_id": "mu2EjxS788J56mpMa",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -20444,6 +20592,7 @@
 {
 	"_id": "g7PWA3i3wPTu9GhxJ",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -20627,6 +20776,7 @@
 {
 	"_id": "HCpKDapTKuBGHe2vy",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -20752,6 +20902,7 @@
 {
 	"_id": "vAsT4XrvdHLhC3oxE",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -20848,6 +20999,7 @@
 {
 	"_id": "W4uWZt77qJu6uLv7d",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -21002,6 +21154,7 @@
 {
 	"_id": "EMsba6K6dZcCrzuFg",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -21127,6 +21280,7 @@
 {
 	"_id": "8TvL4Hai3gmPjF7Si",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -21310,6 +21464,7 @@
 {
 	"_id": "HHJW3QKycnSgyLH5j",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -21406,6 +21561,7 @@
 {
 	"_id": "DiiPJXjeXzjYnk76X",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -21560,6 +21716,7 @@
 {
 	"_id": "AJAwLbfZyEFmcPpzv",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -21714,6 +21871,7 @@
 {
 	"_id": "GEHWwoLWP9FbewgiJ",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -21810,6 +21968,7 @@
 {
 	"_id": "FLJXJ9akHHbasAZzj",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -21964,6 +22123,7 @@
 {
 	"_id": "wn3Yu66roM5wRwTin",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -22089,6 +22249,7 @@
 {
 	"_id": "4LeXkyju7YqB3FxNC",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -22185,6 +22346,7 @@
 {
 	"_id": "pE2FdLLkBHyKPZpzk",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -22339,6 +22501,7 @@
 {
 	"_id": "yNh32kccWYuYJnZAN",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -22435,6 +22598,7 @@
 {
 	"_id": "3ybTi6gBL57iumN4B",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -22531,6 +22695,7 @@
 {
 	"_id": "5B2zh2KnMATYm6rvE",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -22714,6 +22879,7 @@
 {
 	"_id": "FbzabM9aHtc3kNdoE",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -22839,6 +23005,7 @@
 {
 	"_id": "Y7m936fYWHNSA7CTG",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -22935,6 +23102,7 @@
 {
 	"_id": "YsJZ5pTy6brqogq7m",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -23089,6 +23257,7 @@
 {
 	"_id": "bMGfbSXxdHhC9yLhC",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -23272,6 +23441,7 @@
 {
 	"_id": "zoBwMBS6fqJsuW34X",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -23397,6 +23567,7 @@
 {
 	"_id": "tK8kwCoJBqseHYQHu",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -23551,6 +23722,7 @@
 {
 	"_id": "DWkbHMZbDe4jdQxqF",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -23705,6 +23877,7 @@
 {
 	"_id": "vQHNCsDhkeYPrnyje",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -23859,6 +24032,7 @@
 {
 	"_id": "Gom7NnAi2X6kc4oFh",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -24042,6 +24216,7 @@
 {
 	"_id": "XSCKEBT89ryjoE6gN",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -24196,6 +24371,7 @@
 {
 	"_id": "cms3RDzrBP95vF9kp",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -24379,6 +24555,7 @@
 {
 	"_id": "k3S6bh3Qj2BSvt5rD",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -24562,6 +24739,7 @@
 {
 	"_id": "rCwFjcQic4N5p9bbK",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -24658,6 +24836,7 @@
 {
 	"_id": "eTo84koEEvCYFBPW8",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -24841,6 +25020,7 @@
 {
 	"_id": "PvkAu9Y7HSXJECa3c",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -24937,6 +25117,7 @@
 {
 	"_id": "4QAdSam7scy9qhZ3s",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -25120,6 +25301,7 @@
 {
 	"_id": "osg6HwQDwm82H7tGE",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -25303,6 +25485,7 @@
 {
 	"_id": "L4LmP7vMbEnGPgqmo",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -25428,6 +25611,7 @@
 {
 	"_id": "pF6hT8ogwCrSHYTFt",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -25611,6 +25795,7 @@
 {
 	"_id": "NuLEbXoXWzSiiXsM4",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -25736,6 +25921,7 @@
 {
 	"_id": "LGRhjXuhLxY7PTztR",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -25919,6 +26105,7 @@
 {
 	"_id": "yFg8HFbGLmJtazsS8",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -26015,6 +26202,7 @@
 {
 	"_id": "5mABqqyovFaHkvpnS",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -26169,6 +26357,7 @@
 {
 	"_id": "o7FuitQinEAawcLKM",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -26323,6 +26512,7 @@
 {
 	"_id": "YMBimzM2dYyJ5E72E",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -26506,6 +26696,7 @@
 {
 	"_id": "CnJDngHrEwWJWn7JL",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -26602,6 +26793,7 @@
 {
 	"_id": "YyLzoarJ68zk7BrzT",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -26727,6 +26919,7 @@
 {
 	"_id": "TDSy97gbRct8q4SEj",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -26823,6 +27016,7 @@
 {
 	"_id": "xMwu2sKxgFnNfZfkC",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -26948,6 +27142,7 @@
 {
 	"_id": "yHcFC5Jkv6F8WxJE7",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -27131,6 +27326,7 @@
 {
 	"_id": "RFb5YBG3wB75joNRz",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -27227,6 +27423,7 @@
 {
 	"_id": "bi3bx6RmMi7xKs22P",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -27410,6 +27607,7 @@
 {
 	"_id": "T9z3juLeigaqTXLJD",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -27593,6 +27791,7 @@
 {
 	"_id": "DaYt2hxEQ5RZPYCYx",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -27689,6 +27888,7 @@
 {
 	"_id": "w4Xda6j5TuHQKaqyD",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -27843,6 +28043,7 @@
 {
 	"_id": "bxoR4HfRzoDrBzTYF",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -27968,6 +28169,7 @@
 {
 	"_id": "BnWRmpn4D89gsdfMw",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -28093,6 +28295,7 @@
 {
 	"_id": "9LwJRBN9zwWus8ztJ",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -28247,6 +28450,7 @@
 {
 	"_id": "bWzMimoXQPzDYBR4c",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -28430,6 +28634,7 @@
 {
 	"_id": "skPQPgdWBLoQx7Cqh",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -28555,6 +28760,7 @@
 {
 	"_id": "RgP4bcxjv2mHotSDF",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -28709,6 +28915,7 @@
 {
 	"_id": "oBSvty9YjSmzh32KR",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -28863,6 +29070,7 @@
 {
 	"_id": "J4hqK3yRxRxcmFic3",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -29017,6 +29225,7 @@
 {
 	"_id": "bX8Zo6dy3R8L5nvYF",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -29200,6 +29409,7 @@
 {
 	"_id": "a2mHm4S5ggiQbgkYC",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -29325,6 +29535,7 @@
 {
 	"_id": "7WxojxGr4o23wsfQ6",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -29450,6 +29661,7 @@
 {
 	"_id": "PqRciCDYKDFLJv2PH",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -29575,6 +29787,7 @@
 {
 	"_id": "yZPMbQGEdg5P3Faka",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -29729,6 +29942,7 @@
 {
 	"_id": "KpdftvR4MG5bcFiJ2",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -29825,6 +30039,7 @@
 {
 	"_id": "JyxPtr3KyCKbWHdfa",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -30008,6 +30223,7 @@
 {
 	"_id": "sq3BkLSJAL3kA4e6b",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -30133,6 +30349,7 @@
 {
 	"_id": "bKZT5H2ukqzdiqKXN",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -30258,6 +30475,7 @@
 {
 	"_id": "YtrXAwFBoaxFqfu7x",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -30441,6 +30659,7 @@
 {
 	"_id": "9FpBqgHKSfhza6Q9v",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -30595,6 +30814,7 @@
 {
 	"_id": "gHH2HSkZuNssjmtRp",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -30749,6 +30969,7 @@
 {
 	"_id": "EwezwA84bjQHig2bb",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -30845,6 +31066,7 @@
 {
 	"_id": "8zXzbLF3RwGjN2Lof",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -31028,6 +31250,7 @@
 {
 	"_id": "pryz548aG6iv5KTFF",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -31153,6 +31376,7 @@
 {
 	"_id": "LhjWZZiJbAejeFNxW",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -31249,6 +31473,7 @@
 {
 	"_id": "Qq63dAMkWDPLPJZGw",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -31345,6 +31570,7 @@
 {
 	"_id": "4PPsYCppBfTTpcfRz",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -31528,6 +31754,7 @@
 {
 	"_id": "Zhd2timtT5N2Qqsix",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -31653,6 +31880,7 @@
 {
 	"_id": "sJQohJ6w4znfkDRcQ",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -31807,6 +32035,7 @@
 {
 	"_id": "eKD2AdHzL4RQ7PNpS",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -31903,6 +32132,7 @@
 {
 	"_id": "mifnFvttWHGRaDjsQ",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -32057,6 +32287,7 @@
 {
 	"_id": "i4jqPfpkhM37EH98e",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -32240,6 +32471,7 @@
 {
 	"_id": "wjeisigc82m4ehudS",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -32423,6 +32655,7 @@
 {
 	"_id": "APpxWpE9RjrHoM4Na",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -32606,6 +32839,7 @@
 {
 	"_id": "o5aSCv98a7Dtza2TK",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -32760,6 +32994,7 @@
 {
 	"_id": "hoz4Q2XKdTFLKAEnu",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -32885,6 +33120,7 @@
 {
 	"_id": "zKuigjFhSBJjRCRdw",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -32981,6 +33217,7 @@
 {
 	"_id": "r9EjnSZrE9ffFKo8F",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -33077,6 +33314,7 @@
 {
 	"_id": "TJ2aeJYX4sMhJdyXB",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -33202,6 +33440,7 @@
 {
 	"_id": "Yy4AZbhaEDuJRsWdo",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -33298,6 +33537,7 @@
 {
 	"_id": "6koveGu8wYbYyNby7",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -33394,6 +33634,7 @@
 {
 	"_id": "4hJSXabyxw8qXdyy3",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -33519,6 +33760,7 @@
 {
 	"_id": "zHe2jKmvA2iqRApgz",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -33673,6 +33915,7 @@
 {
 	"_id": "ijRxvMf4mycf4xLwu",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -33769,6 +34012,7 @@
 {
 	"_id": "dN3vykYq6HvCC5GoM",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -33923,6 +34167,7 @@
 {
 	"_id": "fTN9MWB37qF6EoSJS",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -34077,6 +34322,7 @@
 {
 	"_id": "DhXPnWrHMy26RPC8J",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -34231,6 +34477,7 @@
 {
 	"_id": "G9r4Se8HKYACxfXRR",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -34414,6 +34661,7 @@
 {
 	"_id": "ZwDFSCTHgsH3G9iCc",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -34539,6 +34787,7 @@
 {
 	"_id": "H4MimGDFp7XEvvvro",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -34693,6 +34942,7 @@
 {
 	"_id": "MAC4NKd2CgDoynKqv",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -34818,6 +35068,7 @@
 {
 	"_id": "p6Jf38fLrxGTeaKER",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -34914,6 +35165,7 @@
 {
 	"_id": "9CkzXieWcBdBZgNHR",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -35010,6 +35262,7 @@
 {
 	"_id": "AtL5oXyt6cfjcdwgH",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -35135,6 +35388,7 @@
 {
 	"_id": "zEoWYmkCoEufAEzyq",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -35318,6 +35572,7 @@
 {
 	"_id": "FkkMN2oAtCDaAGHho",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -35501,6 +35756,7 @@
 {
 	"_id": "ZTz3L4NvjJTktfKjy",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -35597,6 +35853,7 @@
 {
 	"_id": "WPxGx5k7vSmuh8kDG",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -35751,6 +36008,7 @@
 {
 	"_id": "zS7N57mSvDuQyyuCi",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -35876,6 +36134,7 @@
 {
 	"_id": "bgHiRezdv96dRvwZa",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -36059,6 +36318,7 @@
 {
 	"_id": "mciEP5mSrZ9JrPtDi",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -36155,6 +36415,7 @@
 {
 	"_id": "LgyvYG8CfF3nfg2cN",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -36251,6 +36512,7 @@
 {
 	"_id": "qMfrjBxHt8erYSR2d",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -36434,6 +36696,7 @@
 {
 	"_id": "Cra9kFHqJWJFRTru2",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -36530,6 +36793,7 @@
 {
 	"_id": "Ltw3hhwjMb5L3CpQW",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -36713,6 +36977,7 @@
 {
 	"_id": "QiPAZRGBFiZw7Ckhh",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -36867,6 +37132,7 @@
 {
 	"_id": "hQLJbeemxbrcMszEq",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -36963,6 +37229,7 @@
 {
 	"_id": "8yEw4hxrauroQdnXr",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -37117,6 +37384,7 @@
 {
 	"_id": "wpaAzirfxYuSfyTre",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -37242,6 +37510,7 @@
 {
 	"_id": "Jejd5DuFQe29ir4pw",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -37396,6 +37665,7 @@
 {
 	"_id": "DPkypFqpJ33Dr65JX",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -37579,6 +37849,7 @@
 {
 	"_id": "xxwYPHM2pD9Gx5wTX",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -37675,6 +37946,7 @@
 {
 	"_id": "uffG7FsDyyqYTs6K7",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -37800,6 +38072,7 @@
 {
 	"_id": "pxiJwb824AHFgnoco",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -37925,6 +38198,7 @@
 {
 	"_id": "oPDG2YfnzH6d7sbwe",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -38079,6 +38353,7 @@
 {
 	"_id": "gNJYvb4pdZf2rDeZJ",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -38175,6 +38450,7 @@
 {
 	"_id": "NHmkjrnDNYpXLnnsi",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -38329,6 +38605,7 @@
 {
 	"_id": "i6a4M66zNhaGtYTJe",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -38483,6 +38760,7 @@
 {
 	"_id": "QCsvjAazCbss25dzG",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -38608,6 +38886,7 @@
 {
 	"_id": "wGB8mPcAfsSzBPrxY",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -38733,6 +39012,7 @@
 {
 	"_id": "5LseskwQQZB2GLAXP",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -38916,6 +39196,7 @@
 {
 	"_id": "CzqLWQHvxrPpYcZQb",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -39012,6 +39293,7 @@
 {
 	"_id": "etuoGSdCWARnsiNhg",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -39195,6 +39477,7 @@
 {
 	"_id": "roeanx7bWmDznS8Cx",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -39320,6 +39603,7 @@
 {
 	"_id": "EEfYcdJqqyTKGbd6K",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -39503,6 +39787,7 @@
 {
 	"_id": "8PyuyuCzZYiWe6uED",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -39599,6 +39884,7 @@
 {
 	"_id": "LPfD527R5Qe2KJPz4",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -39753,6 +40039,7 @@
 {
 	"_id": "AmA3ATjjGR42KiJt3",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -39878,6 +40165,7 @@
 {
 	"_id": "fb3qo2wSBdXYALXuM",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -39974,6 +40262,7 @@
 {
 	"_id": "XbmMC2s2pZyc9pPAg",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -40157,6 +40446,7 @@
 {
 	"_id": "TCjiZFwnXNDDDPM9M",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -40311,6 +40601,7 @@
 {
 	"_id": "8CoqvzpNXWZca4LpR",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -40494,6 +40785,7 @@
 {
 	"_id": "mLYkS5dzAyTvSyTmA",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -40677,6 +40969,7 @@
 {
 	"_id": "ayNuEc6Xuq2JCWu4z",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -40773,6 +41066,7 @@
 {
 	"_id": "4XzSr4CLKG32vzQoH",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -40956,6 +41250,7 @@
 {
 	"_id": "7aqyKQXcbdGSQCDgE",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -41052,6 +41347,7 @@
 {
 	"_id": "ekTaCdEJ4Bz8uCW4A",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -41148,6 +41444,7 @@
 {
 	"_id": "7RXNPXogANxSsbbzN",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -41302,6 +41599,7 @@
 {
 	"_id": "Katz55RSS7m2yQySj",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -41485,6 +41783,7 @@
 {
 	"_id": "uX9fgL7G6TZ95jMFG",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -41581,6 +41880,7 @@
 {
 	"_id": "sMQZqP4FKSsFiRAqh",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -41677,6 +41977,7 @@
 {
 	"_id": "DkyQQqMtDePZPRX6c",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -41860,6 +42161,7 @@
 {
 	"_id": "4N2ggmwTR79DYhySr",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -41956,6 +42258,7 @@
 {
 	"_id": "gJjkSxeCTSPA84DWt",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -42052,6 +42355,7 @@
 {
 	"_id": "sesanw2MHaugk7wYv",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -42148,6 +42452,7 @@
 {
 	"_id": "h6qifcvyNeWzCL9Mk",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -42273,6 +42578,7 @@
 {
 	"_id": "vWrpoJhkHAQWMXQ7n",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -42427,6 +42733,7 @@
 {
 	"_id": "HvxvRKempSBsmgq5Z",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -42610,6 +42917,7 @@
 {
 	"_id": "xYCe8AApvEw4jrY2N",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -42735,6 +43043,7 @@
 {
 	"_id": "yvDwG7WDSujvYzFs9",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -42889,6 +43198,7 @@
 {
 	"_id": "uRccWatqLHmj56nNe",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -42985,6 +43295,7 @@
 {
 	"_id": "MZkmgeGnRHsx3WQzD",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -43139,6 +43450,7 @@
 {
 	"_id": "XxkQ9fnAMrTzuKved",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -43264,6 +43576,7 @@
 {
 	"_id": "FnNgHEsqnMep2qTg6",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -43360,6 +43673,7 @@
 {
 	"_id": "gEjFd9eC6xb6mMF5P",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -43485,6 +43799,7 @@
 {
 	"_id": "jCpnTFCdiaYT7qhKq",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -43610,6 +43925,7 @@
 {
 	"_id": "L99ME5JuD385QdCKJ",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -43793,6 +44109,7 @@
 {
 	"_id": "6shGnLRLJoMgycJ4h",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -43889,6 +44206,7 @@
 {
 	"_id": "itKqJDeRvzER9rxB2",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -44014,6 +44332,7 @@
 {
 	"_id": "b5X3txMAukLqCEdWr",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -44110,6 +44429,7 @@
 {
 	"_id": "u69kRdH7urhqr6nya",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -44293,6 +44613,7 @@
 {
 	"_id": "hLTEQ28Pnp6aHQAyT",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -44389,6 +44710,7 @@
 {
 	"_id": "tnAq5mtYpSDubmupc",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -44572,6 +44894,7 @@
 {
 	"_id": "ndrKBgSzRrYqCSLyd",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -44668,6 +44991,7 @@
 {
 	"_id": "H98n3dDDEnvpo33QN",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -44851,6 +45175,7 @@
 {
 	"_id": "4wvPPJnQanto6JTmq",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -44947,6 +45272,7 @@
 {
 	"_id": "czjSNrAiKteD8XWYd",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -45130,6 +45456,7 @@
 {
 	"_id": "3KXM4xGsFxdfsvsM8",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -45226,6 +45553,7 @@
 {
 	"_id": "7SQL6r7XzhD8LTyMy",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -45409,6 +45737,7 @@
 {
 	"_id": "FdykWuTAT9ekHv5pg",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -45505,6 +45834,7 @@
 {
 	"_id": "c5r3ajJbn7K8nQmHT",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -45630,6 +45960,7 @@
 {
 	"_id": "oGL6BHBaPZzGYYGru",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -45784,6 +46115,7 @@
 {
 	"_id": "E5338oii6PpW5pWju",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -45967,6 +46299,7 @@
 {
 	"_id": "GrJEcxrsLscouAutn",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -46063,6 +46396,7 @@
 {
 	"_id": "M36ReoAtCepjC3Z8o",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -46246,6 +46580,7 @@
 {
 	"_id": "Z4hdxfscwK2bqPavi",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -46400,6 +46735,7 @@
 {
 	"_id": "tv7naoyxCdRQcGxEW",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -46525,6 +46861,7 @@
 {
 	"_id": "xgJZ2BNzxXctZeAee",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -46621,6 +46958,7 @@
 {
 	"_id": "rCYrExFcETEqKpraX",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -46775,6 +47113,7 @@
 {
 	"_id": "8tRWjtKYxxMnzQDNt",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -46900,6 +47239,7 @@
 {
 	"_id": "MiXpfDJWiTLpkwRdk",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -47054,6 +47394,7 @@
 {
 	"_id": "PTRfDEN9B4LiKbs3w",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -47179,6 +47520,7 @@
 {
 	"_id": "xiuxdzaw3MY2aJKWH",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -47333,6 +47675,7 @@
 {
 	"_id": "RPn5k7GfGQMaorskr",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -47516,6 +47859,7 @@
 {
 	"_id": "NfyyFjBvAcbb9PWe4",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -47612,6 +47956,7 @@
 {
 	"_id": "ikLoMs9WnZTuoXEi2",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -47766,6 +48111,7 @@
 {
 	"_id": "xXS7q9eh3zxiudKZR",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -47920,6 +48266,7 @@
 {
 	"_id": "cBKSAbNeTLnmHzYXa",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -48045,6 +48392,7 @@
 {
 	"_id": "qFYWGzavFM8HnLP7u",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -48228,6 +48576,7 @@
 {
 	"_id": "96B4QdcHMazXW7JYm",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -48353,6 +48702,7 @@
 {
 	"_id": "pErq9z8yTTjuCYvh3",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -48478,6 +48828,7 @@
 {
 	"_id": "RGchcq9QYEmLt2Cdu",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -48661,6 +49012,7 @@
 {
 	"_id": "KmXtTPMmxrivjjmtb",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -48786,6 +49138,7 @@
 {
 	"_id": "5SAKxcv8HBhs4JBMq",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -48882,6 +49235,7 @@
 {
 	"_id": "XQFB6X24Hev8PGqAu",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -49065,6 +49419,7 @@
 {
 	"_id": "PSYkohBh6Qeyxk4cx",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -49248,6 +49603,7 @@
 {
 	"_id": "HqKFYszdnYAQY7ESy",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -49373,6 +49729,7 @@
 {
 	"_id": "g7DPv8gs4BchukjYD",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -49469,6 +49826,7 @@
 {
 	"_id": "NXkLCiefNRauvjgwM",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -49594,6 +49952,7 @@
 {
 	"_id": "pkkmbuJJNScxyqxmn",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -49748,6 +50107,7 @@
 {
 	"_id": "hXmtoa4MhcQaRfPLi",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -49931,6 +50291,7 @@
 {
 	"_id": "LJodJZmPB7f8WvWvj",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -50056,6 +50417,7 @@
 {
 	"_id": "XnjrT44rfL5KjjJ87",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -50152,6 +50514,7 @@
 {
 	"_id": "SSLQFkpK8seLGunr9",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -50335,6 +50698,7 @@
 {
 	"_id": "YMJqY4m3rS5RKMEfv",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -50460,6 +50824,7 @@
 {
 	"_id": "9BCxP2NtdkfhrzciR",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -50614,6 +50979,7 @@
 {
 	"_id": "ndArrAoDAwQeuB7hq",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -50768,6 +51134,7 @@
 {
 	"_id": "xRAWPfSrwpSPRHRto",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -50893,6 +51260,7 @@
 {
 	"_id": "fznEjCbqXPRshQTAz",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -50989,6 +51357,7 @@
 {
 	"_id": "WMZYvshcJm5R9Sb2E",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -51085,6 +51454,7 @@
 {
 	"_id": "3BuvwYPfZmLqR2EFj",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -51210,6 +51580,7 @@
 {
 	"_id": "AzNNJQJgf39GFZHbe",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -51306,6 +51677,7 @@
 {
 	"_id": "aitneFQqg3RfvSiFi",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -51402,6 +51774,7 @@
 {
 	"_id": "pxLKS3k5WMwHfRcim",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -51556,6 +51929,7 @@
 {
 	"_id": "y9fBoW6B6JhjNnjCk",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -51710,6 +52084,7 @@
 {
 	"_id": "jiTbSRaTjWvGZknbu",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -51864,6 +52239,7 @@
 {
 	"_id": "7EeB6xNZTHorpRtgn",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -52018,6 +52394,7 @@
 {
 	"_id": "pRnYn9LpRTCXsBajj",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -52201,6 +52578,7 @@
 {
 	"_id": "ZmZcdFM4FKKrTFXc5",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -52326,6 +52704,7 @@
 {
 	"_id": "QB4qmhTs7i3bx7sTi",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -52422,6 +52801,7 @@
 {
 	"_id": "e6TzpicoDzHZGsGnY",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -52518,6 +52898,7 @@
 {
 	"_id": "5ZyL3JTEmHoE7kZmZ",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -52701,6 +53082,7 @@
 {
 	"_id": "J8a7zFTjSNLjfwraX",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -52826,6 +53208,7 @@
 {
 	"_id": "eFA2kdhJyeQcySxgM",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -52922,6 +53305,7 @@
 {
 	"_id": "dz4ReHpFnni9APKB5",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -53105,6 +53489,7 @@
 {
 	"_id": "chr5NRaTh6M7sEKHh",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -53201,6 +53586,7 @@
 {
 	"_id": "qywfNX6FegWZK8bYF",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -53297,6 +53683,7 @@
 {
 	"_id": "L7f84v66iECcaqXji",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -53422,6 +53809,7 @@
 {
 	"_id": "Gn45ciT6GE4SFmDFF",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -53518,6 +53906,7 @@
 {
 	"_id": "QM9Ez5dKEiYgXuq4B",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -53614,6 +54003,7 @@
 {
 	"_id": "BtsSid7TDmtnRdkdj",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -53739,6 +54129,7 @@
 {
 	"_id": "GASgb32GtG6SqSY6p",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -53835,6 +54226,7 @@
 {
 	"_id": "mDHoJ2Tyfjk5QiKsw",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -53960,6 +54352,7 @@
 {
 	"_id": "ra7fTrcrdQXoFHCsx",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -54143,6 +54536,7 @@
 {
 	"_id": "EaRuoBuSDDydYrqrc",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -54326,6 +54720,7 @@
 {
 	"_id": "rBGDjrrcqATFZejZE",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -54451,6 +54846,7 @@
 {
 	"_id": "s8dLGzYTtoddm3r3H",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -54576,6 +54972,7 @@
 {
 	"_id": "a26aufhXAXEHGymkT",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -54672,6 +55069,7 @@
 {
 	"_id": "2Yi7Y7DW6FJN2zLnz",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -54855,6 +55253,7 @@
 {
 	"_id": "3iW7vnhfEgHNHSKeW",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -54951,6 +55350,7 @@
 {
 	"_id": "ms9rx77mmxtr5ecqz",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -55076,6 +55476,7 @@
 {
 	"_id": "cKkYbJZEENhDbXMoR",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -55201,6 +55602,7 @@
 {
 	"_id": "viiiZZzaPw8anfrXz",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -55326,6 +55728,7 @@
 {
 	"_id": "7tG5HG5hjHZZRuxRk",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -55509,6 +55912,7 @@
 {
 	"_id": "K5zHBPkgBweJhkqd9",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -55663,6 +56067,7 @@
 {
 	"_id": "7didqtNecFG2bEpjE",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -55759,6 +56164,7 @@
 {
 	"_id": "5F5gTNZyzdm92qHsR",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -55884,6 +56290,7 @@
 {
 	"_id": "9MWowb3foNYCSirjT",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -56009,6 +56416,7 @@
 {
 	"_id": "tsooi8dHL4XpMBP3Y",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -56134,6 +56542,7 @@
 {
 	"_id": "EiNu5Ph3YcRYTgcvX",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -56317,6 +56726,7 @@
 {
 	"_id": "9uvaZjBoAfdBnihj2",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -56442,6 +56852,7 @@
 {
 	"_id": "rj7NFQ5FTsgvrxWmq",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -56567,6 +56978,7 @@
 {
 	"_id": "SiRHvCEcktbotYL7w",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -56721,6 +57133,7 @@
 {
 	"_id": "2ZNFx2K69iZHjRMsi",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -56846,6 +57259,7 @@
 {
 	"_id": "Lp3u4rezHrRKPAMSA",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -57029,6 +57443,7 @@
 {
 	"_id": "fBKMtvjCTxqXqX2Tn",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -57212,6 +57627,7 @@
 {
 	"_id": "teB6bs4koRWd92pQE",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -57395,6 +57811,7 @@
 {
 	"_id": "7b7YhokghhHmma89p",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -57549,6 +57966,7 @@
 {
 	"_id": "NwCgtAboPPBLmyQNE",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -57674,6 +58092,7 @@
 {
 	"_id": "8DLX5QcnwYhstdJtR",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -57857,6 +58276,7 @@
 {
 	"_id": "CuDg6gMdu2HatCofh",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -57953,6 +58373,7 @@
 {
 	"_id": "yectfCBKaMxjHXJEy",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -58049,6 +58470,7 @@
 {
 	"_id": "9b3NNBSEJfntTzYJW",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -58145,6 +58567,7 @@
 {
 	"_id": "ENXSAcEuCDxyAkc2D",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -58241,6 +58664,7 @@
 {
 	"_id": "EyxA3qgKww8KAwsEd",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -58424,6 +58848,7 @@
 {
 	"_id": "jHA8CbXSt5ds9BMTk",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -58607,6 +59032,7 @@
 {
 	"_id": "gDH2ju2Scb9PQ8vdp",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -58790,6 +59216,7 @@
 {
 	"_id": "vKCfzcf8uQ3h4k3xT",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -58973,6 +59400,7 @@
 {
 	"_id": "6sxTDumbhALw5sf6W",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -59069,6 +59497,7 @@
 {
 	"_id": "j5XJHz6Ae9ce48saA",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -59165,6 +59594,7 @@
 {
 	"_id": "HQkMXazaJFMR8FRZi",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -59348,6 +59778,7 @@
 {
 	"_id": "b9pWBdsGdxjoS2sZd",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -59473,6 +59904,7 @@
 {
 	"_id": "AjJGMtn6rA6WQ7j7M",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -59598,6 +60030,7 @@
 {
 	"_id": "uifiojRwLM73HhKMa",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -59694,6 +60127,7 @@
 {
 	"_id": "zSyuupLPZSQBf4FNR",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -59877,6 +60311,7 @@
 {
 	"_id": "Fs7mhLP3MaCQHdcne",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -59973,6 +60408,7 @@
 {
 	"_id": "9LQnQHWGcsKxmZdA3",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -60069,6 +60505,7 @@
 {
 	"_id": "j3oNNKpcuhW8GiHgy",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -60165,6 +60602,7 @@
 {
 	"_id": "7MwHEDyzMTZ9t4bsg",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -60290,6 +60728,7 @@
 {
 	"_id": "JJwAMf64KguhCWva2",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -60473,6 +60912,7 @@
 {
 	"_id": "dYQ4dmQv3AkzfWLZo",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -60656,6 +61096,7 @@
 {
 	"_id": "Jo5mP2vAGMtuD3sc6",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -60810,6 +61251,7 @@
 {
 	"_id": "3fSFXs64ZdFsJB5hR",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -60935,6 +61377,7 @@
 {
 	"_id": "inBeunsiovzfiHWyY",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -61060,6 +61503,7 @@
 {
 	"_id": "Cbyj7fEpBE3qw5rqi",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -61185,6 +61629,7 @@
 {
 	"_id": "FR2yGXv4zW7KkSWiu",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -61339,6 +61784,7 @@
 {
 	"_id": "3WofZ6W5hAKnQWvkE",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -61522,6 +61968,7 @@
 {
 	"_id": "9bMYz5zfuhvDdMG2R",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -61676,6 +62123,7 @@
 {
 	"_id": "nKMRrn3MbyCohFDDS",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -61772,6 +62220,7 @@
 {
 	"_id": "LC6xrDnujpr42xrii",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -61926,6 +62375,7 @@
 {
 	"_id": "HasQYPE58pCmk7iLg",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -62109,6 +62559,7 @@
 {
 	"_id": "2N4p8GBidFNfz8YLj",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -62234,6 +62685,7 @@
 {
 	"_id": "vLaCJ7GWHqQ6RbBZw",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -62417,6 +62869,7 @@
 {
 	"_id": "R764Z5CySPcsaWhxz",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -62571,6 +63024,7 @@
 {
 	"_id": "NzQF32SPPnvjQLNoX",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -62667,6 +63121,7 @@
 {
 	"_id": "3EZirrr4kkbZswjgf",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -62792,6 +63247,7 @@
 {
 	"_id": "ELqwzD9TBLg27DjZD",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -62917,6 +63373,7 @@
 {
 	"_id": "tD7WmJvDeE97QFej9",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -63071,6 +63528,7 @@
 {
 	"_id": "dCpnGuvxo2BuZoiFg",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -63254,6 +63712,7 @@
 {
 	"_id": "zfvxyELyR62LLwD6J",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -63437,6 +63896,7 @@
 {
 	"_id": "NT7ZTCjcyKQLYKrSR",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -63620,6 +64080,7 @@
 {
 	"_id": "8PbMJBLyQxcqaTobW",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -63745,6 +64206,7 @@
 {
 	"_id": "RMaf7A6m8W2LBJh86",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -63928,6 +64390,7 @@
 {
 	"_id": "T7K88Q5NH72HK7bqh",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -64024,6 +64487,7 @@
 {
 	"_id": "mNT5PAxoWBQRSAjzB",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -64149,6 +64613,7 @@
 {
 	"_id": "ZFb7BZNyWMN3WqDna",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -64274,6 +64739,7 @@
 {
 	"_id": "Wwj6WEvb5SDmx2NiC",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -64428,6 +64894,7 @@
 {
 	"_id": "mZN8bpYedqGSzhdip",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -64582,6 +65049,7 @@
 {
 	"_id": "JLXwJzNxwYqhoY3Bh",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -64707,6 +65175,7 @@
 {
 	"_id": "8xrmhH34Xv7NTvPu5",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -64890,6 +65359,7 @@
 {
 	"_id": "aJEuNAoHEmFXEZ5fi",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -65073,6 +65543,7 @@
 {
 	"_id": "nrXsPTni9BBo7EHDA",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -65198,6 +65669,7 @@
 {
 	"_id": "ZEjb5yDWqc358n87i",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -65294,6 +65766,7 @@
 {
 	"_id": "d8DSuXKSuDZYpZ9bk",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -65419,6 +65892,7 @@
 {
 	"_id": "HKxepwEryFm2vLCc3",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -65544,6 +66018,7 @@
 {
 	"_id": "ao4BRNMDzDnMQpDzz",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -65698,6 +66173,7 @@
 {
 	"_id": "YYEbSA3SMQSBsoqJp",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -65823,6 +66299,7 @@
 {
 	"_id": "9im8pfEEcbWSMQjFS",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -65948,6 +66425,7 @@
 {
 	"_id": "ggqWn9hTPuCB68Qtx",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -66131,6 +66609,7 @@
 {
 	"_id": "uYvuucgCB5b3iBrZc",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -66285,6 +66764,7 @@
 {
 	"_id": "WL2nnHS8v58NrnXik",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -66439,6 +66919,7 @@
 {
 	"_id": "mAXQWkcnDKADCwcMz",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -66593,6 +67074,7 @@
 {
 	"_id": "BsCyK4hHhRf2W8Bs5",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -66689,6 +67171,7 @@
 {
 	"_id": "joMXnpcLNFRgEh7AQ",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -66814,6 +67297,7 @@
 {
 	"_id": "wqoaJEWeyn8pHrsi4",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -66968,6 +67452,7 @@
 {
 	"_id": "y8zKq8CZbxzZi65bj",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -67151,6 +67636,7 @@
 {
 	"_id": "sTFzgpZmrNu59Q7Kz",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -67276,6 +67762,7 @@
 {
 	"_id": "M3vfzodY6pHKPLKe8",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -67430,6 +67917,7 @@
 {
 	"_id": "EBe67FYesCHf6qkpu",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -67584,6 +68072,7 @@
 {
 	"_id": "bfHquAeWsa6gCiSXH",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -67709,6 +68198,7 @@
 {
 	"_id": "FbuuKimx5Wzn6qG9P",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -67834,6 +68324,7 @@
 {
 	"_id": "2zG6duoxRPG23irsz",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -67959,6 +68450,7 @@
 {
 	"_id": "wLF8zB3W7JRMBgJmy",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -68113,6 +68605,7 @@
 {
 	"_id": "zrSoY6umnG9DecxnH",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -68209,6 +68702,7 @@
 {
 	"_id": "qNSNgP5QEMJMsxjvB",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -68305,6 +68799,7 @@
 {
 	"_id": "sNpDGD3HrawRDcsaq",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -68430,6 +68925,7 @@
 {
 	"_id": "sDX6iHvLYvRqfqsiZ",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -68526,6 +69022,7 @@
 {
 	"_id": "ShZnfxzHWMuzD3kyv",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -68651,6 +69148,7 @@
 {
 	"_id": "ZHhFdyBe9v3PgjRZD",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -68834,6 +69332,7 @@
 {
 	"_id": "8JQDkQwJQJo7DQfXp",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -68959,6 +69458,7 @@
 {
 	"_id": "ez3dkymXxGEiMqe7X",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -69113,6 +69613,7 @@
 {
 	"_id": "Q6Jd372nQnCK2FX8s",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -69296,6 +69797,7 @@
 {
 	"_id": "bY5gx9FTXSygQYbkz",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -69450,6 +69952,7 @@
 {
 	"_id": "dwNnBpstaRRKDFqzj",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -69546,6 +70049,7 @@
 {
 	"_id": "hnQdkgatpts7tHRdy",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -69729,6 +70233,7 @@
 {
 	"_id": "7JckownNYZKd2ku6A",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -69854,6 +70359,7 @@
 {
 	"_id": "8a5pJGq63ytPgoLoq",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -70037,6 +70543,7 @@
 {
 	"_id": "KxmAfa28yEszAqYSz",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -70162,6 +70669,7 @@
 {
 	"_id": "o29egC5MtMwujScP9",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -70316,6 +70824,7 @@
 {
 	"_id": "bmBuCuzkAtdg4G8sY",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -70470,6 +70979,7 @@
 {
 	"_id": "XHsY9ai3py2vE43Rk",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -70595,6 +71105,7 @@
 {
 	"_id": "9CX2PzwPtsMaeWkGi",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -70691,6 +71202,7 @@
 {
 	"_id": "ShWN4mQNTZo2qQ4zd",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -70874,6 +71386,7 @@
 {
 	"_id": "9ffjdu2kYDprN7ep5",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -71028,6 +71541,7 @@
 {
 	"_id": "pcNFFFSQWXfLNzthG",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -71211,6 +71725,7 @@
 {
 	"_id": "RLeR5LwPGjQuXroK3",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -71365,6 +71880,7 @@
 {
 	"_id": "NsHgD9PRA4K6DsJFa",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -71548,6 +72064,7 @@
 {
 	"_id": "XotkvxS9hbRMdxkMa",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -71644,6 +72161,7 @@
 {
 	"_id": "MgvEzpWC4fPxEBcmk",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -71798,6 +72316,7 @@
 {
 	"_id": "kGRQ9yF5sX8PKpmjz",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -71952,6 +72471,7 @@
 {
 	"_id": "xzRZnzhspjJRJQdbn",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -72106,6 +72626,7 @@
 {
 	"_id": "Zj5kQiRnA9eWiebwM",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -72231,6 +72752,7 @@
 {
 	"_id": "8ZW3sZwYNyAE7wYWs",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -72356,6 +72878,7 @@
 {
 	"_id": "6ZR5XnyG6Tvx5RTJX",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -72481,6 +73004,7 @@
 {
 	"_id": "5Yv7r6W7P7G7szABY",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -72606,6 +73130,7 @@
 {
 	"_id": "96Y4HfKiBdosLfbWY",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -72702,6 +73227,7 @@
 {
 	"_id": "KGBxmnzevL3Y8ZNEn",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -72827,6 +73353,7 @@
 {
 	"_id": "2E58yACHN4JnQFPv9",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -73010,6 +73537,7 @@
 {
 	"_id": "L5jPA2negLQEgy3o3",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -73106,6 +73634,7 @@
 {
 	"_id": "YpM9MgDnM6Ezzu55i",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -73202,6 +73731,7 @@
 {
 	"_id": "vdyBAuix7Gdd5NtQz",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -73356,6 +73886,7 @@
 {
 	"_id": "8mQp2AaMQTqfHtWQs",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -73510,6 +74041,7 @@
 {
 	"_id": "WTy9eyZtabYunEW2t",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -73664,6 +74196,7 @@
 {
 	"_id": "oxk7fxegETdPqr5DT",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -73789,6 +74322,7 @@
 {
 	"_id": "g8mMj85AeDW85MYGY",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -73943,6 +74477,7 @@
 {
 	"_id": "A45mJgoE2cRdZ7xqX",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -74039,6 +74574,7 @@
 {
 	"_id": "jmwTHXk3z5SRwv346",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -74164,6 +74700,7 @@
 {
 	"_id": "QCHqZYXLaA3yZ62mS",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -74260,6 +74797,7 @@
 {
 	"_id": "PWigqv9kSycRPr4iP",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -74385,6 +74923,7 @@
 {
 	"_id": "zdkpoqGZT9YozpTyJ",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -74481,6 +75020,7 @@
 {
 	"_id": "LGLwCS8fLcPQ2MFnX",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -74606,6 +75146,7 @@
 {
 	"_id": "QfSw5bgM7Lp85XFum",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -74702,6 +75243,7 @@
 {
 	"_id": "GbwxayzXmDb2rWdqm",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -74798,6 +75340,7 @@
 {
 	"_id": "TYp3KPv9TBiQccSoH",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -74981,6 +75524,7 @@
 {
 	"_id": "5eHnvg3vcj66a3Qqs",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -75077,6 +75621,7 @@
 {
 	"_id": "DmcLuqLZ8qt9mGvnW",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -75202,6 +75747,7 @@
 {
 	"_id": "eqgMEY9o8jePWcnv2",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -75298,6 +75844,7 @@
 {
 	"_id": "DJzxmPsr4YkxamSyC",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -75394,6 +75941,7 @@
 {
 	"_id": "Enj6ZhFJ9GvfQe9SL",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -75577,6 +76125,7 @@
 {
 	"_id": "75XANnuh9NKBAjKJe",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -75673,6 +76222,7 @@
 {
 	"_id": "jGLbzA3F9aLRJZW52",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -75827,6 +76377,7 @@
 {
 	"_id": "KAoRqA8M3mtfDjGQA",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -75981,6 +76532,7 @@
 {
 	"_id": "ieCgec85aD3j55w7u",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -76135,6 +76687,7 @@
 {
 	"_id": "fSt2zaCX8pYyZaFrq",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -76289,6 +76842,7 @@
 {
 	"_id": "7zmzDgs2XdPFJwSx3",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -76385,6 +76939,7 @@
 {
 	"_id": "zcGfhWJHxn4GYtr6w",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -76481,6 +77036,7 @@
 {
 	"_id": "Ko4tcuYREuuFb2LN5",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -76577,6 +77133,7 @@
 {
 	"_id": "wA3rWKwPPum4SWe6j",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -76760,6 +77317,7 @@
 {
 	"_id": "sXv9ksbzbEnobyjTA",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -76943,6 +77501,7 @@
 {
 	"_id": "hgs7Fn6NQWMfPW5cG",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -77126,6 +77685,7 @@
 {
 	"_id": "DzNE5d4ZRq2xP62Gf",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -77251,6 +77811,7 @@
 {
 	"_id": "jLcePkThmLgrqjzuq",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -77405,6 +77966,7 @@
 {
 	"_id": "A9XSuYo6SBq5goJk7",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -77588,6 +78150,7 @@
 {
 	"_id": "SXJtk9FYHJ5f9M32a",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -77713,6 +78276,7 @@
 {
 	"_id": "7o5nyuBtWMTFznxEb",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -77867,6 +78431,7 @@
 {
 	"_id": "rFgDXQaj26Zbvha9v",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -78050,6 +78615,7 @@
 {
 	"_id": "ffz86otdLniG22Jx3",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -78175,6 +78741,7 @@
 {
 	"_id": "qT6Q27ZgPydPf4AN8",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -78329,6 +78896,7 @@
 {
 	"_id": "9jwkwXcatbiByRWws",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -78483,6 +79051,7 @@
 {
 	"_id": "fvgXFz69LvLK3f28c",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -78579,6 +79148,7 @@
 {
 	"_id": "nxiWbakBDF38BydHC",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -78704,6 +79274,7 @@
 {
 	"_id": "B4NAWTKhHiW8eWRCH",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -78829,6 +79400,7 @@
 {
 	"_id": "24NA4BtpWDqrPbT3Z",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -78954,6 +79526,7 @@
 {
 	"_id": "tzvq86xEdbz9FMhsD",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -79108,6 +79681,7 @@
 {
 	"_id": "2wTy8tJdQv3f3wa6d",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -79291,6 +79865,7 @@
 {
 	"_id": "oAmeeALWYmRFEDqEa",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -79474,6 +80049,7 @@
 {
 	"_id": "xuNziFJAKLouad4iA",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -79628,6 +80204,7 @@
 {
 	"_id": "2P4cQ2Kt7ZYg5tM4N",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -79724,6 +80301,7 @@
 {
 	"_id": "bgLJYMus5NAmyQ8pX",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -79849,6 +80427,7 @@
 {
 	"_id": "rJdrGAkz6AmCwDNCb",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -80003,6 +80582,7 @@
 {
 	"_id": "9yJ3wsmkv4axwjund",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -80157,6 +80737,7 @@
 {
 	"_id": "qfbh7x7Tjponzcfc5",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -80253,6 +80834,7 @@
 {
 	"_id": "7LjunCMgfBB2HNNJS",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -80349,6 +80931,7 @@
 {
 	"_id": "cvPzxz8z8f94cgTDW",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -80474,6 +81057,7 @@
 {
 	"_id": "jrNXWTweS3aZwygBp",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -80570,6 +81154,7 @@
 {
 	"_id": "6nhZmoq9u96vtXF38",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -80666,6 +81251,7 @@
 {
 	"_id": "zGw7ktX82DGgrYDDQ",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -80762,6 +81348,7 @@
 {
 	"_id": "zpGdMaY4biP7p76Nw",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -80945,6 +81532,7 @@
 {
 	"_id": "dWdeMYKpoMp3KD8sr",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -81099,6 +81687,7 @@
 {
 	"_id": "JYi6pWhfQmoA8vaJ9",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -81224,6 +81813,7 @@
 {
 	"_id": "LoTSftJ3FTnSyRSfs",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -81407,6 +81997,7 @@
 {
 	"_id": "LpEW7WiANkB4JBcgh",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -81503,6 +82094,7 @@
 {
 	"_id": "JjXe8Lwqbavt3g9x8",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -81657,6 +82249,7 @@
 {
 	"_id": "cytxhCBx9rDfx5QAD",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -81782,6 +82375,7 @@
 {
 	"_id": "aHwZkegN7chPcoJ9a",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -81936,6 +82530,7 @@
 {
 	"_id": "HAjf8xwvh7mTvJnjm",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -82090,6 +82685,7 @@
 {
 	"_id": "YMr8aHmiocq4tmuyJ",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -82273,6 +82869,7 @@
 {
 	"_id": "5W475d9aQR4n6n4kP",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -82456,6 +83053,7 @@
 {
 	"_id": "fuJE6SjHPGbSuaucw",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -82639,6 +83237,7 @@
 {
 	"_id": "kiTfp2hShxEvTML85",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -82735,6 +83334,7 @@
 {
 	"_id": "23jD43sBRyEdTp25Q",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -82831,6 +83431,7 @@
 {
 	"_id": "dvuDotcgRomp9bMAa",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -82927,6 +83528,7 @@
 {
 	"_id": "Sr9BMtKG3vroJYByQ",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -83081,6 +83683,7 @@
 {
 	"_id": "RaAq8HyoWSKKuL5jy",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -83177,6 +83780,7 @@
 {
 	"_id": "g6GbdZMJpt4A3g26a",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -83302,6 +83906,7 @@
 {
 	"_id": "xzqCYWu8Q46cXZKsM",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -83485,6 +84090,7 @@
 {
 	"_id": "apLxcqHc5Cn6oYkmk",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -83581,6 +84187,7 @@
 {
 	"_id": "o9huiXdoxs376gM5x",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -83706,6 +84313,7 @@
 {
 	"_id": "usroJQiPW345yAW6y",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -83831,6 +84439,7 @@
 {
 	"_id": "ksEwtopdAeFQWLLcS",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -83956,6 +84565,7 @@
 {
 	"_id": "fTSDz9XgQRPjNHNkv",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -84110,6 +84720,7 @@
 {
 	"_id": "bZwzN3z9JTiiN7QtB",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -84264,6 +84875,7 @@
 {
 	"_id": "x8Z3GeF4tgcHgie5P",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -84447,6 +85059,7 @@
 {
 	"_id": "gwyg2ZPg8ainCiQ6A",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -84572,6 +85185,7 @@
 {
 	"_id": "sF7NMxkKb6BWcxThJ",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -84697,6 +85311,7 @@
 {
 	"_id": "Jkw4astctfdpjsMAq",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -84880,6 +85495,7 @@
 {
 	"_id": "pRpE3DAjXaNmvA2bx",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -84976,6 +85592,7 @@
 {
 	"_id": "5SycjqMLyEHkZSZ8h",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -85101,6 +85718,7 @@
 {
 	"_id": "rLjxM5PJXnNa6B6zT",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -85284,6 +85902,7 @@
 {
 	"_id": "aesdLiWvBQWPqxtJD",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -85438,6 +86057,7 @@
 {
 	"_id": "gWFi6W5tgpWBfk5XS",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -85563,6 +86183,7 @@
 {
 	"_id": "wpdQYjiTyvsyBhN57",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -85688,6 +86309,7 @@
 {
 	"_id": "Zzk9HnjRDsmy3GFix",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -85813,6 +86435,7 @@
 {
 	"_id": "rbLoM2r8BCjXQK5br",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -85996,6 +86619,7 @@
 {
 	"_id": "RJgCqxJ5HGCXd2GrZ",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -86150,6 +86774,7 @@
 {
 	"_id": "A44KTS8sbS2PTATML",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -86333,6 +86958,7 @@
 {
 	"_id": "DeGWRz3ru62kqKdQ9",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -86458,6 +87084,7 @@
 {
 	"_id": "QJ8tcZvnu57ozNW9f",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -86641,6 +87268,7 @@
 {
 	"_id": "886yPjNzB28uzZJzf",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -86766,6 +87394,7 @@
 {
 	"_id": "QExGhrn2MWRHytbMh",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -86949,6 +87578,7 @@
 {
 	"_id": "Xov7idwC8khFrMfNC",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -87074,6 +87704,7 @@
 {
 	"_id": "BRq6a6LQ4ZmTmaEG5",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -87170,6 +87801,7 @@
 {
 	"_id": "3c6WRf7JGNprpHfvN",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -87266,6 +87898,7 @@
 {
 	"_id": "jDL5Fn3EtuW3HnNhB",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -87362,6 +87995,7 @@
 {
 	"_id": "NADJzfLreSAvjhJ8G",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -87516,6 +88150,7 @@
 {
 	"_id": "KXHEZFz7pSHPBAktH",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -87641,6 +88276,7 @@
 {
 	"_id": "EFBf2vpfLLNrnFDr4",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -87795,6 +88431,7 @@
 {
 	"_id": "hjoq226bJsbNdjzLs",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -87978,6 +88615,7 @@
 {
 	"_id": "CT2uohJroC6PgPWaF",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -88103,6 +88741,7 @@
 {
 	"_id": "zGFEC7HMFWMBXKgLB",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -88199,6 +88838,7 @@
 {
 	"_id": "Pe8QBXvq3rkFuKbpd",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -88324,6 +88964,7 @@
 {
 	"_id": "FztZzr3jNbbnuZSPF",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -88420,6 +89061,7 @@
 {
 	"_id": "c2c8xAxkmeme99BQp",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -88574,6 +89216,7 @@
 {
 	"_id": "FASyHxy54xyLqh9Ce",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -88757,6 +89400,7 @@
 {
 	"_id": "iGWev6ycNqrGqfSm4",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -88853,6 +89497,7 @@
 {
 	"_id": "2QrC3CbL8rZWFRjYY",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -88978,6 +89623,7 @@
 {
 	"_id": "KTsJRWiRGTnPYkQED",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -89074,6 +89720,7 @@
 {
 	"_id": "KtmBETb7DqxeMrTiJ",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -89170,6 +89817,7 @@
 {
 	"_id": "rvp3k9AR9DzAkwEGY",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -89324,6 +89972,7 @@
 {
 	"_id": "kd4tFojk6ZGNmkgdm",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -89420,6 +90069,7 @@
 {
 	"_id": "gXK4kFLHrmZK6keNe",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -89545,6 +90195,7 @@
 {
 	"_id": "CLWBuZrMsh8kjqAEM",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -89699,6 +90350,7 @@
 {
 	"_id": "LWa8CHEx8d3kuQkQp",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -89795,6 +90447,7 @@
 {
 	"_id": "CSLz3qzn5xYHA5BmK",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -89920,6 +90573,7 @@
 {
 	"_id": "h8Au2pB3SXRkh3DFd",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -90016,6 +90670,7 @@
 {
 	"_id": "afnoSTpuouvatmzCp",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -90199,6 +90854,7 @@
 {
 	"_id": "XxiETDpZFye9b3vnf",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -90353,6 +91009,7 @@
 {
 	"_id": "xGyf6kFnQK7ynNhry",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -90507,6 +91164,7 @@
 {
 	"_id": "azbwvZi6pP2MjAQjv",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -90661,6 +91319,7 @@
 {
 	"_id": "4CnJDuDSzHbzcPkSj",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -90757,6 +91416,7 @@
 {
 	"_id": "u3Mdkf8pZm9oLg8eX",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -90853,6 +91513,7 @@
 {
 	"_id": "FSAxyMtc8tn6EG3Ke",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -91007,6 +91668,7 @@
 {
 	"_id": "XHFseo68JpBcNjDSq",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -91190,6 +91852,7 @@
 {
 	"_id": "98K67YfRxg4doLvxP",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -91373,6 +92036,7 @@
 {
 	"_id": "fdzbCYAYfv2TACB9N",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -91469,6 +92133,7 @@
 {
 	"_id": "8pDwSAQ2TNZ4LFCMR",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -91623,6 +92288,7 @@
 {
 	"_id": "ih9sR2fzT4iBkprxk",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -91806,6 +92472,7 @@
 {
 	"_id": "yht6kigWgPfoihQ6s",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -91931,6 +92598,7 @@
 {
 	"_id": "GsQmRK8QYcPf8YacT",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -92056,6 +92724,7 @@
 {
 	"_id": "P2sQm3fRWZKoJbp2X",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -92210,6 +92879,7 @@
 {
 	"_id": "wDcdSFB8TLHBKSbDt",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -92335,6 +93005,7 @@
 {
 	"_id": "s8b2XThFHKTAsJ7GR",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -92518,6 +93189,7 @@
 {
 	"_id": "f7hymiNS6wNmQRgsN",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -92672,6 +93344,7 @@
 {
 	"_id": "s2C74nBAccjYraHTx",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -92855,6 +93528,7 @@
 {
 	"_id": "7Cm9mndafa7PgS9Xa",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -93009,6 +93683,7 @@
 {
 	"_id": "YS49RG9o793mJF2KK",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -93163,6 +93838,7 @@
 {
 	"_id": "qctdH5tWrNDrd6xr7",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -93317,6 +93993,7 @@
 {
 	"_id": "K894zFggk4o96J9Ye",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -93413,6 +94090,7 @@
 {
 	"_id": "zCcRdyBPrbeRr875W",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -93596,6 +94274,7 @@
 {
 	"_id": "YSMGvapjRwjdqu4Jh",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -93779,6 +94458,7 @@
 {
 	"_id": "BnRpJwohnMQDi3bzM",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -93933,6 +94613,7 @@
 {
 	"_id": "npiS9syB5MmAJJHe3",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -94058,6 +94739,7 @@
 {
 	"_id": "8ZmRcDBbNXLe4NJp9",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -94154,6 +94836,7 @@
 {
 	"_id": "M26qZWpp3pA8puBcT",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -94250,6 +94933,7 @@
 {
 	"_id": "EnGBg9j4q5G6won7B",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -94404,6 +95088,7 @@
 {
 	"_id": "mc7QmASBu4AjqcJRf",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -94529,6 +95214,7 @@
 {
 	"_id": "yuwrZ6eutdCH46eys",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -94625,6 +95311,7 @@
 {
 	"_id": "yvBHkqZqzjB4653X4",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -94750,6 +95437,7 @@
 {
 	"_id": "HAPb2qL5rYqt9jD75",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -94904,6 +95592,7 @@
 {
 	"_id": "wveBfvRKCzL5JAxQj",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -95087,6 +95776,7 @@
 {
 	"_id": "Sz6RkF9pmcipKLSy9",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -95241,6 +95931,7 @@
 {
 	"_id": "RQj9KDADCJk6F8CuF",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -95395,6 +96086,7 @@
 {
 	"_id": "GPRoeyCSL7NDtAwds",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -95578,6 +96270,7 @@
 {
 	"_id": "77pW8YbCDqFNmDZon",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -95703,6 +96396,7 @@
 {
 	"_id": "JGpHpfLrgCgz38d4u",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -95799,6 +96493,7 @@
 {
 	"_id": "yvwjWwmKDmKv7wagt",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -95924,6 +96619,7 @@
 {
 	"_id": "HES2JrdFpJ4DMMiy2",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -96078,6 +96774,7 @@
 {
 	"_id": "BYndJ9ghtbxjM92pL",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -96261,6 +96958,7 @@
 {
 	"_id": "QvmLaEKeYASx7C5AS",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -96357,6 +97055,7 @@
 {
 	"_id": "aP8ZskigpGCo5FtWT",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -96482,6 +97181,7 @@
 {
 	"_id": "qcuSjiLTBe9yX9BsF",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -96665,6 +97365,7 @@
 {
 	"_id": "YmG6HrwbzLzx9sqiM",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -96819,6 +97520,7 @@
 {
 	"_id": "vLRCm8THYxuJu995M",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -96944,6 +97646,7 @@
 {
 	"_id": "rC6s5MHmqE92fg2QQ",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -97069,6 +97772,7 @@
 {
 	"_id": "xHfkMQYoo4sDY9aKG",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -97194,6 +97898,7 @@
 {
 	"_id": "r5GFEoQQaSmJdDgnP",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -97319,6 +98024,7 @@
 {
 	"_id": "tQBKkPvEvsg6E7Eiq",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -97502,6 +98208,7 @@
 {
 	"_id": "zi7kkh7Sb7cEtRGzg",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -97685,6 +98392,7 @@
 {
 	"_id": "fJxeGz6F8xxTJtzJK",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -97839,6 +98547,7 @@
 {
 	"_id": "35AYAD9hbqjfi2XHq",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -97993,6 +98702,7 @@
 {
 	"_id": "uYSifry6CjvGGrMvW",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -98118,6 +98828,7 @@
 {
 	"_id": "co3RAWJHGSTPRGPH6",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -98214,6 +98925,7 @@
 {
 	"_id": "oeuaKcchtfgdqXY2J",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -98397,6 +99109,7 @@
 {
 	"_id": "9AwXECnYf94A9x48h",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -98522,6 +99235,7 @@
 {
 	"_id": "Hc8inem28yLCtmmB7",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -98647,6 +99361,7 @@
 {
 	"_id": "WEFsbkRvCkFuxtNvj",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -98772,6 +99487,7 @@
 {
 	"_id": "kWyq8ZXNTN4nrosRt",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -98868,6 +99584,7 @@
 {
 	"_id": "q7pbHBwiGHPYTE3e7",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -99051,6 +99768,7 @@
 {
 	"_id": "3CRWrqoRwuyNf9BBp",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -99176,6 +99894,7 @@
 {
 	"_id": "xsc7jichskQAEK3xX",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -99359,6 +100078,7 @@
 {
 	"_id": "sbfxZDuLF59Lz3NvM",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -99484,6 +100204,7 @@
 {
 	"_id": "5D6yxdi7Jrh75Dpf4",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -99638,6 +100359,7 @@
 {
 	"_id": "H6q8g4JZ2qDsLNyQS",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -99734,6 +100456,7 @@
 {
 	"_id": "vyDqeEMJDwzM9sohR",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -99888,6 +100611,7 @@
 {
 	"_id": "3974JXXdg65iGryNP",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -100042,6 +100766,7 @@
 {
 	"_id": "EEumB5de7wYJoTTcE",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -100225,6 +100950,7 @@
 {
 	"_id": "mWDGaZYkgNRTh349R",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -100379,6 +101105,7 @@
 {
 	"_id": "6bmgcKsjux8cxLoC5",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -100475,6 +101202,7 @@
 {
 	"_id": "hw6nJYqNNa8YKSGxn",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -100658,6 +101386,7 @@
 {
 	"_id": "hevDbreq47TiP7Xba",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -100841,6 +101570,7 @@
 {
 	"_id": "mkQfwsLRKqPs5n9Hg",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -101024,6 +101754,7 @@
 {
 	"_id": "3xGuTonaTdZMSnuwh",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -101178,6 +101909,7 @@
 {
 	"_id": "F6XCYDPyjqPFSeMHe",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -101303,6 +102035,7 @@
 {
 	"_id": "Xk2SXs8hZKF9c2i2a",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -101399,6 +102132,7 @@
 {
 	"_id": "5JrcEorS9QYFkAhNd",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -101553,6 +102287,7 @@
 {
 	"_id": "ZpxkSbAo7W9JW5jSt",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -101649,6 +102384,7 @@
 {
 	"_id": "QRREpeoaCd2kzAJHN",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -101745,6 +102481,7 @@
 {
 	"_id": "8eJQqqWxJBkZB4qTQ",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -101928,6 +102665,7 @@
 {
 	"_id": "BAdAeve2HZKtgLJbK",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -102024,6 +102762,7 @@
 {
 	"_id": "YhtHMRzoPvz4WLqsS",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -102178,6 +102917,7 @@
 {
 	"_id": "yqCxvP4MAzPnvaaoY",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -102303,6 +103043,7 @@
 {
 	"_id": "SThBtGcQmaZLcNYdN",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -102428,6 +103169,7 @@
 {
 	"_id": "siKgFAugR8yuMci3i",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -102524,6 +103266,7 @@
 {
 	"_id": "2WTweopkf5gSah3Ad",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -102678,6 +103421,7 @@
 {
 	"_id": "yJXCzS8hPx64pkKv2",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -102832,6 +103576,7 @@
 {
 	"_id": "JY82kntsRhyp698ct",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -102986,6 +103731,7 @@
 {
 	"_id": "osZ9QfatBB8yWysSA",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -103082,6 +103828,7 @@
 {
 	"_id": "8rXrofqjnLdC9uMzW",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -103178,6 +103925,7 @@
 {
 	"_id": "xvseG3JDLTTbsnmvN",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -103303,6 +104051,7 @@
 {
 	"_id": "ALCg87Gd2zSQoHRar",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -103486,6 +104235,7 @@
 {
 	"_id": "GGRe7WN76swtnziCG",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -103640,6 +104390,7 @@
 {
 	"_id": "ZTTrY9kioxdCX9yM8",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -103794,6 +104545,7 @@
 {
 	"_id": "QHpGg7saPWNDHXCje",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -103890,6 +104642,7 @@
 {
 	"_id": "nC3qdjmfmxXPMXHtA",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -104044,6 +104797,7 @@
 {
 	"_id": "7brgn9e4zF2BmaEsS",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -104198,6 +104952,7 @@
 {
 	"_id": "t9gEn4Zip4dtKguiP",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -104381,6 +105136,7 @@
 {
 	"_id": "BJniTBYC9jvTrJDNQ",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -104564,6 +105320,7 @@
 {
 	"_id": "wsPhE72X3DZ6x3vdK",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -104718,6 +105475,7 @@
 {
 	"_id": "jfHSoSZ9LyGMFfHew",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -104843,6 +105601,7 @@
 {
 	"_id": "ynSwZ7PuPDrysZovw",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -104997,6 +105756,7 @@
 {
 	"_id": "cr8LrAQANX5vC3ak7",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -105093,6 +105853,7 @@
 {
 	"_id": "z8mb7PCjk7pWY4HsH",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -105189,6 +105950,7 @@
 {
 	"_id": "c85PZ4btkxEwXjXC7",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -105285,6 +106047,7 @@
 {
 	"_id": "htRiAsdaqfkWWgrri",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -105468,6 +106231,7 @@
 {
 	"_id": "jWrmjF3ALHAnDXPPK",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -105651,6 +106415,7 @@
 {
 	"_id": "hf6zWXhF8zrbDDJgw",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -105834,6 +106599,7 @@
 {
 	"_id": "9Y6J9s5Cd6SCfjvpm",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -105988,6 +106754,7 @@
 {
 	"_id": "7avN2DryazWtFgBrc",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -106113,6 +106880,7 @@
 {
 	"_id": "B86vBNWwKRWBzsg9y",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -106296,6 +107064,7 @@
 {
 	"_id": "qzii8mFQdYSLiFnjc",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -106479,6 +107248,7 @@
 {
 	"_id": "KNJMw73ygnnkqAX2c",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -106604,6 +107374,7 @@
 {
 	"_id": "tdb8dtbGyejgkbXzf",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -106729,6 +107500,7 @@
 {
 	"_id": "tAv9ZY7TTTSJcgDHa",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -106825,6 +107597,7 @@
 {
 	"_id": "47hN2w5PSXmoQCTtf",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -106979,6 +107752,7 @@
 {
 	"_id": "F5uyn9eSuXiygSQ4P",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -107162,6 +107936,7 @@
 {
 	"_id": "ds39Z9u4gKjm9pXDS",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -107316,6 +108091,7 @@
 {
 	"_id": "trs8JoqXMmgMFnNHY",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -107412,6 +108188,7 @@
 {
 	"_id": "enzg69Ss6j8TBwGXJ",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -107566,6 +108343,7 @@
 {
 	"_id": "3SpcFcMnbZ9JcKcGM",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -107662,6 +108440,7 @@
 {
 	"_id": "tqHWwZwTPmv7yhWh2",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -107758,6 +108537,7 @@
 {
 	"_id": "btDmXxptJE4kfYcyg",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -107912,6 +108692,7 @@
 {
 	"_id": "vRaGXsHSme2srAXue",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -108066,6 +108847,7 @@
 {
 	"_id": "m96ghZYJXMhzvhoDy",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -108249,6 +109031,7 @@
 {
 	"_id": "fP3b5bosBHgorYkkb",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -108403,6 +109186,7 @@
 {
 	"_id": "RLEt5RshF4ZYDNH6C",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -108586,6 +109370,7 @@
 {
 	"_id": "6FAdijesZWMZY8Gug",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -108740,6 +109525,7 @@
 {
 	"_id": "gZ5baAdK3fEWPkyhw",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -108865,6 +109651,7 @@
 {
 	"_id": "oMtJiPiLxgyvoYEWW",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -109048,6 +109835,7 @@
 {
 	"_id": "ADrR9BHcWtposgYnc",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -109202,6 +109990,7 @@
 {
 	"_id": "WbDj8FD9jc76Sefyd",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -109327,6 +110116,7 @@
 {
 	"_id": "3ZxMCB8LCMD4ezevF",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -109510,6 +110300,7 @@
 {
 	"_id": "2pnFqsY3sbsSBDF6c",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -109693,6 +110484,7 @@
 {
 	"_id": "C7MXpAxSJmFfdJv3R",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -109847,6 +110639,7 @@
 {
 	"_id": "Wo7Pt6rtwCgkMdbRp",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -109943,6 +110736,7 @@
 {
 	"_id": "re9Ra8a8ouiEx8BQH",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -110068,6 +110862,7 @@
 {
 	"_id": "3M5kXCS36ZdhFFLuA",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -110193,6 +110988,7 @@
 {
 	"_id": "WtG9cim6D9ZcNF5Br",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -110376,6 +111172,7 @@
 {
 	"_id": "MC2eNZ3bk7DSbL6vj",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -110472,6 +111269,7 @@
 {
 	"_id": "86oMAowvXd8Ja4NoG",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -110655,6 +111453,7 @@
 {
 	"_id": "LixbQRPkZEwTSZoee",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -110780,6 +111579,7 @@
 {
 	"_id": "BWMp6JXP7wr8vHRWM",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -110876,6 +111676,7 @@
 {
 	"_id": "pq6gwbui4s8sDhGcg",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -111059,6 +111860,7 @@
 {
 	"_id": "mPkYcnhciJJgdKrGc",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -111242,6 +112044,7 @@
 {
 	"_id": "hCEafipxnwbZhfaSH",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -111396,6 +112199,7 @@
 {
 	"_id": "YaauChmGix2ymSvLk",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -111521,6 +112325,7 @@
 {
 	"_id": "njSqhtSrzd4WqnJxH",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -111704,6 +112509,7 @@
 {
 	"_id": "m4ANAokZgnqMLizoD",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -111829,6 +112635,7 @@
 {
 	"_id": "dZKoHfGkApzG7T8zG",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -111983,6 +112790,7 @@
 {
 	"_id": "aJnm3vDA5xzAwRqaX",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -112108,6 +112916,7 @@
 {
 	"_id": "QwZbWxGhKqdRExESe",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -112262,6 +113071,7 @@
 {
 	"_id": "c8yXosxb5eB3xjq8z",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -112445,6 +113255,7 @@
 {
 	"_id": "m4hGexszDKFjzKvWz",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -112599,6 +113410,7 @@
 {
 	"_id": "Eh4epbL2JGAbZm35k",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -112695,6 +113507,7 @@
 {
 	"_id": "tMLiX6WGyMrw3qpHD",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -112849,6 +113662,7 @@
 {
 	"_id": "ASurgJk5uBGgAu5YK",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -113003,6 +113817,7 @@
 {
 	"_id": "3mGCvj3ha4gYvxFbA",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -113157,6 +113972,7 @@
 {
 	"_id": "SYDw7ZF2g4wZ92KPC",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -113311,6 +114127,7 @@
 {
 	"_id": "ZntFfNaxtPXCgPL82",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -113494,6 +114311,7 @@
 {
 	"_id": "83cLbs6hWN4GDGFzs",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -113619,6 +114437,7 @@
 {
 	"_id": "MqaBvqCbALYKyWpHW",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -113744,6 +114563,7 @@
 {
 	"_id": "iD65SCbda48RYeSWb",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -113840,6 +114660,7 @@
 {
 	"_id": "3MMMneNQs9evvLGvK",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -114023,6 +114844,7 @@
 {
 	"_id": "TPmM7NF84t3rBeBgR",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -114206,6 +115028,7 @@
 {
 	"_id": "BBAvtJwGxdtauJo9r",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -114331,6 +115154,7 @@
 {
 	"_id": "3qiDs7mZiSni5p8nw",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -114427,6 +115251,7 @@
 {
 	"_id": "JuyBuFTvkfEqADydy",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -114523,6 +115348,7 @@
 {
 	"_id": "9Cm46XXGvzGioosxn",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -114648,6 +115474,7 @@
 {
 	"_id": "eEif5rKskETxk6vvo",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -114831,6 +115658,7 @@
 {
 	"_id": "tiEamtzxm9Eb47gHT",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -114985,6 +115813,7 @@
 {
 	"_id": "9ut7bED6euHMTn6nA",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -115081,6 +115910,7 @@
 {
 	"_id": "CWgg8KvKR3gHzefFf",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -115235,6 +116065,7 @@
 {
 	"_id": "mdRvq7N5JSGdMTJAv",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -115360,6 +116191,7 @@
 {
 	"_id": "cG3DRKcg99tiTiv2Q",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -115456,6 +116288,7 @@
 {
 	"_id": "TA2tqzpBmRpQmtzJs",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -115639,6 +116472,7 @@
 {
 	"_id": "wgTkhRZm3gg3TFred",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -115735,6 +116569,7 @@
 {
 	"_id": "fQvKQcjaGD4pwSraL",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -115831,6 +116666,7 @@
 {
 	"_id": "F3R7euWJRu8wL23MS",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -115985,6 +116821,7 @@
 {
 	"_id": "BNCsCfqKcPohLNEKk",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -116168,6 +117005,7 @@
 {
 	"_id": "TqLpYPDQbpc4YkQ6E",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -116264,6 +117102,7 @@
 {
 	"_id": "qh25qzopJL5CD6CMi",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -116389,6 +117228,7 @@
 {
 	"_id": "PAQY6KfTFaYZAs8nH",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -116485,6 +117325,7 @@
 {
 	"_id": "pGrxFibYJhqFy4MZf",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -116581,6 +117422,7 @@
 {
 	"_id": "9g8J7AHqPjjnMLdYo",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -116706,6 +117548,7 @@
 {
 	"_id": "b3gyGCEwsjKL6hd9w",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -116802,6 +117645,7 @@
 {
 	"_id": "uBXF9QRJcBPLRXBFd",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -116956,6 +117800,7 @@
 {
 	"_id": "hZexpfJW7NrTpA5kT",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -117110,6 +117955,7 @@
 {
 	"_id": "WE2GQPhnEGTeLp6qa",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -117235,6 +118081,7 @@
 {
 	"_id": "Wv3C3xbEg33NtfiZ6",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -117418,6 +118265,7 @@
 {
 	"_id": "RL5BS4tqNwmsaKabZ",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -117543,6 +118391,7 @@
 {
 	"_id": "m9wdFzSWuLzZS9K5w",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -117668,6 +118517,7 @@
 {
 	"_id": "HRze3oSipq5zmC9M7",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -117793,6 +118643,7 @@
 {
 	"_id": "q2hM7SxA4H6PQm4u4",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -117889,6 +118740,7 @@
 {
 	"_id": "9wx9M8BK82x3dnyXd",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -118043,6 +118895,7 @@
 {
 	"_id": "SMn3By3aijyF7mzfD",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -118197,6 +119050,7 @@
 {
 	"_id": "dA32YLRia2yKcKw2j",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -118380,6 +119234,7 @@
 {
 	"_id": "32u6NWF9ndhhFiCAp",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -118476,6 +119331,7 @@
 {
 	"_id": "bs6nE7rENwTEPB9rM",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -118659,6 +119515,7 @@
 {
 	"_id": "Jg4dBbb2x7e6soWqo",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -118813,6 +119670,7 @@
 {
 	"_id": "STcg9NquPHCZxTeSe",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -118909,6 +119767,7 @@
 {
 	"_id": "n3WxhcJDkY5nr2yeD",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -119005,6 +119864,7 @@
 {
 	"_id": "u356EY6C5m4LbKndW",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -119188,6 +120048,7 @@
 {
 	"_id": "tmHunDxou36xuLihH",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -119371,6 +120232,7 @@
 {
 	"_id": "5nTdGyN5Qu4ys54Ga",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -119496,6 +120358,7 @@
 {
 	"_id": "E4JxNchtw9NXyC8fd",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -119679,6 +120542,7 @@
 {
 	"_id": "gq8e6wpSsxcu5SmmM",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -119804,6 +120668,7 @@
 {
 	"_id": "2FtQyvfMqRhfED26L",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -119900,6 +120765,7 @@
 {
 	"_id": "hz7arokfhXnbMgbSL",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -119996,6 +120862,7 @@
 {
 	"_id": "3x9swomg6qAm45H8g",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -120150,6 +121017,7 @@
 {
 	"_id": "7MdBh2dEQxRo3GesQ",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -120304,6 +121172,7 @@
 {
 	"_id": "XpSsCq8HfjNtkH7Lv",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -120487,6 +121356,7 @@
 {
 	"_id": "bXvaJBF8poE5tcGQJ",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -120641,6 +121511,7 @@
 {
 	"_id": "mMgfRCAR9rcWA7SoA",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -120824,6 +121695,7 @@
 {
 	"_id": "F5t3C5KY4tadXsfEv",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -120978,6 +121850,7 @@
 {
 	"_id": "xeCCvh8PMriweCb8J",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -121074,6 +121947,7 @@
 {
 	"_id": "BabtdXELkcfWMv9LE",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -121228,6 +122102,7 @@
 {
 	"_id": "XTWmxunP7Tm9LRCuD",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -121411,6 +122286,7 @@
 {
 	"_id": "5WWvfNZAyAXJQwbJ9",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -121536,6 +122412,7 @@
 {
 	"_id": "PCCSoi4fur4Ko5uJu",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -121632,6 +122509,7 @@
 {
 	"_id": "QQHvCmn4KEimvbAr6",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -121728,6 +122606,7 @@
 {
 	"_id": "Ym6B3qqCT3BxmwZuR",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -121911,6 +122790,7 @@
 {
 	"_id": "iWP9SDjAZWiiiFMGq",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -122036,6 +122916,7 @@
 {
 	"_id": "oCQu6qrKQ6n5nXJHm",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -122219,6 +123100,7 @@
 {
 	"_id": "xNiWNgaWxzdNDLrzH",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -122373,6 +123255,7 @@
 {
 	"_id": "5GwRR63KNrGwbTYTN",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -122556,6 +123439,7 @@
 {
 	"_id": "2ccztApJ8MXXX3Z8T",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -122739,6 +123623,7 @@
 {
 	"_id": "8EaHr9czJ5kPXz26s",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -122864,6 +123749,7 @@
 {
 	"_id": "pA4MZDChQZxwFvaue",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -123018,6 +123904,7 @@
 {
 	"_id": "9MzizbxeNwtNDQGJk",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -123114,6 +124001,7 @@
 {
 	"_id": "PcFMq9kw4iXnMxkFi",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -123239,6 +124127,7 @@
 {
 	"_id": "bXbh6KPGgnkz9v4e9",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -123422,6 +124311,7 @@
 {
 	"_id": "5eQ3i6LSyasxqqkAY",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -123547,6 +124437,7 @@
 {
 	"_id": "yd4t2G4Xua4teAFzg",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -123672,6 +124563,7 @@
 {
 	"_id": "u8XCFn4QPJmFZq9e7",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -123768,6 +124660,7 @@
 {
 	"_id": "SKghpGi8RrKBBCJpi",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -123951,6 +124844,7 @@
 {
 	"_id": "DaHEJzEJ7ihJ3uWQn",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -124134,6 +125028,7 @@
 {
 	"_id": "hQjfgq6wJrNKvnCep",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -124288,6 +125183,7 @@
 {
 	"_id": "LpLDNgiWB3iZzADTR",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -124471,6 +125367,7 @@
 {
 	"_id": "YxifWoGc5kNWwzzj3",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -124625,6 +125522,7 @@
 {
 	"_id": "cRqC9Wa8LX2KLkDZ2",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -124750,6 +125648,7 @@
 {
 	"_id": "AL3fWMegisJ7xyEf9",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -124875,6 +125774,7 @@
 {
 	"_id": "x6nwpoHjgR9qxa2CL",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -124971,6 +125871,7 @@
 {
 	"_id": "PySgBunQJCZXq2FGj",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -125067,6 +125968,7 @@
 {
 	"_id": "JpkqQJs6djWcPmFrF",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -125221,6 +126123,7 @@
 {
 	"_id": "sxXwmetHWAZEHuRDe",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -125375,6 +126278,7 @@
 {
 	"_id": "85pvqcZCS6oSsASpD",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -125529,6 +126433,7 @@
 {
 	"_id": "icyrRu9eN3KhkvEf9",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -125625,6 +126530,7 @@
 {
 	"_id": "zvzWrJ5nH33Rgj5sL",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -125808,6 +126714,7 @@
 {
 	"_id": "EGiacBxqiyuDjPSf4",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -125904,6 +126811,7 @@
 {
 	"_id": "aoxKirb2wHsufnZmg",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -126000,6 +126908,7 @@
 {
 	"_id": "Kt3tr5skbK34GxYML",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -126125,6 +127034,7 @@
 {
 	"_id": "JzNTsp9GPiGazd6aT",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -126221,6 +127131,7 @@
 {
 	"_id": "FWn58XR6vK4YckdGb",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -126404,6 +127315,7 @@
 {
 	"_id": "tNsrzjynp4ADNZje9",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -126558,6 +127470,7 @@
 {
 	"_id": "nkLsYWR9jijkuzD3E",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -126712,6 +127625,7 @@
 {
 	"_id": "G3AbgHLjPv8wdwseE",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -126895,6 +127809,7 @@
 {
 	"_id": "YbTjsdAshpKthyAqv",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -127049,6 +127964,7 @@
 {
 	"_id": "eGeNceJ22djMucK8y",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -127232,6 +128148,7 @@
 {
 	"_id": "cpxuYAT2xbqBexMZC",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -127328,6 +128245,7 @@
 {
 	"_id": "4CFpxq9vtNrMtBf4R",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -127482,6 +128400,7 @@
 {
 	"_id": "9WzAEufeTkgCuQn5y",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -127578,6 +128497,7 @@
 {
 	"_id": "HfjSMnZ6QrXATvLpS",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -127732,6 +128652,7 @@
 {
 	"_id": "HNznJAGYbd3Lp8qvY",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -127915,6 +128836,7 @@
 {
 	"_id": "AbMbRnrR7JAkWsRc9",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -128011,6 +128933,7 @@
 {
 	"_id": "jRzBR4HBpgygKMmBc",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -128194,6 +129117,7 @@
 {
 	"_id": "GaMv4ksH926gWXmfa",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -128377,6 +129301,7 @@
 {
 	"_id": "QY2rtoZgyuRNiyrvz",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -128560,6 +129485,7 @@
 {
 	"_id": "KDXCJpeMnYc2A9prF",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -128743,6 +129669,7 @@
 {
 	"_id": "dvvRm5cTRmxoNWL4f",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -128839,6 +129766,7 @@
 {
 	"_id": "id2PEAHtcJqHuRQc4",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -128964,6 +129892,7 @@
 {
 	"_id": "BqCKqP4vQHyzRpCw8",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -129060,6 +129989,7 @@
 {
 	"_id": "MnkmGLYrwr5gxz6jN",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -129156,6 +130086,7 @@
 {
 	"_id": "oM6rPdA2kPgRhv6fi",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -129310,6 +130241,7 @@
 {
 	"_id": "cDb3QnuCohENYwrGi",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -129464,6 +130396,7 @@
 {
 	"_id": "iugF9HDknCSPiBmEA",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -129589,6 +130522,7 @@
 {
 	"_id": "T4fDsQ9x2xgpaRkJJ",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -129685,6 +130619,7 @@
 {
 	"_id": "ofrMMofwFPGrYaxPe",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -129781,6 +130716,7 @@
 {
 	"_id": "3imHQkDhabHvcqMqA",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -129906,6 +130842,7 @@
 {
 	"_id": "pzEtXx8TEqr5DwHPS",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -130002,6 +130939,7 @@
 {
 	"_id": "SoYxmBPhYvxRSi69u",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -130098,6 +131036,7 @@
 {
 	"_id": "84cyXAtDzvo73m7xg",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -130281,6 +131220,7 @@
 {
 	"_id": "YdSeFuCfSosd5s5BC",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -130435,6 +131375,7 @@
 {
 	"_id": "DyJmPur6RGZzWHgAa",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -130618,6 +131559,7 @@
 {
 	"_id": "gN659y4KyD5r97jqb",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -130772,6 +131714,7 @@
 {
 	"_id": "qL3taeNpYoDw6rNTS",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -130897,6 +131840,7 @@
 {
 	"_id": "awcpkfKevt5w7wHN8",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -131022,6 +131966,7 @@
 {
 	"_id": "TQpYY7gamPFfNwNTm",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -131147,6 +132092,7 @@
 {
 	"_id": "sqyCPjM9kZEe3oWdK",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -131243,6 +132189,7 @@
 {
 	"_id": "Rq84phZLpF6uj5Cai",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -131339,6 +132286,7 @@
 {
 	"_id": "K9ffdAm7StMvoohdr",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -131464,6 +132412,7 @@
 {
 	"_id": "G8RpjoRoPXa9KpTQp",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -131560,6 +132509,7 @@
 {
 	"_id": "qmaBEfxPa2QHR86MT",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -131714,6 +132664,7 @@
 {
 	"_id": "As6cyJ2ot55RJhKeN",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -131810,6 +132761,7 @@
 {
 	"_id": "HChpGfPpyMMzSmeae",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -131906,6 +132858,7 @@
 {
 	"_id": "nBBJ6QYgLrvWsp7FP",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -132002,6 +132955,7 @@
 {
 	"_id": "EdsE37n2dpxrEFp2a",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -132185,6 +133139,7 @@
 {
 	"_id": "rnAnjoLHp6grBPdBu",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -132368,6 +133323,7 @@
 {
 	"_id": "gdnD3kzWwYzHMmBk9",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -132551,6 +133507,7 @@
 {
 	"_id": "vRNDwcfqBhqTvjA3B",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -132734,6 +133691,7 @@
 {
 	"_id": "jSPZwqodqbJofCALn",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -132859,6 +133817,7 @@
 {
 	"_id": "TF9zX6P48AArQLGQu",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -132984,6 +133943,7 @@
 {
 	"_id": "EpCDfxo9qZnMuAQwa",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -133138,6 +134098,7 @@
 {
 	"_id": "G6kr9nCsKKjerKoud",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -133234,6 +134195,7 @@
 {
 	"_id": "66eWr9NmbjQL5L2Ak",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -133330,6 +134292,7 @@
 {
 	"_id": "R6apCsKJLmvWdhpHY",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -133426,6 +134389,7 @@
 {
 	"_id": "myfARqXsnKQ8Q7fbS",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -133522,6 +134486,7 @@
 {
 	"_id": "ZLEGFwBG75StquTy9",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -133647,6 +134612,7 @@
 {
 	"_id": "jEgrB57eRjcmevPgb",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -133743,6 +134709,7 @@
 {
 	"_id": "ijHmQCN9hjAHgC3ER",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -133868,6 +134835,7 @@
 {
 	"_id": "h4fjeMiHpTw8Roroc",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -134051,6 +135019,7 @@
 {
 	"_id": "yTmG3kfDfXX2acbnM",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -134234,6 +135203,7 @@
 {
 	"_id": "pJKa2rRkNop3toC7g",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -134330,6 +135300,7 @@
 {
 	"_id": "TAhoYQ8ZdXJ4HzEAM",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -134455,6 +135426,7 @@
 {
 	"_id": "3SnBDR64HkPmPzWCk",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -134609,6 +135581,7 @@
 {
 	"_id": "yZuGZoEoRALeCWWQy",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -134792,6 +135765,7 @@
 {
 	"_id": "hJ6FCtSCyYXZnoLRg",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -134917,6 +135891,7 @@
 {
 	"_id": "HoYEsvHzMoQ2kxfi3",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -135013,6 +135988,7 @@
 {
 	"_id": "4oZcJiKxP8Cd84csX",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -135167,6 +136143,7 @@
 {
 	"_id": "sHwkm4HJEnEWyNnvo",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -135350,6 +136327,7 @@
 {
 	"_id": "EoehzTJgsWw37nWkX",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -135504,6 +136482,7 @@
 {
 	"_id": "2mnadyMQunBWdgjL7",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -135687,6 +136666,7 @@
 {
 	"_id": "PFLg4YWJEdhAP64Xw",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -135783,6 +136763,7 @@
 {
 	"_id": "3YbqyeoH3iTLhRRAp",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -135966,6 +136947,7 @@
 {
 	"_id": "8s3JCEf6oEKXPAkPp",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -136120,6 +137102,7 @@
 {
 	"_id": "hBzHJNWvC5ituuXTm",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -136274,6 +137257,7 @@
 {
 	"_id": "ZRLshzs6Ni3qFFefP",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -136399,6 +137383,7 @@
 {
 	"_id": "xBu3uougcjFJX38u7",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -136524,6 +137509,7 @@
 {
 	"_id": "Jegetq3LFbFbiyktr",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -136707,6 +137693,7 @@
 {
 	"_id": "ErbWvcQmXNRarv2DF",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -136832,6 +137819,7 @@
 {
 	"_id": "rWz2ygAx8958oRdNv",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -137015,6 +138003,7 @@
 {
 	"_id": "mvZb5iGYAHbdAtfsP",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -137140,6 +138129,7 @@
 {
 	"_id": "vKh5yLZzAgRBGN87L",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -137236,6 +138226,7 @@
 {
 	"_id": "wM2ZktNT5kSN9uXoN",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -137419,6 +138410,7 @@
 {
 	"_id": "bZwAJ3ycT3dzBDn3f",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -137544,6 +138536,7 @@
 {
 	"_id": "zDNbaTiya56sY6Xap",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -137640,6 +138633,7 @@
 {
 	"_id": "scjYTggYGkbxp9BJQ",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -137794,6 +138788,7 @@
 {
 	"_id": "AeyMeaX8C5EEvMBB8",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -137977,6 +138972,7 @@
 {
 	"_id": "ZytqSkC6rBGPrjCaH",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -138102,6 +139098,7 @@
 {
 	"_id": "wZFaeubnjBYiyNwQ8",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -138256,6 +139253,7 @@
 {
 	"_id": "T8xAgfMAqyPwRKCF5",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -138439,6 +139437,7 @@
 {
 	"_id": "Mt3wF5h6z5c3QBMWS",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",
@@ -138564,6 +139563,7 @@
 {
 	"_id": "jDttCcoTyjLihzoLr",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"originCountry": "US",

--- a/sample-data/data/small/Products.json
+++ b/sample-data/data/small/Products.json
@@ -23,11 +23,6 @@
 	"vendor": "Bluestone Coffee",
 	"description": "A bag of rich Arabica coffee. Great for a fueling up for a night out or for settling in for a night of coding at home",
 	"isBackorder": true,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [
 		"hZdSevCBP8dDc66Ba"
 	]
@@ -143,11 +138,6 @@
 	"vendor": "Mugworks",
 	"description": "A sturdy mug to keep your hot drinks hot and your cold drinks cold",
 	"isBackorder": true,
-	"positions": {
-		"reaction swag shop": {
-			"weight": 1
-		}
-	},
 	"hashtags": [
 		"hZdSevCBP8dDc66Ba"
 	]

--- a/sample-data/data/small/Products.json
+++ b/sample-data/data/small/Products.json
@@ -1,6 +1,7 @@
 [{
 	"_id": "h2v7MYCXBtjMm7Piv",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"title": "Reaction Bag of Beans",
@@ -116,6 +117,7 @@
 {
 	"_id": "z6paQqnrGnWBvepyB",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"title": "Reaction Mug",
@@ -173,6 +175,7 @@
 {
 	"_id": "gygxrADdPPWoCCmS7",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"title": "Reaction Commerce Pouch",
@@ -230,6 +233,7 @@
 {
 	"_id": "ioKwBYk6Nom9K92cv",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"title": "Reaction Scout Book",
@@ -287,6 +291,7 @@
 {
 	"_id": "xsudQc3K2EbqCeFBm",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"title": "Reaction Ladies Shirt",
@@ -460,6 +465,7 @@
 {
 	"_id": "GpZM5v5qQBCdXsoqW",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"title": "Reaction Mens Shirt",
@@ -633,6 +639,7 @@
 {
 	"_id": "9zxhE27pAvx8vbKr5",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"ancestors": [],
 	"shopId": "J8Bhq3uTtdgwZx3rz",
 	"title": "Reaction Sticker",
@@ -690,6 +697,7 @@
 {
 	"_id": "5pe6Y2sxKy5eppGMF",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"isVisible": true,
 	"ancestors": [],
 	"title": "Reaction Hoodie",
@@ -861,6 +869,7 @@
 {
 	"_id": "Ks3fNppgpv4G8R4gt",
 	"type": "simple",
+  "supportedFulfillmentTypes": ["shipping"],
 	"isVisible": true,
 	"ancestors": [],
 	"title": "Reaction Camp Shirt",

--- a/sample-data/data/small/Products.json
+++ b/sample-data/data/small/Products.json
@@ -13,8 +13,8 @@
 	"template": "productDetailSimple",
 	"price": {
 		"range": "12 - 24",
-		"min": 12,
-		"max": 24
+		"min": 12.00,
+		"max": 24.00
 	},
 	"workflow": {
 		"status": "new"
@@ -33,7 +33,7 @@
 	"ancestors": [
 		"h2v7MYCXBtjMm7Piv"
 	],
-	"price": 0,
+	"price": 0.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -64,7 +64,7 @@
 	],
 	"type": "variant",
 	"title": "One pound bag",
-	"price": 12,
+	"price": 12.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 15,
@@ -93,7 +93,7 @@
 	],
 	"type": "variant",
 	"title": "Two pound bag",
-	"price": 24,
+	"price": 24.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 28,
@@ -129,8 +129,8 @@
 	"template": "productDetailSimple",
 	"price": {
 		"range": "15",
-		"min": 15,
-		"max": 15
+		"min": 15.00,
+		"max": 15.00
 	},
 	"workflow": {
 		"status": "new"
@@ -149,7 +149,7 @@
 	"ancestors": [
 		"z6paQqnrGnWBvepyB"
 	],
-	"price": 15,
+	"price": 15.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -187,8 +187,8 @@
 	"template": "productDetailSimple",
 	"price": {
 		"range": "8",
-		"min": 8,
-		"max": 8
+		"min": 8.00,
+		"max": 8.00
 	},
 	"workflow": {
 		"status": "new"
@@ -207,7 +207,7 @@
 	"ancestors": [
 		"gygxrADdPPWoCCmS7"
 	],
-	"price": 8,
+	"price": 8.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -245,8 +245,8 @@
 	"template": "productDetailSimple",
 	"price": {
 		"range": "6",
-		"min": 6,
-		"max": 6
+		"min": 6.00,
+		"max": 6.00
 	},
 	"workflow": {
 		"status": "new"
@@ -265,7 +265,7 @@
 	"ancestors": [
 		"ioKwBYk6Nom9K92cv"
 	],
-	"price": 6,
+	"price": 6.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -303,8 +303,8 @@
 	"template": "productDetailSimple",
 	"price": {
 		"range": "18 - 20",
-		"min": 18,
-		"max": 20
+		"min": 18.00,
+		"max": 20.00
 	},
 	"workflow": {
 		"status": "new"
@@ -323,7 +323,7 @@
 	"ancestors": [
 		"xsudQc3K2EbqCeFBm"
 	],
-	"price": 18,
+	"price": 18.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -354,7 +354,7 @@
 	],
 	"type": "variant",
 	"title": "SM",
-	"price": 18,
+	"price": 18.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 24,
@@ -383,7 +383,7 @@
 	],
 	"type": "variant",
 	"title": "M",
-	"price": 18,
+	"price": 18.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 24,
@@ -412,7 +412,7 @@
 	],
 	"type": "variant",
 	"title": "L",
-	"price": 18,
+	"price": 18.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 24,
@@ -441,7 +441,7 @@
 	],
 	"type": "variant",
 	"title": "XL",
-	"price": 20,
+	"price": 20.00,
 	"isVisible": true,
 	"isDeleted": false,
 	"compareAtPrice": 26,
@@ -476,8 +476,8 @@
 	"template": "productDetailSimple",
 	"price": {
 		"range": "18 - 20",
-		"min": 18,
-		"max": 20
+		"min": 18.00,
+		"max": 20.00
 	},
 	"workflow": {
 		"status": "new"
@@ -497,7 +497,7 @@
 	"ancestors": [
 		"GpZM5v5qQBCdXsoqW"
 	],
-	"price": 18,
+	"price": 18.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -528,7 +528,7 @@
 		"cxYA8s8qdi8qnYSNw"
 	],
 	"lowInventoryWarningThreshold": 0,
-	"price": 18,
+	"price": 18.00,
 	"height": 1,
 	"compareAtPrice": 24,
 	"originCountry": "US",
@@ -557,7 +557,7 @@
 		"cxYA8s8qdi8qnYSNw"
 	],
 	"lowInventoryWarningThreshold": 0,
-	"price": 18,
+	"price": 18.00,
 	"height": 2,
 	"compareAtPrice": 24,
 	"originCountry": "US",
@@ -586,7 +586,7 @@
 		"cxYA8s8qdi8qnYSNw"
 	],
 	"lowInventoryWarningThreshold": 0,
-	"price": 18,
+	"price": 18.00,
 	"height": 1,
 	"compareAtPrice": 24,
 	"originCountry": "US",
@@ -615,7 +615,7 @@
 		"cxYA8s8qdi8qnYSNw"
 	],
 	"lowInventoryWarningThreshold": 0,
-	"price": 20,
+	"price": 20.00,
 	"height": 1,
 	"compareAtPrice": 26,
 	"originCountry": "US",
@@ -651,8 +651,8 @@
 	"template": "productDetailSimple",
 	"price": {
 		"range": "4",
-		"min": 4,
-		"max": 4
+		"min": 4.00,
+		"max": 4.00
 	},
 	"workflow": {
 		"status": "new"
@@ -671,7 +671,7 @@
 	"ancestors": [
 		"9zxhE27pAvx8vbKr5"
 	],
-	"price": 4,
+	"price": 4.00,
 	"type": "variant",
 	"isVisible": true,
 	"isDeleted": false,
@@ -712,8 +712,8 @@
 	},
 	"price": {
 		"range": "35",
-		"min": 35,
-		"max": 35
+		"min": 35.00,
+		"max": 35.00
 	},
 	"vendor": "Hanes",
 	"description": "Whether DJ'ing your EDM set or hacking into the NSA this stylish hoodie will keep your tiny fragile body warm",
@@ -728,7 +728,7 @@
 	"ancestors": [
 		"5pe6Y2sxKy5eppGMF"
 	],
-	"price": 0,
+	"price": 0.00,
 	"inventoryQuantity": 0,
 	"isDeleted": false,
 	"compareAtPrice": 0,
@@ -758,7 +758,7 @@
 	],
 	"type": "variant",
 	"title": "S",
-	"price": 35,
+	"price": 35.00,
 	"inventoryQuantity": 100,
 	"isDeleted": false,
 	"compareAtPrice": 55,
@@ -787,7 +787,7 @@
 	],
 	"type": "variant",
 	"title": "M",
-	"price": 35,
+	"price": 35.00,
 	"inventoryQuantity": 100,
 	"isDeleted": false,
 	"compareAtPrice": 55,
@@ -816,7 +816,7 @@
 	],
 	"type": "variant",
 	"title": "L",
-	"price": 35,
+	"price": 35.00,
 	"inventoryQuantity": 100,
 	"isDeleted": false,
 	"compareAtPrice": 55,
@@ -845,7 +845,7 @@
 	],
 	"type": "variant",
 	"title": "XL",
-	"price": 35,
+	"price": 35.00,
 	"inventoryQuantity": 100,
 	"isDeleted": false,
 	"compareAtPrice": 55,
@@ -883,8 +883,8 @@
 	},
 	"price": {
 		"range": "40 - 45",
-		"min": 40,
-		"max": 45
+		"min": 40.00,
+		"max": 45.00
 	},
 	"vendor": "Hanes",
 	"description": "This camp shirt is a classy, clean alternative to T-shirts or Polos. Represent Reaction at camp or on the road",
@@ -900,7 +900,7 @@
 	"ancestors": [
 		"Ks3fNppgpv4G8R4gt"
 	],
-	"price": 0,
+	"price": 0.00,
 	"inventoryQuantity": 0,
 	"isDeleted": false,
 	"compareAtPrice": 0,
@@ -930,7 +930,7 @@
 	],
 	"type": "variant",
 	"title": "S",
-	"price": 40,
+	"price": 40.00,
 	"inventoryQuantity": 100,
 	"isDeleted": false,
 	"compareAtPrice": 55,
@@ -959,7 +959,7 @@
 	],
 	"type": "variant",
 	"title": "M",
-	"price": 40,
+	"price": 40.00,
 	"inventoryQuantity": 100,
 	"isDeleted": false,
 	"compareAtPrice": 55,
@@ -988,7 +988,7 @@
 	],
 	"type": "variant",
 	"title": "L",
-	"price": 45,
+	"price": 45.00,
 	"inventoryQuantity": 100,
 	"isDeleted": false,
 	"compareAtPrice": 55,
@@ -1017,7 +1017,7 @@
 	],
 	"type": "variant",
 	"title": "XL",
-	"price": 45,
+	"price": 45.00,
 	"inventoryQuantity": 100,
 	"isDeleted": false,
 	"compareAtPrice": 55,

--- a/server/dataset.js
+++ b/server/dataset.js
@@ -18,11 +18,6 @@ export const productTemplate = {
   isLowQuantity: false,
   isSoldOut: false,
   isBackorder: false,
-  positions: {
-    "reaction swag shop": {
-      weight: 1
-    }
-  },
   hashtags: []
 };
 

--- a/server/dataset.js
+++ b/server/dataset.js
@@ -355,13 +355,8 @@ export const orderTemplate = {
         carrier: "Flat Rate"
       },
       paymentId: "CPgv7L9bH9wXFEGTT",
-      items: [
-        {
-          _id: "5DipCF2Nvdb4tLzsi",
-          productId: "BCTMZ6HTxFSppJESk",
-          shopId: "J8Bhq3uTtdgwZx3rz",
-          variantId: "CJoRBm9vRrorc9mxZ"
-        }
+      itemIds: [
+        "5DipCF2Nvdb4tLzsi"
       ],
       workflow: {
         status: "new",

--- a/server/dataset.js
+++ b/server/dataset.js
@@ -73,8 +73,6 @@ export const optionTemplate = {
 };
 
 export const orderTemplate = {
-  sessionId: "SjtGZesckPtxRf755",
-  userId: "qoSQCkbnHayhf49xc",
   accountId: "qoSQCkbnHayhf49xc",
   currencyCode: "USD",
   shopId: "J8Bhq3uTtdgwZx3rz",
@@ -276,7 +274,8 @@ export const orderTemplate = {
           rate: 2.99,
           enabled: true,
           _id: "ppsATnw3f4r4ARHvu",
-          carrier: "Flat Rate"
+          carrier: "Flat Rate",
+          currencyCode: "USD"
         },
         paymentId: "CPgv7L9bH9wXFEGTT",
         items: [

--- a/server/dataset.js
+++ b/server/dataset.js
@@ -18,7 +18,8 @@ export const productTemplate = {
   isLowQuantity: false,
   isSoldOut: false,
   isBackorder: false,
-  hashtags: []
+  hashtags: [],
+  supportedFulfillmentTypes: ["shipping"]
 };
 
 export const variantTemplate = {

--- a/server/dataset.js
+++ b/server/dataset.js
@@ -272,7 +272,6 @@ export const orderTemplate = {
           group: "Ground",
           handling: 0,
           rate: 2.99,
-          enabled: true,
           _id: "ppsATnw3f4r4ARHvu",
           carrier: "Flat Rate",
           currencyCode: "USD"
@@ -319,27 +318,6 @@ export const orderTemplate = {
   shipping: [
     {
       shopId: "J8Bhq3uTtdgwZx3rz",
-      shipmentQuotes: [
-        {
-          carrier: "Flat Rate",
-          method: {
-            name: "Standard",
-            label: "Standard",
-            group: "Ground",
-            handling: 0,
-            rate: 2.99,
-            enabled: true,
-            _id: "ppsATnw3f4r4ARHvu",
-            carrier: "Flat Rate"
-          },
-          rate: 2.99,
-          shopId: "J8Bhq3uTtdgwZx3rz"
-        }
-      ],
-      shipmentQuotesQueryStatus: {
-        requestStatus: "success",
-        numOfShippingMethodsFound: 1
-      },
       _id: "uqxDNgszdbk7TCQoY",
       address: {
         country: "US",
@@ -361,11 +339,28 @@ export const orderTemplate = {
         group: "Ground",
         handling: 0,
         rate: 2.99,
-        enabled: true,
         _id: "ppsATnw3f4r4ARHvu",
-        carrier: "Flat Rate"
+        carrier: "Flat Rate",
+        currencyCode: "USD"
       },
-      paymentId: "CPgv7L9bH9wXFEGTT",
+      payment: {
+        _id: "CPgv7L9bH9wXFEGTT",
+        displayName: "Visa 4242",
+        amount: 15.98,
+        invoice: {
+          shipping: 2.99,
+          subtotal: 12.99,
+          taxes: 0,
+          discounts: 0,
+          total: 15.98
+        },
+        method: "credit",
+        mode: "authorize",
+        paymentPluginName: "example-paymentmethod",
+        processor: "Example",
+        status: "created",
+        shopId: "J8Bhq3uTtdgwZx3rz"
+      },
       itemIds: [ "5DipCF2Nvdb4tLzsi" ],
       workflow: {
         status: "new",

--- a/server/dataset.js
+++ b/server/dataset.js
@@ -308,11 +308,9 @@ export const orderTemplate = {
         amount: 12.99,
         currencyCode: "USD"
       },
-      productId: "BCTMZ6HTxFSppJESk",
       productSlug: "example-product",
       productType: "simple",
       productVendor: "Example Manufacturer",
-      shopId: "J8Bhq3uTtdgwZx3rz",
       taxCode: "0000",
       updatedAt: new Date(),
       variantId: "CJoRBm9vRrorc9mxZ",

--- a/server/dataset.js
+++ b/server/dataset.js
@@ -8,8 +8,8 @@ export const productTemplate = {
   isVisible: true,
   price: {
     range: "12 - 24",
-    min: 12,
-    max: 24
+    min: 12.00,
+    max: 24.00
   },
   template: "productDetailSimple",
   workflow: {
@@ -24,7 +24,7 @@ export const productTemplate = {
 
 export const variantTemplate = {
   ancestors: [],
-  price: 0,
+  price: 0.00,
   type: "variant",
   isVisible: true,
   isDeleted: false,
@@ -52,7 +52,7 @@ export const optionTemplate = {
   ancestors: [],
   type: "variant",
   title: "One pound bag",
-  price: 12,
+  price: 12.00,
   isVisible: true,
   isDeleted: false,
   compareAtPrice: 15,

--- a/server/dataset.js
+++ b/server/dataset.js
@@ -82,239 +82,6 @@ export const orderTemplate = {
       "coreOrderWorkflow/created"
     ]
   },
-  billing: [
-    {
-      paymentMethod: {
-        processor: "Example",
-        paymentPackageId: "xEiA2uER9fheyCi4v",
-        paymentSettingsKey: "example-paymentmethod",
-        storedCard: "Visa 4242",
-        method: "credit",
-        transactionId: "jLQ5nbTbJYPA7H2aw",
-        riskLevel: "normal",
-        currency: "USD",
-        amount: 15.98,
-        status: "created",
-        mode: "authorize",
-        transactions: [
-          {
-            amount: 15.98,
-            transactionId: "jLQ5nbTbJYPA7H2aw",
-            currency: "USD"
-          }
-        ],
-        workflow: {
-          status: "new"
-        }
-      },
-      invoice: {
-        shipping: 2.99,
-        subtotal: 12.99,
-        taxes: 0,
-        discounts: 0,
-        total: 15.98
-      },
-      address: {
-        country: "US",
-        fullName: "Fake Customer",
-        address1: "2110 Main St. Suite 207",
-        postal: "90405",
-        city: "Santa Monica",
-        region: "CA",
-        phone: "3236873265",
-        isShippingDefault: true,
-        isBillingDefault: true,
-        isCommercial: false,
-        _id: "vxkNHcB5mQ33gFRYP",
-        failedValidation: false
-      },
-      shopId: "J8Bhq3uTtdgwZx3rz",
-      _id: "CPgv7L9bH9wXFEGTT",
-      currency: {
-        userCurrency: "USD",
-        exchangeRate: 1
-      }
-    }
-  ],
-  discount: 0,
-  tax: 0,
-  items: [
-    {
-      _id: "5DipCF2Nvdb4tLzsi",
-      shopId: "J8Bhq3uTtdgwZx3rz",
-      productId: "BCTMZ6HTxFSppJESk",
-      quantity: 1,
-      product: {
-        _id: "BCTMZ6HTxFSppJESk",
-        title: "Basic Reaction Product",
-        shopId: "J8Bhq3uTtdgwZx3rz",
-        ancestors: [],
-        description: "Sign in as administrator to edit.",
-        handle: "example-product",
-        hashtags: [
-          "rpjCvTBGjhBi2xdro",
-          "cseCBSSrJ3t8HQSNP"
-        ],
-        price: {
-          range: "12.99 - 19.99",
-          min: 12.99,
-          max: 19.99
-        },
-        isVisible: true,
-        isLowQuantity: false,
-        isSoldOut: false,
-        isBackorder: false,
-        metafields: [
-          {
-            key: "Material",
-            value: "Cotton"
-          },
-          {
-            key: "Quality",
-            value: "Excellent"
-          }
-        ],
-        pageTitle: "This is a basic product. You can do a lot with it.",
-        type: "simple",
-        vendor: "Example Manufacturer",
-        originCountry: "US",
-        requiresShipping: true,
-        isDeleted: false,
-        template: "productDetailSimple",
-        workflow: {
-          status: "new"
-        }
-      },
-      variants: {
-        _id: "CJoRBm9vRrorc9mxZ",
-        title: "Option 2 - Green Tomato",
-        ancestors: [
-          "BCTMZ6HTxFSppJESk",
-          "6qiqPwBkeJdtdQc4G"
-        ],
-        optionTitle: "Green",
-        price: 12.99,
-        inventoryManagement: true,
-        inventoryPolicy: true,
-        inventoryQuantity: 42,
-        isVisible: true,
-        weight: 25,
-        length: 10,
-        height: 3,
-        width: 10,
-        metafields: [
-          {
-            key: null,
-            value: null
-          }
-        ],
-        shopId: "J8Bhq3uTtdgwZx3rz",
-        taxable: true,
-        type: "variant",
-        isDeleted: false,
-        compareAtPrice: 0,
-        lowInventoryWarningThreshold: 0,
-        taxCode: "0000",
-        originCountry: "US",
-        workflow: {
-          status: "new"
-        }
-      },
-      title: "Basic Reaction Product",
-      type: "simple",
-      parcel: {
-        weight: 25,
-        height: 3,
-        width: 10,
-        length: 10
-      },
-      shippingMethod: {
-        shopId: "J8Bhq3uTtdgwZx3rz",
-        shipmentQuotes: [
-          {
-            carrier: "Flat Rate",
-            method: {
-              name: "Standard",
-              label: "Standard",
-              group: "Ground",
-              handling: 0,
-              rate: 2.99,
-              enabled: true,
-              _id: "ppsATnw3f4r4ARHvu",
-              carrier: "Flat Rate"
-            },
-            rate: 2.99,
-            shopId: "J8Bhq3uTtdgwZx3rz"
-          }
-        ],
-        shipmentQuotesQueryStatus: {
-          requestStatus: "success",
-          numOfShippingMethodsFound: 1
-        },
-        _id: "uqxDNgszdbk7TCQoY",
-        address: {
-          country: "US",
-          fullName: "Fake Customer",
-          address1: "2110 Main St. Suite 207",
-          postal: "90405",
-          city: "Santa Monica",
-          region: "CA",
-          phone: "3236873265",
-          isShippingDefault: true,
-          isBillingDefault: true,
-          isCommercial: false,
-          _id: "vxkNHcB5mQ33gFRYP",
-          failedValidation: false
-        },
-        shipmentMethod: {
-          name: "Standard",
-          label: "Standard",
-          group: "Ground",
-          handling: 0,
-          rate: 2.99,
-          _id: "ppsATnw3f4r4ARHvu",
-          carrier: "Flat Rate",
-          currencyCode: "USD"
-        },
-        paymentId: "CPgv7L9bH9wXFEGTT",
-        items: [
-          {
-            _id: "5DipCF2Nvdb4tLzsi",
-            productId: "BCTMZ6HTxFSppJESk",
-            shopId: "J8Bhq3uTtdgwZx3rz",
-            variantId: "CJoRBm9vRrorc9mxZ"
-          }
-        ],
-        workflow: {
-          status: "new",
-          workflow: [
-            "coreOrderWorkflow/notStarted"
-          ]
-        }
-      },
-      workflow: {
-        status: "new",
-        workflow: [
-          "coreOrderWorkflow/created"
-        ]
-      },
-      addedAt: new Date(),
-      createdAt: new Date(),
-      isTaxable: true,
-      optionTitle: "Green",
-      priceWhenAdded: {
-        amount: 12.99,
-        currencyCode: "USD"
-      },
-      productSlug: "example-product",
-      productType: "simple",
-      productVendor: "Example Manufacturer",
-      taxCode: "0000",
-      updatedAt: new Date(),
-      variantId: "CJoRBm9vRrorc9mxZ",
-      variantTitle: "Option 2 - Green Tomato",
-    }
-  ],
   shipping: [
     {
       shopId: "J8Bhq3uTtdgwZx3rz",
@@ -361,6 +128,24 @@ export const orderTemplate = {
         status: "created",
         shopId: "J8Bhq3uTtdgwZx3rz"
       },
+      items: [
+        {
+          _id: "5DipCF2Nvdb4tLzsi",
+          productId: "BCTMZ6HTxFSppJESk",
+          shopId: "J8Bhq3uTtdgwZx3rz",
+          variantId: "CJoRBm9vRrorc9mxZ",
+          createdAt: new Date(),
+          addedAt: new Date(),
+          updatedAt: new Date(),
+          price: {
+            amount: 12.99,
+            currencyCode: "USD"
+          },
+          quantity: 1,
+          subtotal: 12.99,
+          title: "Option 2 - Green Tomato"
+        }
+      ],
       itemIds: [ "5DipCF2Nvdb4tLzsi" ],
       workflow: {
         status: "new",

--- a/server/dataset.js
+++ b/server/dataset.js
@@ -80,6 +80,8 @@ export const optionTemplate = {
 export const orderTemplate = {
   sessionId: "SjtGZesckPtxRf755",
   userId: "qoSQCkbnHayhf49xc",
+  accountId: "qoSQCkbnHayhf49xc",
+  currencyCode: "USD",
   shopId: "J8Bhq3uTtdgwZx3rz",
   workflow: {
     status: "new",
@@ -302,7 +304,24 @@ export const orderTemplate = {
         workflow: [
           "coreOrderWorkflow/created"
         ]
-      }
+      },
+      addedAt: new Date(),
+      createdAt: new Date(),
+      isTaxable: true,
+      optionTitle: "Green",
+      priceWhenAdded: {
+        amount: 12.99,
+        currencyCode: "USD"
+      },
+      productId: "BCTMZ6HTxFSppJESk",
+      productSlug: "example-product",
+      productType: "simple",
+      productVendor: "Example Manufacturer",
+      shopId: "J8Bhq3uTtdgwZx3rz",
+      taxCode: "0000",
+      updatedAt: new Date(),
+      variantId: "CJoRBm9vRrorc9mxZ",
+      variantTitle: "Option 2 - Green Tomato",
     }
   ],
   shipping: [
@@ -355,9 +374,7 @@ export const orderTemplate = {
         carrier: "Flat Rate"
       },
       paymentId: "CPgv7L9bH9wXFEGTT",
-      itemIds: [
-        "5DipCF2Nvdb4tLzsi"
-      ],
+      itemIds: [ "5DipCF2Nvdb4tLzsi" ],
       workflow: {
         status: "new",
         workflow: [

--- a/server/methods.js
+++ b/server/methods.js
@@ -16,8 +16,18 @@ import Logger from "@reactioncommerce/logger";
 import { productTemplate, variantTemplate, optionTemplate, orderTemplate } from "./dataset";
 import collections from "/imports/collections/rawCollections";
 import publishProductToCatalogById from "/imports/plugins/core/catalog/server/no-meteor/utils/publishProductToCatalogById";
+import getGraphQLContextInMeteorMethod from "/imports/plugins/core/graphql/server/getGraphQLContextInMeteorMethod";
 
 const methods = {};
+
+function getContext() {
+  const context = {
+    ...Promise.await(getGraphQLContextInMeteorMethod(Meteor.userId())),
+    collections
+  };
+
+  return context;
+}
 
 /**
  * @method resetMedia
@@ -43,7 +53,7 @@ function loadSmallProducts() {
     product.updatedAt = new Date();
     Products.insert(product, {}, { publish: true });
     if (product.type === "simple" && product.isVisible) {
-      publishProductToCatalogById(product._id, collections);
+      publishProductToCatalogById(product._id, getContext());
     }
   });
   turnOnRevisions();
@@ -314,7 +324,7 @@ function attachProductImages(from = "random") {
       imagesAdded.push(product._id);
     }
     if (product.type === "simple" && product.isVisible) {
-      publishProductToCatalogById(product._id, collections);
+      publishProductToCatalogById(product._id, getContext());
     }
   }
   Logger.info("loaded product images");

--- a/server/methods.js
+++ b/server/methods.js
@@ -309,7 +309,7 @@ function attachProductImages(from = "random") {
   const products = Products.find({}).fetch();
   const productIds = products.map(({ _id }) => _id);
   const media = MediaRecords.find({ "metadata.productId": { $in: productIds } }).fetch();
-  const productIdsWithMedia = _.uniq(media.map((doc) => doc.metadata.productId));
+  const productIdsWithMedia = [...new Set(media.map((doc) => doc.metadata.productId))];
   let imagesAdded = [];
   for (const product of products) {
     // include top level products and options but not top-level variants

--- a/server/methods.js
+++ b/server/methods.js
@@ -369,8 +369,8 @@ function addProduct() {
     const optionId = Random.id().toString();
     option._id = optionId;
     option.optionTitle = faker.commerce.productName();
-    option.price = faker.commerce.price();
-    optionPrices.push(parseFloat(option.price));
+    option.price = parseFloat(faker.commerce.price());
+    optionPrices.push(option.price);
     option.ancestors = [productId, variantId];
     products.push(option);
   }
@@ -389,8 +389,8 @@ function addProduct() {
 
   const priceObject = {
     range: priceRange,
-    min: priceMin,
-    max: priceMax
+    min: parseFloat(priceMin),
+    max: parseFloat(priceMax)
   };
 
   product.price = priceObject;

--- a/server/methods.js
+++ b/server/methods.js
@@ -272,6 +272,7 @@ async function createProductImageFromUrl(product) {
   } while (!isImage);
 
   const fileRecord = await FileRecord.fromUrl(url, { fetch });
+
   const { shopId } = product;
   const topVariant = getTopVariant(product._id);
   if (product.type === "simple") {

--- a/server/methods.js
+++ b/server/methods.js
@@ -12,7 +12,7 @@ import { Random } from "meteor/random";
 import { Job } from "/imports/plugins/core/job-collection/lib";
 import { Products, ProductSearch, Tags, Packages, Jobs, Orders, OrderSearch, Catalog, MediaRecords } from "/lib/collections";
 import { Media } from "/imports/plugins/core/files/server";
-import { Logger } from "/server/api";
+import Logger from "@reactioncommerce/logger";
 import { productTemplate, variantTemplate, optionTemplate, orderTemplate } from "./dataset";
 import collections from "/imports/collections/rawCollections";
 import publishProductToCatalogById from "/imports/plugins/core/catalog/server/no-meteor/utils/publishProductToCatalogById";

--- a/server/methods.js
+++ b/server/methods.js
@@ -3,7 +3,6 @@ import randomPuppy from "random-puppy";
 import fetch from "node-fetch";
 import jpeg from "jpeg-js";
 import faker from "faker";
-import _ from "lodash";
 import { slugify } from "transliteration";
 import bufferStreamReader from "buffer-stream-reader";
 import { FileRecord } from "@reactioncommerce/file-collections";
@@ -338,10 +337,13 @@ function attachProductImages(from = "random") {
  */
 function addProduct() {
   const products = [];
-  const product = _.cloneDeep(productTemplate);
+
+  const product = { ...productTemplate };
   const productId = Random.id().toString();
-  const variant = _.cloneDeep(variantTemplate);
+
+  const variant = { ...variantTemplate };
   const variantId = Random.id().toString();
+
   product._id = productId;
   product.description = faker.lorem.paragraph();
   product.title = faker.commerce.productName();
@@ -349,17 +351,21 @@ function addProduct() {
   product.handle = slugify(product.title);
   product.createdAt = new Date();
   product.updatedAt = new Date();
+
   // always one top level variant
   variant._id = variantId;
   variant.ancestors = [productId];
   variant.title = faker.commerce.productName();
   variant.createdAt = new Date();
   variant.updatedAt = new Date();
+
   products.push(variant);
+
   const numOptions = Random.choice([1, 2, 3, 4]);
   const optionPrices = [];
+
   for (let x = 0; x < numOptions; x += 1) {
-    const option = _.cloneDeep(optionTemplate);
+    const option = { ...optionTemplate };
     const optionId = Random.id().toString();
     option._id = optionId;
     option.optionTitle = faker.commerce.productName();
@@ -368,20 +374,29 @@ function addProduct() {
     option.ancestors = [productId, variantId];
     products.push(option);
   }
-  const priceMin = _.min(optionPrices);
-  const priceMax = _.max(optionPrices);
+
+  // Math.(min|max).apply allows to pass arguments as array, as Math.(min|max) usually take an indefinite number of args
+  // ex.: Math.min(1, 2, 3, 4)
+  // See https://www.jstips.co/en/javascript/calculate-the-max-min-value-from-an-array/
+  const priceMin = Math.min.apply(null, optionPrices);
+  const priceMax = Math.max.apply(null, optionPrices);
+
   let priceRange = `${priceMin} - ${priceMax}`;
   // if we don't have a range
   if (priceMin === priceMax) {
     priceRange = priceMin.toString();
   }
+
   const priceObject = {
     range: priceRange,
     min: priceMin,
     max: priceMax
   };
+
   product.price = priceObject;
+
   products.push(product);
+
   return products;
 }
 

--- a/server/methods.js
+++ b/server/methods.js
@@ -392,6 +392,7 @@ function addProduct() {
 function addOrder() {
   const order = { ...orderTemplate };
   order._id = Random.id().toString();
+  order.referenceId = Random.id().toString();
   order.createdAt = new Date();
   order.email = faker.internet.email();
   const newName = `${faker.name.firstName()} ${faker.name.lastName()}`;

--- a/server/methods.js
+++ b/server/methods.js
@@ -390,7 +390,7 @@ function addProduct() {
  * @returns {object} order - The order object
  */
 function addOrder() {
-  const order = _.cloneDeep(orderTemplate);
+  const order = { ...orderTemplate };
   order._id = Random.id().toString();
   order.createdAt = new Date();
   order.email = faker.internet.email();

--- a/server/methods.js
+++ b/server/methods.js
@@ -238,7 +238,7 @@ function loadSwagShopProductImage(product) {
 
     Promise.await(Media.insert(fileRecord));
     Promise.await(storeFromAttachedBuffer(fileRecord));
-  } catch {
+  } catch (e) {
     return; // When image is not found, do nothing
   }
 }
@@ -313,9 +313,9 @@ function attachProductImages(from = "random") {
       }
       imagesAdded.push(product._id);
     }
-    if (product.type === "simple" && product.isVisible) { 
-      publishProductToCatalogById(product._id, collections); 
-    } 
+    if (product.type === "simple" && product.isVisible) {
+      publishProductToCatalogById(product._id, collections);
+    }
   }
   Logger.info("loaded product images");
 }

--- a/server/methods.js
+++ b/server/methods.js
@@ -395,20 +395,13 @@ function addOrder() {
   order.referenceId = Random.id().toString();
   order.createdAt = new Date();
   order.email = faker.internet.email();
+
   const newName = `${faker.name.firstName()} ${faker.name.lastName()}`;
-  order.billing.forEach((billingRecord, index) => {
-    order.billing[index].paymentMethod.createdAt = new Date();
-    order.billing[index].address.fullName = newName;
-  });
 
   order.shipping.forEach((shippingRecord, index) => {
     order.shipping[index].address.fullName = newName;
   });
 
-  order.items.forEach((item, index) => {
-    order.items[index].product.createdAt = new Date();
-    order.items[index].variants.createdAt = new Date();
-  });
   return order;
 }
 


### PR DESCRIPTION
This PR is a mix of various schema changes that were brought to Reaction since 1.15 to make sure that product and order insertions work.

I've also removed Lodash which was causing more issues than anything else. Also fixed the puppy image generator by specifically adding `node-fetch` as a dependency, which strangely enough wasn't the case before so it couldn't be found when I tried to use it.

Tested with 2.0 RC-9.